### PR TITLE
feat(d2): database schema, auth, and Docker dev stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Database (admin connection — used for migrations)
+DATABASE_URL=postgresql://lightboard_admin:lightboard_admin_password@localhost:5432/lightboard
+
+# Database (app connection — RLS enforced)
+DATABASE_APP_URL=postgresql://lightboard_app:lightboard_app_password@localhost:5432/lightboard
+
+# Redis
+REDIS_URL=redis://localhost:6379
+
+# Encryption (generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")
+ENCRYPTION_MASTER_KEY=change-me-generate-a-real-key
+
+# Auth
+AUTH_SECRET=change-me-generate-a-real-secret

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,73 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: [build]
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: lightboard
+          POSTGRES_USER: lightboard_admin
+          POSTGRES_PASSWORD: lightboard_admin_password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U lightboard_admin -d lightboard"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://lightboard_admin:lightboard_admin_password@localhost:5432/lightboard
+      DATABASE_APP_URL: postgresql://lightboard_admin:lightboard_admin_password@localhost:5432/lightboard
+      REDIS_URL: redis://localhost:6379
+      ENCRYPTION_MASTER_KEY: ci-test-key-0123456789abcdef0123456789abcdef0123456789abcdef
+      AUTH_SECRET: ci-test-secret
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Create telemetry schema
+        run: PGPASSWORD=lightboard_admin_password psql -h localhost -U lightboard_admin -d lightboard -c "CREATE SCHEMA IF NOT EXISTS telemetry;"
+      - name: Push database schema
+        run: pnpm --filter @lightboard/db db:push
+      - name: Install Playwright browsers
+        run: pnpm --filter @lightboard/web exec playwright install --with-deps chromium
+      - name: Build application
+        run: pnpm build
+      - name: Start application
+        run: pnpm --filter @lightboard/web start &
+        env:
+          PORT: 3000
+      - name: Wait for server
+        run: npx wait-on http://localhost:3000/login --timeout 30000
+      - name: Run E2E tests
+        run: pnpm --filter @lightboard/web test:e2e
+        env:
+          BASE_URL: http://localhost:3000
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+          retention-days: 7
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test } from '@playwright/test';
+
+const UNIQUE = Date.now();
+const TEST_ORG = 'E2E Test Org';
+const TEST_NAME = 'E2E Tester';
+const TEST_EMAIL = `e2e-${UNIQUE}@test.com`;
+const TEST_PASSWORD = 'e2e-password-123';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('auth flows', () => {
+  test.beforeAll(async ({ request }) => {
+    // Clean up any stale test data by registering a throwaway to confirm DB is reachable
+    const health = await request.get('/api/auth/me');
+    expect([401, 200]).toContain(health.status());
+  });
+
+  test('unauthenticated user is redirected to login', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('login page renders correctly', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.getByRole('heading', { name: 'Log in' })).toBeVisible();
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await expect(page.getByLabel('Password')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Log in' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Create account' })).toBeVisible();
+  });
+
+  test('register page renders correctly', async ({ page }) => {
+    await page.goto('/register');
+    await expect(page.getByRole('heading', { name: 'Create account' })).toBeVisible();
+    await expect(page.getByLabel('Organization name')).toBeVisible();
+    await expect(page.getByLabel('Full name')).toBeVisible();
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await expect(page.getByLabel('Password')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create account' })).toBeVisible();
+  });
+
+  test('navigate between login and register', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByRole('link', { name: 'Create account' }).click();
+    await expect(page).toHaveURL(/\/register/);
+
+    await page.getByRole('link', { name: 'Log in' }).click();
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('API returns 401 without session', async ({ request }) => {
+    const response = await request.get('/api/auth/me');
+    expect(response.status()).toBe(401);
+  });
+
+  test('register with short password returns 400', async ({ request }) => {
+    const response = await request.post('/api/auth/register', {
+      data: {
+        orgName: 'Short Org',
+        name: 'Short User',
+        email: `short-${UNIQUE}@test.com`,
+        password: 'short',
+      },
+    });
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe('Password must be at least 8 characters');
+  });
+
+  test('register creates account and sets session', async ({ request }) => {
+    const response = await request.post('/api/auth/register', {
+      data: {
+        orgName: TEST_ORG,
+        name: TEST_NAME,
+        email: TEST_EMAIL,
+        password: TEST_PASSWORD,
+      },
+    });
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.user.email).toBe(TEST_EMAIL);
+    expect(body.user.role).toBe('admin');
+  });
+
+  test('authenticated user can access dashboard', async ({ page }) => {
+    // Login via API to set cookie
+    const loginRes = await page.request.post('/api/auth/login', {
+      data: { email: TEST_EMAIL, password: TEST_PASSWORD },
+    });
+    expect(loginRes.ok()).toBeTruthy();
+
+    await page.goto('/');
+    await expect(page).toHaveURL('/');
+    await expect(page.getByText('Welcome to Lightboard')).toBeVisible();
+  });
+
+  test('register with duplicate email returns 409', async ({ request }) => {
+    const response = await request.post('/api/auth/register', {
+      data: {
+        orgName: 'Dup Org',
+        name: 'Dup User',
+        email: TEST_EMAIL,
+        password: TEST_PASSWORD,
+      },
+    });
+    expect(response.status()).toBe(409);
+    const body = await response.json();
+    expect(body.error).toBe('Email already in use');
+  });
+
+  test('login with wrong password shows error', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').pressSequentially(TEST_EMAIL);
+    await page.getByLabel('Password').pressSequentially('wrong-password');
+    await page.getByRole('button', { name: 'Log in' }).click();
+
+    await expect(page.getByText('Invalid email or password')).toBeVisible();
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('login with valid credentials redirects to dashboard', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').pressSequentially(TEST_EMAIL);
+    await page.getByLabel('Password').pressSequentially(TEST_PASSWORD);
+    await page.getByRole('button', { name: 'Log in' }).click();
+
+    await expect(page).toHaveURL('/', { timeout: 15000 });
+    await expect(page.getByText('Welcome to Lightboard')).toBeVisible();
+  });
+
+  test('logout redirects to login', async ({ page }) => {
+    // Login via API
+    const loginRes = await page.request.post('/api/auth/login', {
+      data: { email: TEST_EMAIL, password: TEST_PASSWORD },
+    });
+    expect(loginRes.ok()).toBeTruthy();
+
+    await page.goto('/');
+    await expect(page.getByText('Welcome to Lightboard')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Log out' }).click();
+    await expect(page).toHaveURL(/\/login/, { timeout: 10000 });
+  });
+
+  test('authenticated user navigates between dashboard pages', async ({ page }) => {
+    // Login via API
+    const loginRes = await page.request.post('/api/auth/login', {
+      data: { email: TEST_EMAIL, password: TEST_PASSWORD },
+    });
+    expect(loginRes.ok()).toBeTruthy();
+
+    await page.goto('/');
+    await expect(page.getByText('Welcome to Lightboard')).toBeVisible();
+
+    await page.getByRole('link', { name: 'Explore' }).click();
+    await expect(page).toHaveURL(/\/explore/);
+    await expect(page.getByText('Ask a question about your data')).toBeVisible();
+
+    await page.getByRole('link', { name: 'Data Sources' }).click();
+    await expect(page).toHaveURL(/\/data-sources/);
+
+    await page.getByRole('link', { name: 'Settings' }).click();
+    await expect(page).toHaveURL(/\/settings/);
+  });
+});

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -15,7 +15,8 @@
     "explore": "Explore",
     "dataSources": "Data Sources",
     "views": "Views",
-    "settings": "Settings"
+    "settings": "Settings",
+    "logout": "Log out"
   },
   "home": {
     "title": "Welcome to Lightboard",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -42,5 +42,19 @@
   },
   "settings": {
     "title": "Settings"
+  },
+  "auth": {
+    "login": "Log in",
+    "loginDescription": "Enter your credentials to continue.",
+    "register": "Create account",
+    "registerDescription": "Set up your organization and admin account.",
+    "email": "Email",
+    "password": "Password",
+    "name": "Full name",
+    "orgName": "Organization name",
+    "loginPrompt": "Don't have an account?",
+    "registerPrompt": "Already have an account?",
+    "invalidCredentials": "Invalid email or password.",
+    "emailInUse": "An account with this email already exists."
   }
 }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -4,7 +4,8 @@ import createNextIntlPlugin from 'next-intl/plugin';
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const nextConfig: NextConfig = {
-  transpilePackages: ['@lightboard/ui'],
+  transpilePackages: ['@lightboard/ui', '@lightboard/db'],
+  serverExternalPackages: ['pg', '@node-rs/argon2'],
 };
 
 export default withNextIntl(nextConfig);

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,6 +6,7 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 const nextConfig: NextConfig = {
   transpilePackages: ['@lightboard/ui', '@lightboard/db'],
   serverExternalPackages: ['pg', '@node-rs/argon2'],
+  devIndicators: false,
 };
 
 export default withNextIntl(nextConfig);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,8 +12,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@lightboard/db": "workspace:*",
     "@lightboard/ui": "workspace:*",
     "clsx": "^2.1.1",
+    "ioredis": "^5.6.1",
     "lucide-react": "^0.500.0",
     "next": "^15.3.2",
     "next-intl": "^4.1.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint && tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@lightboard/db": "workspace:*",
@@ -21,6 +22,7 @@
     "next-intl": "^4.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "next-view-transitions": "^0.3.0",
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
@@ -36,6 +38,7 @@
     "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4.1.6",
     "typescript": "^5.8.2",
+    "@playwright/test": "^1.52.0",
     "vitest": "^3.1.0"
   }
 }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+
+/** Playwright E2E test configuration. */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+  use: {
+    baseURL: process.env.BASE_URL ?? 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  webServer: process.env.CI
+    ? undefined
+    : {
+        command: 'pnpm dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: true,
+        cwd: '../..',
+      },
+});

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -1,0 +1,16 @@
+import { NextIntlClientProvider } from 'next-intl';
+import { getLocale, getMessages } from 'next-intl/server';
+
+/** Auth layout — centered card, no sidebar. */
+export default async function AuthLayout({ children }: { children: React.ReactNode }) {
+  const locale = await getLocale();
+  const messages = await getMessages();
+
+  return (
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <div className="flex min-h-screen items-center justify-center bg-neutral-50 dark:bg-neutral-950">
+        {children}
+      </div>
+    </NextIntlClientProvider>
+  );
+}

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -8,7 +8,7 @@ export default async function AuthLayout({ children }: { children: React.ReactNo
 
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>
-      <div className="flex min-h-screen items-center justify-center bg-neutral-50 dark:bg-neutral-950">
+      <div className="flex min-h-screen items-center justify-center" style={{ backgroundColor: 'var(--color-muted)' }}>
         {children}
       </div>
     </NextIntlClientProvider>

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { LoginForm } from '@/components/auth/login-form';
+
+/** Login page. */
+export default function LoginPage() {
+  const t = useTranslations('auth');
+  const router = useRouter();
+  const [error, setError] = useState('');
+
+  async function handleLogin(email: string, password: string) {
+    setError('');
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json();
+      setError(data.error ?? t('invalidCredentials'));
+      return;
+    }
+
+    router.push('/');
+    router.refresh();
+  }
+
+  return <LoginForm onSubmit={handleLogin} error={error} />;
+}

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { useRouter } from 'next/navigation';
+import { useTransitionRouter } from 'next-view-transitions';
 import { useState } from 'react';
 import { LoginForm } from '@/components/auth/login-form';
 
 /** Login page. */
 export default function LoginPage() {
   const t = useTranslations('auth');
-  const router = useRouter();
+  const router = useTransitionRouter();
   const [error, setError] = useState('');
 
   async function handleLogin(email: string, password: string) {

--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { useRouter } from 'next/navigation';
+import { useTransitionRouter } from 'next-view-transitions';
 import { useState } from 'react';
 import { RegisterForm } from '@/components/auth/register-form';
 
 /** Register page. */
 export default function RegisterPage() {
   const t = useTranslations('auth');
-  const router = useRouter();
+  const router = useTransitionRouter();
   const [error, setError] = useState('');
 
   async function handleRegister(data: {

--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { RegisterForm } from '@/components/auth/register-form';
+
+/** Register page. */
+export default function RegisterPage() {
+  const t = useTranslations('auth');
+  const router = useRouter();
+  const [error, setError] = useState('');
+
+  async function handleRegister(data: {
+    email: string;
+    password: string;
+    name: string;
+    orgName: string;
+  }) {
+    setError('');
+    const res = await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+
+    if (!res.ok) {
+      const resData = await res.json();
+      setError(resData.error ?? t('emailInUse'));
+      return;
+    }
+
+    router.push('/');
+    router.refresh();
+  }
+
+  return <RegisterForm onSubmit={handleRegister} error={error} />;
+}

--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,0 +1,44 @@
+import { createSession, verifyPassword } from '@lightboard/db/auth';
+import { NextResponse, type NextRequest } from 'next/server';
+import { getAdminDb, setSessionCookie } from '@/lib/auth';
+
+/** POST /api/auth/login — Authenticate with email and password. */
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { email, password } = body as { email?: string; password?: string };
+
+  if (!email || !password) {
+    return NextResponse.json({ error: 'Email and password are required' }, { status: 400 });
+  }
+
+  const db = getAdminDb();
+
+  // Look up user (admin pool, no RLS — login must work across orgs)
+  const user = await db.query.users.findFirst({
+    where: (u, { eq }) => eq(u.email, email),
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: 'Invalid email or password' }, { status: 401 });
+  }
+
+  const validPassword = await verifyPassword(user.passwordHash, password);
+  if (!validPassword) {
+    return NextResponse.json({ error: 'Invalid email or password' }, { status: 401 });
+  }
+
+  // Create session with org_id denormalized
+  const { token, expiresAt } = await createSession(db, user.id, user.orgId);
+
+  const response = NextResponse.json({
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      role: user.role,
+      orgId: user.orgId,
+    },
+  });
+  setSessionCookie(response, token, expiresAt);
+  return response;
+}

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -1,0 +1,17 @@
+import { invalidateSession } from '@lightboard/db/auth';
+import { NextResponse, type NextRequest } from 'next/server';
+import { clearSessionCookie, getAdminDb, getSessionToken } from '@/lib/auth';
+
+/** POST /api/auth/logout — Invalidate the current session. */
+export async function POST(req: NextRequest) {
+  const token = getSessionToken(req);
+
+  if (token) {
+    const db = getAdminDb();
+    await invalidateSession(db, token);
+  }
+
+  const response = NextResponse.json({ ok: true });
+  clearSessionCookie(response);
+  return response;
+}

--- a/apps/web/src/app/api/auth/me/route.ts
+++ b/apps/web/src/app/api/auth/me/route.ts
@@ -1,0 +1,27 @@
+import { validateSession } from '@lightboard/db/auth';
+import { NextResponse, type NextRequest } from 'next/server';
+import { getAdminDb, getSessionToken } from '@/lib/auth';
+
+/** GET /api/auth/me — Return the currently authenticated user. */
+export async function GET(req: NextRequest) {
+  const token = getSessionToken(req);
+  if (!token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const db = getAdminDb();
+  const result = await validateSession(db, token);
+  if (!result) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  return NextResponse.json({
+    user: {
+      id: result.user.id,
+      email: result.user.email,
+      name: result.user.name,
+      role: result.user.role,
+      orgId: result.user.orgId,
+    },
+  });
+}

--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -31,26 +31,34 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Email already in use' }, { status: 409 });
   }
 
-  // Create organization
-  const slug = orgName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-  const orgs = await db.insert(organizations).values({ name: orgName, slug }).returning();
-  const org = orgs[0]!;
+  try {
+    // Create organization
+    const slug = orgName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    const orgs = await db.insert(organizations).values({ name: orgName, slug }).returning();
+    const org = orgs[0]!;
 
-  // Create admin user
-  const passwordHash = await hashPassword(password);
-  const usersResult = await db
-    .insert(users)
-    .values({ orgId: org.id, email, name, passwordHash, role: 'admin' as const })
-    .returning({ id: users.id, email: users.email, name: users.name, role: users.role });
-  const user = usersResult[0]!;
+    // Create admin user
+    const passwordHash = await hashPassword(password);
+    const usersResult = await db
+      .insert(users)
+      .values({ orgId: org.id, email, name, passwordHash, role: 'admin' as const })
+      .returning({ id: users.id, email: users.email, name: users.name, role: users.role });
+    const user = usersResult[0]!;
 
-  // Create session
-  const { token, expiresAt } = await createSession(db, user.id, org.id);
+    // Create session
+    const { token, expiresAt } = await createSession(db, user.id, org.id);
 
-  const response = NextResponse.json(
-    { user: { id: user.id, email: user.email, name: user.name, role: user.role, orgId: org.id } },
-    { status: 201 },
-  );
-  setSessionCookie(response, token, expiresAt);
-  return response;
+    const response = NextResponse.json(
+      { user: { id: user.id, email: user.email, name: user.name, role: user.role, orgId: org.id } },
+      { status: 201 },
+    );
+    setSessionCookie(response, token, expiresAt);
+    return response;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('unique') || message.includes('duplicate')) {
+      return NextResponse.json({ error: 'Email already in use' }, { status: 409 });
+    }
+    return NextResponse.json({ error: 'Registration failed' }, { status: 500 });
+  }
 }

--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -1,0 +1,56 @@
+import { createSession, hashPassword } from '@lightboard/db/auth';
+import { organizations, users } from '@lightboard/db/schema';
+import { NextResponse, type NextRequest } from 'next/server';
+import { getAdminDb, setSessionCookie } from '@/lib/auth';
+
+/** POST /api/auth/register — Create a new organization and admin user. */
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { email, password, name, orgName } = body as {
+    email?: string;
+    password?: string;
+    name?: string;
+    orgName?: string;
+  };
+
+  if (!email || !password || !name || !orgName) {
+    return NextResponse.json({ error: 'All fields are required' }, { status: 400 });
+  }
+
+  if (password.length < 8) {
+    return NextResponse.json({ error: 'Password must be at least 8 characters' }, { status: 400 });
+  }
+
+  const db = getAdminDb();
+
+  // Check if email already exists
+  const existing = await db.query.users.findFirst({
+    where: (u, { eq }) => eq(u.email, email),
+  });
+  if (existing) {
+    return NextResponse.json({ error: 'Email already in use' }, { status: 409 });
+  }
+
+  // Create organization
+  const slug = orgName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  const orgs = await db.insert(organizations).values({ name: orgName, slug }).returning();
+  const org = orgs[0]!;
+
+  // Create admin user
+  const passwordHash = await hashPassword(password);
+  const usersResult = await db
+    .insert(users)
+    .values({ orgId: org.id, email, name, passwordHash, role: 'admin' as const })
+    .returning({ id: users.id, email: users.email, name: users.name, role: users.role });
+  const user = usersResult[0]!;
+
+  // Create session
+  const { token, expiresAt } = await createSession(db, user.id, org.id);
+
+  const response = NextResponse.json(
+    { user: { id: user.id, email: user.email, name: user.name, role: user.role, orgId: org.id } },
+    { status: 201 },
+  );
+  setSessionCookie(response, token, expiresAt);
+  return response;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages } from 'next-intl/server';
+import { ViewTransitions } from 'next-view-transitions';
 
 import '@/styles/globals.css';
 
@@ -14,17 +15,19 @@ export const metadata: Metadata = {
 
 /**
  * Root layout wrapping the entire application.
- * Provides i18n context to all client components.
+ * Provides i18n context and view transitions to all client components.
  */
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const locale = await getLocale();
   const messages = await getMessages();
 
   return (
-    <html lang={locale} suppressHydrationWarning>
-      <body className="min-h-screen bg-background font-sans antialiased">
-        <NextIntlClientProvider messages={messages}>{children}</NextIntlClientProvider>
-      </body>
-    </html>
+    <ViewTransitions>
+      <html lang={locale} suppressHydrationWarning>
+        <body className="min-h-screen bg-background font-sans antialiased">
+          <NextIntlClientProvider messages={messages}>{children}</NextIntlClientProvider>
+        </body>
+      </html>
+    </ViewTransitions>
   );
 }

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -46,7 +46,7 @@ export function LoginForm({ onSubmit, error }: LoginFormProps) {
       </CardHeader>
       <form onSubmit={handleSubmit}>
         <CardContent className="space-y-4">
-          {error && <p className="text-sm text-red-500">{error}</p>}
+          {error && <p className="text-sm" style={{ color: 'var(--color-destructive)' }}>{error}</p>}
           <div className="space-y-2">
             <Label htmlFor="email">{t('email')}</Label>
             <Input
@@ -72,9 +72,9 @@ export function LoginForm({ onSubmit, error }: LoginFormProps) {
           <Button type="submit" className="w-full" disabled={loading}>
             {loading ? '...' : t('login')}
           </Button>
-          <p className="text-sm text-neutral-500">
+          <p className="text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
             {t('loginPrompt')}{' '}
-            <Link href="/register" className="text-neutral-900 underline dark:text-neutral-100">
+            <Link href="/register" className="underline" style={{ color: 'var(--color-foreground)' }}>
               {t('register')}
             </Link>
           </p>

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -12,7 +12,7 @@ import {
   Label,
 } from '@lightboard/ui';
 import { useTranslations } from 'next-intl';
-import Link from 'next/link';
+import { Link } from 'next-view-transitions';
 import { useState } from 'react';
 
 /** Props for the LoginForm component. */

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+} from '@lightboard/ui';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+import { useState } from 'react';
+
+/** Props for the LoginForm component. */
+interface LoginFormProps {
+  onSubmit: (email: string, password: string) => Promise<void>;
+  error?: string;
+}
+
+/** Login form with email and password fields. */
+export function LoginForm({ onSubmit, error }: LoginFormProps) {
+  const t = useTranslations('auth');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await onSubmit(email, password);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>{t('login')}</CardTitle>
+        <CardDescription>{t('loginDescription')}</CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit}>
+        <CardContent className="space-y-4">
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <div className="space-y-2">
+            <Label htmlFor="email">{t('email')}</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">{t('password')}</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+        </CardContent>
+        <CardFooter className="flex-col space-y-4">
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? '...' : t('login')}
+          </Button>
+          <p className="text-sm text-neutral-500">
+            {t('loginPrompt')}{' '}
+            <Link href="/register" className="text-neutral-900 underline dark:text-neutral-100">
+              {t('register')}
+            </Link>
+          </p>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}

--- a/apps/web/src/components/auth/register-form.tsx
+++ b/apps/web/src/components/auth/register-form.tsx
@@ -12,7 +12,7 @@ import {
   Label,
 } from '@lightboard/ui';
 import { useTranslations } from 'next-intl';
-import Link from 'next/link';
+import { Link } from 'next-view-transitions';
 import { useState } from 'react';
 
 /** Props for the RegisterForm component. */

--- a/apps/web/src/components/auth/register-form.tsx
+++ b/apps/web/src/components/auth/register-form.tsx
@@ -48,7 +48,7 @@ export function RegisterForm({ onSubmit, error }: RegisterFormProps) {
       </CardHeader>
       <form onSubmit={handleSubmit}>
         <CardContent className="space-y-4">
-          {error && <p className="text-sm text-red-500">{error}</p>}
+          {error && <p className="text-sm" style={{ color: 'var(--color-destructive)' }}>{error}</p>}
           <div className="space-y-2">
             <Label htmlFor="orgName">{t('orgName')}</Label>
             <Input
@@ -93,9 +93,9 @@ export function RegisterForm({ onSubmit, error }: RegisterFormProps) {
           <Button type="submit" className="w-full" disabled={loading}>
             {loading ? '...' : t('register')}
           </Button>
-          <p className="text-sm text-neutral-500">
+          <p className="text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
             {t('registerPrompt')}{' '}
-            <Link href="/login" className="text-neutral-900 underline dark:text-neutral-100">
+            <Link href="/login" className="underline" style={{ color: 'var(--color-foreground)' }}>
               {t('login')}
             </Link>
           </p>

--- a/apps/web/src/components/auth/register-form.tsx
+++ b/apps/web/src/components/auth/register-form.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+} from '@lightboard/ui';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+import { useState } from 'react';
+
+/** Props for the RegisterForm component. */
+interface RegisterFormProps {
+  onSubmit: (data: { email: string; password: string; name: string; orgName: string }) => Promise<void>;
+  error?: string;
+}
+
+/** Registration form with org name, name, email, and password fields. */
+export function RegisterForm({ onSubmit, error }: RegisterFormProps) {
+  const t = useTranslations('auth');
+  const [orgName, setOrgName] = useState('');
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await onSubmit({ email, password, name, orgName });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>{t('register')}</CardTitle>
+        <CardDescription>{t('registerDescription')}</CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit}>
+        <CardContent className="space-y-4">
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <div className="space-y-2">
+            <Label htmlFor="orgName">{t('orgName')}</Label>
+            <Input
+              id="orgName"
+              value={orgName}
+              onChange={(e) => setOrgName(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="name">{t('name')}</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="email">{t('email')}</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">{t('password')}</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              minLength={8}
+              required
+            />
+          </div>
+        </CardContent>
+        <CardFooter className="flex-col space-y-4">
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? '...' : t('register')}
+          </Button>
+          <p className="text-sm text-neutral-500">
+            {t('registerPrompt')}{' '}
+            <Link href="/login" className="text-neutral-900 underline dark:text-neutral-100">
+              {t('login')}
+            </Link>
+          </p>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -7,11 +7,13 @@ import {
   Compass,
   Database,
   LayoutDashboard,
+  LogOut,
   type LucideIcon,
   Settings,
   SquareKanban,
 } from 'lucide-react';
 
+import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 
 /**
@@ -37,7 +39,14 @@ const NAV_ITEMS: NavItem[] = [
  */
 export function Sidebar() {
   const pathname = usePathname();
+  const router = useRouter();
   const t = useTranslations('nav');
+
+  async function handleLogout() {
+    await fetch('/api/auth/logout', { method: 'POST' });
+    router.push('/login');
+    router.refresh();
+  }
 
   return (
     <aside className="flex h-screen w-60 flex-col border-r border-sidebar-border bg-sidebar">
@@ -69,6 +78,16 @@ export function Sidebar() {
           );
         })}
       </nav>
+
+      <div className="border-t border-sidebar-border p-2">
+        <button
+          onClick={handleLogout}
+          className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+        >
+          <LogOut className="h-4 w-4" />
+          {t('logout')}
+        </button>
+      </div>
     </aside>
   );
 }

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { Link, useTransitionRouter } from 'next-view-transitions';
 import {
   Compass,
   Database,
@@ -12,8 +12,6 @@ import {
   Settings,
   SquareKanban,
 } from 'lucide-react';
-
-import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 
 /**
@@ -39,7 +37,7 @@ const NAV_ITEMS: NavItem[] = [
  */
 export function Sidebar() {
   const pathname = usePathname();
-  const router = useRouter();
+  const router = useTransitionRouter();
   const t = useTranslations('nav');
 
   async function handleLogout() {

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -1,0 +1,107 @@
+import { type Database, setOrgContext } from '@lightboard/db';
+import { validateSession, type SessionValidationResult } from '@lightboard/db/auth';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import * as schema from '@lightboard/db/schema';
+import { cookies } from 'next/headers';
+import { NextResponse, type NextRequest } from 'next/server';
+import pg from 'pg';
+
+const SESSION_COOKIE = 'lb_session';
+
+/** Admin DB pool — bypasses RLS. Used for login, registration, migrations. */
+const adminPool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+/** App DB pool — RLS enforced. Used for all authenticated requests. */
+const appPool = new pg.Pool({
+  connectionString: process.env.DATABASE_APP_URL ?? process.env.DATABASE_URL,
+});
+
+/** Returns the admin database instance (no RLS). */
+export function getAdminDb(): Database {
+  return drizzle(adminPool, { schema });
+}
+
+/** Reads the session token from the request cookies. */
+export function getSessionToken(req: NextRequest): string | undefined {
+  return req.cookies.get(SESSION_COOKIE)?.value;
+}
+
+/** Sets the session cookie on a response. */
+export function setSessionCookie(response: NextResponse, token: string, expiresAt: Date): void {
+  response.cookies.set(SESSION_COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    expires: expiresAt,
+  });
+}
+
+/** Clears the session cookie on a response. */
+export function clearSessionCookie(response: NextResponse): void {
+  response.cookies.set(SESSION_COOKIE, '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+}
+
+/** Handler function signature for authenticated API routes. */
+export type AuthenticatedHandler = (
+  req: NextRequest,
+  ctx: {
+    user: SessionValidationResult['user'];
+    orgId: string;
+    db: Database;
+  },
+) => Promise<NextResponse>;
+
+/**
+ * Wraps an API route handler with auth validation and RLS context.
+ * Validates the session, acquires a pool client with org context set,
+ * and passes the org-scoped database to the handler.
+ */
+export function withAuth(handler: AuthenticatedHandler) {
+  return async (req: NextRequest): Promise<NextResponse> => {
+    const token = getSessionToken(req);
+    if (!token) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const adminDb = getAdminDb();
+    const result = await validateSession(adminDb, token);
+    if (!result) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const client = await appPool.connect();
+    try {
+      await setOrgContext(client, result.session.orgId);
+      const orgDb = drizzle(client, { schema }) as Database;
+      return await handler(req, {
+        user: result.user,
+        orgId: result.session.orgId,
+        db: orgDb,
+      });
+    } finally {
+      client.release();
+    }
+  };
+}
+
+/**
+ * Validates the current request's session from cookies (server component use).
+ * Returns session result or null if not authenticated.
+ */
+export async function validateRequest(): Promise<SessionValidationResult | null> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(SESSION_COOKIE)?.value;
+  if (!token) return null;
+
+  const adminDb = getAdminDb();
+  return validateSession(adminDb, token);
+}

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -1,0 +1,86 @@
+import { redis } from './redis';
+
+/** Rate limit bucket configurations. */
+const BUCKETS = {
+  api: { max: 100, windowSec: 60 },
+  query: { max: 20, windowSec: 60 },
+} as const;
+
+type BucketType = keyof typeof BUCKETS;
+
+/** Result of a rate limit check. */
+export interface RateLimitResult {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetAt: number;
+}
+
+/**
+ * Token bucket rate limiter backed by Redis.
+ * Uses a Lua script for atomic check-and-decrement.
+ */
+const LUA_SCRIPT = `
+  local key = KEYS[1]
+  local max = tonumber(ARGV[1])
+  local window = tonumber(ARGV[2])
+  local now = tonumber(ARGV[3])
+
+  local data = redis.call('HMGET', key, 'tokens', 'last')
+  local tokens = tonumber(data[1])
+  local last = tonumber(data[2])
+
+  if tokens == nil then
+    tokens = max
+    last = now
+  end
+
+  local elapsed = now - last
+  local refill = elapsed * (max / window)
+  tokens = math.min(max, tokens + refill)
+  last = now
+
+  local allowed = 0
+  if tokens >= 1 then
+    tokens = tokens - 1
+    allowed = 1
+  end
+
+  redis.call('HMSET', key, 'tokens', tokens, 'last', last)
+  redis.call('EXPIRE', key, window * 2)
+
+  return {allowed, math.floor(tokens), last + window}
+`;
+
+/** Checks and consumes a rate limit token for the given org and bucket type. */
+export async function checkRateLimit(
+  orgId: string,
+  bucket: BucketType,
+): Promise<RateLimitResult> {
+  const config = BUCKETS[bucket];
+  const key = `ratelimit:${orgId}:${bucket}`;
+  const now = Date.now() / 1000;
+
+  const [allowed, remaining, resetAt] = (await redis.eval(
+    LUA_SCRIPT,
+    1,
+    key,
+    config.max,
+    config.windowSec,
+    now,
+  )) as [number, number, number];
+
+  return {
+    allowed: allowed === 1,
+    limit: config.max,
+    remaining,
+    resetAt: Math.ceil(resetAt),
+  };
+}
+
+/** Adds rate limit headers to a Response. */
+export function addRateLimitHeaders(headers: Headers, result: RateLimitResult): void {
+  headers.set('X-RateLimit-Limit', String(result.limit));
+  headers.set('X-RateLimit-Remaining', String(result.remaining));
+  headers.set('X-RateLimit-Reset', String(result.resetAt));
+}

--- a/apps/web/src/lib/redis.ts
+++ b/apps/web/src/lib/redis.ts
@@ -1,0 +1,7 @@
+import Redis from 'ioredis';
+
+/** Singleton Redis client for rate limiting and caching. */
+export const redis = new Redis(process.env.REDIS_URL ?? 'redis://localhost:6379', {
+  maxRetriesPerRequest: 3,
+  lazyConnect: true,
+});

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,46 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+const SESSION_COOKIE = 'lb_session';
+
+const PUBLIC_PATHS = ['/login', '/register', '/api/auth/login', '/api/auth/register'];
+
+/**
+ * Next.js middleware for route protection.
+ * Runs on the Edge runtime — only does cookie existence checks.
+ * Full session validation happens in the withAuth wrapper (Node.js runtime).
+ */
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const hasSession = req.cookies.has(SESSION_COOKIE);
+
+  // Allow public paths without session
+  if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
+    // Redirect authenticated users away from login/register pages
+    if (hasSession && (pathname === '/login' || pathname === '/register')) {
+      return NextResponse.redirect(new URL('/', req.url));
+    }
+    return NextResponse.next();
+  }
+
+  // Protect dashboard and API routes
+  if (!hasSession) {
+    if (pathname.startsWith('/api/')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except:
+     * - _next/static (static files)
+     * - _next/image (image optimization)
+     * - favicon.ico, sitemap.xml, robots.txt
+     */
+    '/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+  ],
+};

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -63,6 +63,25 @@
   }
 }
 
+/* View transition animations for native-app feel */
+::view-transition-old(root) {
+  animation: fade-out 150ms ease-in;
+}
+
+::view-transition-new(root) {
+  animation: fade-in 200ms ease-out;
+}
+
+@keyframes fade-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 @media (prefers-color-scheme: dark) {
 :root {
   --color-background: oklch(0.145 0 0);

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,5 +1,7 @@
 @import 'tailwindcss';
 
+@source "../../../../packages/ui/src/**/*.{ts,tsx}";
+
 @theme {
   /* Colors - Background */
   --color-background: oklch(1 0 0);
@@ -61,12 +63,13 @@
   }
 }
 
-.dark {
+@media (prefers-color-scheme: dark) {
+:root {
   --color-background: oklch(0.145 0 0);
   --color-foreground: oklch(0.985 0 0);
   --color-muted: oklch(0.269 0 0);
   --color-muted-foreground: oklch(0.708 0 0);
-  --color-card: oklch(0.205 0 0);
+  --color-card: oklch(0.22 0 0);
   --color-card-foreground: oklch(0.985 0 0);
   --color-popover: oklch(0.205 0 0);
   --color-popover-foreground: oklch(0.985 0 0);
@@ -80,8 +83,8 @@
 
   --color-destructive: oklch(0.577 0.245 27.325);
   --color-destructive-foreground: oklch(0.985 0 0);
-  --color-border: oklch(0.269 0 0);
-  --color-input: oklch(0.269 0 0);
+  --color-border: oklch(0.4 0 0);
+  --color-input: oklch(0.4 0 0);
   --color-ring: oklch(0.439 0 0);
 
   --color-sidebar: oklch(0.205 0 0);
@@ -96,4 +99,5 @@
   --color-chart-3: oklch(0.769 0.188 70.08);
   --color-chart-4: oklch(0.627 0.265 303.9);
   --color-chart-5: oklch(0.645 0.246 16.439);
+}
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -11,7 +11,10 @@
     "plugins": [{ "name": "next" }],
     "paths": {
       "@/*": ["./src/*"],
-      "@lightboard/ui": ["../../packages/ui/src"]
+      "@lightboard/db": ["../../packages/db/src"],
+      "@lightboard/db/*": ["../../packages/db/src/*"],
+      "@lightboard/ui": ["../../packages/ui/src"],
+      "@lightboard/ui/*": ["../../packages/ui/src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+/** Vitest configuration — excludes Playwright E2E tests. */
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**', '**/e2e/**'],
+  },
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: lightboard
+      POSTGRES_USER: lightboard_admin
+      POSTGRES_PASSWORD: lightboard_admin_password
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/01-init.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U lightboard_admin -d lightboard"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,0 +1,20 @@
+-- Create the telemetry schema
+CREATE SCHEMA IF NOT EXISTS telemetry;
+
+-- Create the application role (RLS enforced)
+CREATE ROLE lightboard_app LOGIN PASSWORD 'lightboard_app_password';
+
+-- Grant permissions on public schema
+GRANT CONNECT ON DATABASE lightboard TO lightboard_app;
+GRANT USAGE ON SCHEMA public TO lightboard_app;
+GRANT USAGE ON SCHEMA telemetry TO lightboard_app;
+
+-- Allow app role to use sequences (for serial/generated columns)
+ALTER DEFAULT PRIVILEGES FOR ROLE lightboard_admin IN SCHEMA public
+  GRANT ALL ON TABLES TO lightboard_app;
+ALTER DEFAULT PRIVILEGES FOR ROLE lightboard_admin IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO lightboard_app;
+ALTER DEFAULT PRIVILEGES FOR ROLE lightboard_admin IN SCHEMA telemetry
+  GRANT ALL ON TABLES TO lightboard_app;
+ALTER DEFAULT PRIVILEGES FOR ROLE lightboard_admin IN SCHEMA telemetry
+  GRANT USAGE, SELECT ON SEQUENCES TO lightboard_app;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@node-rs/argon2",
       "@parcel/watcher",
       "@swc/core",
       "esbuild",

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,0 +1,12 @@
+import 'dotenv/config';
+import { defineConfig } from 'drizzle-kit';
+
+/** Drizzle Kit configuration for schema migrations. */
+export default defineConfig({
+  schema: './src/schema/index.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+});

--- a/packages/db/drizzle/0001_enable_rls.sql
+++ b/packages/db/drizzle/0001_enable_rls.sql
@@ -1,0 +1,44 @@
+-- Enable Row Level Security on all tables with org_id
+-- This migration must be run after the initial schema migration
+
+-- Organizations: filter on id (not org_id)
+ALTER TABLE organizations ENABLE ROW LEVEL SECURITY;
+CREATE POLICY organizations_tenant_isolation ON organizations
+  USING (id = current_setting('app.current_org_id', true)::uuid);
+CREATE POLICY organizations_tenant_insert ON organizations
+  FOR INSERT WITH CHECK (id = current_setting('app.current_org_id', true)::uuid);
+
+-- Users
+ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+CREATE POLICY users_tenant_isolation ON users
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);
+CREATE POLICY users_tenant_insert ON users
+  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- Sessions
+ALTER TABLE sessions ENABLE ROW LEVEL SECURITY;
+CREATE POLICY sessions_tenant_isolation ON sessions
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);
+CREATE POLICY sessions_tenant_insert ON sessions
+  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- Data Sources
+ALTER TABLE data_sources ENABLE ROW LEVEL SECURITY;
+CREATE POLICY data_sources_tenant_isolation ON data_sources
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);
+CREATE POLICY data_sources_tenant_insert ON data_sources
+  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- Views
+ALTER TABLE views ENABLE ROW LEVEL SECURITY;
+CREATE POLICY views_tenant_isolation ON views
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);
+CREATE POLICY views_tenant_insert ON views
+  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- Telemetry Events (in telemetry schema)
+ALTER TABLE telemetry.telemetry_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY telemetry_events_tenant_isolation ON telemetry.telemetry_events
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);
+CREATE POLICY telemetry_events_tenant_insert ON telemetry.telemetry_events
+  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@lightboard/db",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schema": "./src/schema/index.ts",
+    "./auth": "./src/auth/index.ts",
+    "./crypto": "./src/crypto.ts"
+  },
+  "scripts": {
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push",
+    "db:studio": "drizzle-kit studio",
+    "db:seed": "tsx src/seed.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@node-rs/argon2": "^2.0.2",
+    "@oslojs/crypto": "^1.0.1",
+    "@oslojs/encoding": "^1.1.0",
+    "drizzle-orm": "^0.44.0",
+    "pg": "^8.16.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.15.4",
+    "drizzle-kit": "^0.31.0",
+    "dotenv": "^16.5.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.8.2",
+    "vitest": "^3.1.0"
+  }
+}

--- a/packages/db/src/auth/index.ts
+++ b/packages/db/src/auth/index.ts
@@ -1,0 +1,9 @@
+export { hashPassword, verifyPassword } from './password';
+export {
+  createSession,
+  generateSessionToken,
+  invalidateAllUserSessions,
+  invalidateSession,
+  type SessionValidationResult,
+  validateSession,
+} from './session';

--- a/packages/db/src/auth/password.test.ts
+++ b/packages/db/src/auth/password.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { hashPassword, verifyPassword } from './password';
+
+describe('password hashing', () => {
+  it('hashes and verifies a password', async () => {
+    const hash = await hashPassword('my-secure-password');
+    expect(hash).not.toBe('my-secure-password');
+    expect(await verifyPassword(hash, 'my-secure-password')).toBe(true);
+  });
+
+  it('rejects wrong password', async () => {
+    const hash = await hashPassword('correct-password');
+    expect(await verifyPassword(hash, 'wrong-password')).toBe(false);
+  });
+
+  it('produces different hashes for same input', async () => {
+    const hash1 = await hashPassword('same-password');
+    const hash2 = await hashPassword('same-password');
+    expect(hash1).not.toBe(hash2);
+  });
+});

--- a/packages/db/src/auth/password.ts
+++ b/packages/db/src/auth/password.ts
@@ -1,0 +1,18 @@
+import { hash, verify } from '@node-rs/argon2';
+
+const ARGON2_OPTIONS = {
+  memoryCost: 19456,
+  timeCost: 2,
+  outputLen: 32,
+  parallelism: 1,
+};
+
+/** Hashes a password using Argon2id. */
+export async function hashPassword(password: string): Promise<string> {
+  return hash(password, ARGON2_OPTIONS);
+}
+
+/** Verifies a password against an Argon2id hash. Returns true if the password matches. */
+export async function verifyPassword(hashedPassword: string, password: string): Promise<boolean> {
+  return verify(hashedPassword, password);
+}

--- a/packages/db/src/auth/session.ts
+++ b/packages/db/src/auth/session.ts
@@ -1,0 +1,113 @@
+import { sha256 } from '@oslojs/crypto/sha2';
+import { encodeBase32LowerCaseNoPadding, encodeHexLowerCase } from '@oslojs/encoding';
+import { eq } from 'drizzle-orm';
+import type { Database } from '../client';
+import { sessions } from '../schema/sessions';
+import { users } from '../schema/users';
+
+const SESSION_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const SESSION_REFRESH_THRESHOLD_MS = 15 * 24 * 60 * 60 * 1000; // 15 days
+
+/** Session with associated user data. */
+export interface SessionValidationResult {
+  session: {
+    id: string;
+    userId: string;
+    orgId: string;
+    expiresAt: Date;
+  };
+  user: {
+    id: string;
+    orgId: string;
+    email: string;
+    name: string;
+    role: 'admin' | 'editor' | 'viewer';
+  };
+}
+
+/** Generates a cryptographically random session token. */
+export function generateSessionToken(): string {
+  const bytes = new Uint8Array(20);
+  crypto.getRandomValues(bytes);
+  return encodeBase32LowerCaseNoPadding(bytes);
+}
+
+/**
+ * Creates a new session for a user. Returns the raw token (for the cookie)
+ * and stores the SHA-256 hash as the session ID in the database.
+ */
+export async function createSession(
+  db: Database,
+  userId: string,
+  orgId: string,
+): Promise<{ token: string; expiresAt: Date }> {
+  const token = generateSessionToken();
+  const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
+  const expiresAt = new Date(Date.now() + SESSION_EXPIRY_MS);
+
+  await db.insert(sessions).values({
+    id: sessionId,
+    userId,
+    orgId,
+    expiresAt,
+  });
+
+  return { token, expiresAt };
+}
+
+/**
+ * Validates a session token. Returns session + user if valid, null if expired or not found.
+ * Extends session expiry using a sliding window if more than 15 days remain.
+ */
+export async function validateSession(
+  db: Database,
+  token: string,
+): Promise<SessionValidationResult | null> {
+  const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
+
+  const result = await db
+    .select({
+      session: sessions,
+      user: {
+        id: users.id,
+        orgId: users.orgId,
+        email: users.email,
+        name: users.name,
+        role: users.role,
+      },
+    })
+    .from(sessions)
+    .innerJoin(users, eq(sessions.userId, users.id))
+    .where(eq(sessions.id, sessionId))
+    .limit(1);
+
+  const row = result[0];
+  if (!row) return null;
+
+  const { session, user } = row;
+
+  if (Date.now() >= session.expiresAt.getTime()) {
+    await db.delete(sessions).where(eq(sessions.id, sessionId));
+    return null;
+  }
+
+  // Sliding window: extend if less than 15 days remain
+  if (session.expiresAt.getTime() - Date.now() < SESSION_REFRESH_THRESHOLD_MS) {
+    const newExpiry = new Date(Date.now() + SESSION_EXPIRY_MS);
+    await db.update(sessions).set({ expiresAt: newExpiry }).where(eq(sessions.id, sessionId));
+    session.expiresAt = newExpiry;
+  }
+
+  return { session, user };
+}
+
+/** Invalidates a session by deleting it from the database. */
+export async function invalidateSession(db: Database, token: string): Promise<void> {
+  const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
+  await db.delete(sessions).where(eq(sessions.id, sessionId));
+}
+
+/** Invalidates all sessions for a user. */
+export async function invalidateAllUserSessions(db: Database, userId: string): Promise<void> {
+  await db.delete(sessions).where(eq(sessions.userId, userId));
+}

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,0 +1,43 @@
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+import * as schema from './schema';
+
+export type Database = NodePgDatabase<typeof schema>;
+
+/**
+ * Creates a Drizzle database instance from a connection string.
+ * Use `DATABASE_URL` for admin operations (migrations, cross-org queries).
+ * Use `DATABASE_APP_URL` for application queries (RLS enforced).
+ */
+export function createDb(connectionString: string): { db: Database; pool: pg.Pool } {
+  const pool = new pg.Pool({ connectionString });
+  const db = drizzle(pool, { schema });
+  return { db, pool };
+}
+
+/**
+ * Sets the Postgres session variable for RLS tenant isolation.
+ * Must be called on every request before running org-scoped queries.
+ */
+export async function setOrgContext(client: pg.PoolClient, orgId: string): Promise<void> {
+  await client.query(`SELECT set_config('app.current_org_id', $1, true)`, [orgId]);
+}
+
+/**
+ * Executes a callback with RLS org context set on a dedicated pool client.
+ * The client is automatically released back to the pool after the callback.
+ */
+export async function withOrgContext<T>(
+  pool: pg.Pool,
+  orgId: string,
+  callback: (db: Database, client: pg.PoolClient) => Promise<T>,
+): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await setOrgContext(client, orgId);
+    const db = drizzle(client, { schema });
+    return await callback(db, client);
+  } finally {
+    client.release();
+  }
+}

--- a/packages/db/src/crypto.test.ts
+++ b/packages/db/src/crypto.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { decryptCredentials, encryptCredentials } from './crypto';
+
+const MASTER_KEY = 'a'.repeat(64);
+
+describe('credential encryption', () => {
+  it('round-trips encrypt/decrypt', () => {
+    const orgId = '00000000-0000-0000-0000-000000000001';
+    const plaintext = JSON.stringify({ host: 'localhost', password: 'secret' });
+
+    const encrypted = encryptCredentials(MASTER_KEY, orgId, plaintext);
+    const decrypted = decryptCredentials(MASTER_KEY, orgId, encrypted);
+
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it('produces different ciphertext for different orgs', () => {
+    const orgA = '00000000-0000-0000-0000-000000000001';
+    const orgB = '00000000-0000-0000-0000-000000000002';
+    const plaintext = 'same-data';
+
+    const encA = encryptCredentials(MASTER_KEY, orgA, plaintext);
+    const encB = encryptCredentials(MASTER_KEY, orgB, plaintext);
+
+    expect(encA).not.toBe(encB);
+  });
+
+  it('fails to decrypt with wrong org id', () => {
+    const orgA = '00000000-0000-0000-0000-000000000001';
+    const orgB = '00000000-0000-0000-0000-000000000002';
+    const encrypted = encryptCredentials(MASTER_KEY, orgA, 'secret');
+
+    expect(() => decryptCredentials(MASTER_KEY, orgB, encrypted)).toThrow();
+  });
+
+  it('fails on tampered ciphertext', () => {
+    const orgId = '00000000-0000-0000-0000-000000000001';
+    const encrypted = encryptCredentials(MASTER_KEY, orgId, 'secret');
+    const parts = encrypted.split(':');
+    // Flip bits in the auth tag to trigger GCM authentication failure
+    const tagBuf = Buffer.from(parts[2]!, 'base64');
+    tagBuf[0] = (tagBuf[0] ?? 0) ^ 0xff;
+    const tampered = `${parts[0]}:${parts[1]}:${tagBuf.toString('base64')}`;
+
+    expect(() => decryptCredentials(MASTER_KEY, orgId, tampered)).toThrow();
+  });
+
+  it('fails on invalid format', () => {
+    const orgId = '00000000-0000-0000-0000-000000000001';
+    expect(() => decryptCredentials(MASTER_KEY, orgId, 'not-valid')).toThrow();
+  });
+});

--- a/packages/db/src/crypto.ts
+++ b/packages/db/src/crypto.ts
@@ -1,0 +1,61 @@
+import { createCipheriv, createDecipheriv, hkdfSync, randomBytes } from 'node:crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+const KEY_LENGTH = 32;
+const HKDF_INFO = 'lightboard-credentials';
+
+/**
+ * Derives a per-org encryption key from the master key using HKDF.
+ * Each org gets a unique key so compromising one org's data doesn't expose others.
+ */
+function deriveKey(masterKey: string, orgId: string): Buffer {
+  return Buffer.from(hkdfSync('sha256', masterKey, orgId, HKDF_INFO, KEY_LENGTH));
+}
+
+/**
+ * Encrypts a plaintext string using AES-256-GCM with a per-org derived key.
+ * Returns a base64-encoded string in the format: `iv:ciphertext:authTag`.
+ */
+export function encryptCredentials(
+  masterKey: string,
+  orgId: string,
+  plaintext: string,
+): string {
+  const key = deriveKey(masterKey, orgId);
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return [iv.toString('base64'), encrypted.toString('base64'), authTag.toString('base64')].join(
+    ':',
+  );
+}
+
+/**
+ * Decrypts an encrypted credentials string using AES-256-GCM with a per-org derived key.
+ * Expects the format produced by `encryptCredentials`: `iv:ciphertext:authTag`.
+ */
+export function decryptCredentials(
+  masterKey: string,
+  orgId: string,
+  encrypted: string,
+): string {
+  const [ivB64, ciphertextB64, authTagB64] = encrypted.split(':');
+  if (!ivB64 || !ciphertextB64 || !authTagB64) {
+    throw new Error('Invalid encrypted credentials format');
+  }
+
+  const key = deriveKey(masterKey, orgId);
+  const iv = Buffer.from(ivB64, 'base64');
+  const ciphertext = Buffer.from(ciphertextB64, 'base64');
+  const authTag = Buffer.from(authTagB64, 'base64');
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  decipher.setAuthTag(authTag);
+
+  return decipher.update(ciphertext) + decipher.final('utf8');
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,2 @@
+export { createDb, type Database, setOrgContext, withOrgContext } from './client';
+export * from './schema';

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,0 +1,21 @@
+import 'dotenv/config';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { migrate } from 'drizzle-orm/node-postgres/migrator';
+import pg from 'pg';
+
+/** Runs all pending Drizzle migrations against the database. */
+async function main() {
+  const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+  const db = drizzle(pool);
+
+  console.log('Running migrations...');
+  await migrate(db, { migrationsFolder: './drizzle' });
+  console.log('Migrations complete.');
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error('Migration failed:', err);
+  process.exit(1);
+});

--- a/packages/db/src/schema/data-sources.ts
+++ b/packages/db/src/schema/data-sources.ts
@@ -1,0 +1,24 @@
+import { index, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { dataSourceTypeEnum } from './enums';
+import { organizations } from './organizations';
+
+/** Data sources represent external database/API connections. Credentials are encrypted. */
+export const dataSources = pgTable(
+  'data_sources',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    type: dataSourceTypeEnum('type').notNull(),
+    config: jsonb('config').notNull().default({}),
+    credentials: text('credentials').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [index('data_sources_org_id_idx').on(table.orgId)],
+);

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -1,0 +1,18 @@
+import { pgEnum } from 'drizzle-orm/pg-core';
+
+/** User role within an organization. */
+export const userRoleEnum = pgEnum('user_role', ['admin', 'editor', 'viewer']);
+
+/** Data source connector type. */
+export const dataSourceTypeEnum = pgEnum('data_source_type', [
+  'postgres',
+  'mysql',
+  'clickhouse',
+  'rest',
+  'csv',
+  'prometheus',
+  'elasticsearch',
+]);
+
+/** View visibility level. */
+export const visibilityEnum = pgEnum('visibility', ['private', 'org', 'public']);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,0 +1,14 @@
+export { dataSources } from './data-sources';
+export { dataSourceTypeEnum, userRoleEnum, visibilityEnum } from './enums';
+export { organizations } from './organizations';
+export {
+  dataSourcesRelations,
+  organizationsRelations,
+  sessionsRelations,
+  usersRelations,
+  viewsRelations,
+} from './relations';
+export { sessions } from './sessions';
+export { telemetryEvents } from './telemetry-events';
+export { users } from './users';
+export { views } from './views';

--- a/packages/db/src/schema/organizations.ts
+++ b/packages/db/src/schema/organizations.ts
@@ -1,0 +1,14 @@
+import { jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+
+/** Organizations are the top-level tenant boundary. */
+export const organizations = pgTable('organizations', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: text('name').notNull(),
+  slug: text('slug').notNull().unique(),
+  settings: jsonb('settings').default({}).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .defaultNow()
+    .notNull()
+    .$onUpdate(() => new Date()),
+});

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -1,0 +1,56 @@
+import { relations } from 'drizzle-orm';
+import { dataSources } from './data-sources';
+import { organizations } from './organizations';
+import { sessions } from './sessions';
+import { users } from './users';
+import { views } from './views';
+
+/** Organization has many users, sessions, data sources, and views. */
+export const organizationsRelations = relations(organizations, ({ many }) => ({
+  users: many(users),
+  sessions: many(sessions),
+  dataSources: many(dataSources),
+  views: many(views),
+}));
+
+/** User belongs to an organization and has many sessions and views. */
+export const usersRelations = relations(users, ({ one, many }) => ({
+  organization: one(organizations, {
+    fields: [users.orgId],
+    references: [organizations.id],
+  }),
+  sessions: many(sessions),
+  views: many(views),
+}));
+
+/** Session belongs to a user and an organization. */
+export const sessionsRelations = relations(sessions, ({ one }) => ({
+  user: one(users, {
+    fields: [sessions.userId],
+    references: [users.id],
+  }),
+  organization: one(organizations, {
+    fields: [sessions.orgId],
+    references: [organizations.id],
+  }),
+}));
+
+/** Data source belongs to an organization. */
+export const dataSourcesRelations = relations(dataSources, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [dataSources.orgId],
+    references: [organizations.id],
+  }),
+}));
+
+/** View belongs to an organization and a creator. */
+export const viewsRelations = relations(views, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [views.orgId],
+    references: [organizations.id],
+  }),
+  creator: one(users, {
+    fields: [views.createdBy],
+    references: [users.id],
+  }),
+}));

--- a/packages/db/src/schema/sessions.ts
+++ b/packages/db/src/schema/sessions.ts
@@ -1,0 +1,19 @@
+import { index, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { organizations } from './organizations';
+import { users } from './users';
+
+/** Sessions track authenticated user sessions. org_id is denormalized for RLS. */
+export const sessions = pgTable(
+  'sessions',
+  {
+    id: text('id').primaryKey(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  },
+  (table) => [index('sessions_user_id_idx').on(table.userId)],
+);

--- a/packages/db/src/schema/telemetry-events.ts
+++ b/packages/db/src/schema/telemetry-events.ts
@@ -1,0 +1,23 @@
+import { index, jsonb, pgSchema, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+
+/** Telemetry lives in a separate Postgres schema. */
+const telemetrySchema = pgSchema('telemetry');
+
+/** Telemetry events for observability. Stored in the `telemetry` schema. */
+export const telemetryEvents = telemetrySchema.table(
+  'telemetry_events',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id'),
+    eventType: text('event_type').notNull(),
+    payload: jsonb('payload').notNull().default({}),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('telemetry_events_org_type_time_idx').on(
+      table.orgId,
+      table.eventType,
+      table.createdAt,
+    ),
+  ],
+);

--- a/packages/db/src/schema/users.ts
+++ b/packages/db/src/schema/users.ts
@@ -1,0 +1,24 @@
+import { pgTable, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core';
+import { userRoleEnum } from './enums';
+import { organizations } from './organizations';
+
+/** Users belong to an organization and have a role-based access level. */
+export const users = pgTable(
+  'users',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    email: text('email').notNull(),
+    name: text('name').notNull(),
+    passwordHash: text('password_hash').notNull(),
+    role: userRoleEnum('role').notNull().default('viewer'),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [unique('users_org_email_unique').on(table.orgId, table.email)],
+);

--- a/packages/db/src/schema/views.ts
+++ b/packages/db/src/schema/views.ts
@@ -1,0 +1,28 @@
+import { index, integer, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { visibilityEnum } from './enums';
+import { organizations } from './organizations';
+import { users } from './users';
+
+/** Views store saved visualizations with their QueryIR spec. */
+export const views = pgTable(
+  'views',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    createdBy: uuid('created_by')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    spec: jsonb('spec').notNull(),
+    version: integer('version').notNull().default(1),
+    visibility: visibilityEnum('visibility').notNull().default('private'),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [index('views_org_created_by_idx').on(table.orgId, table.createdBy)],
+);

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,0 +1,67 @@
+import 'dotenv/config';
+import pg from 'pg';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { hashPassword } from './auth/password';
+import { organizations } from './schema/organizations';
+import { users } from './schema/users';
+import * as schema from './schema';
+
+/** Seeds the database with demo data for local development. */
+async function main() {
+  const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+  const db = drizzle(pool, { schema });
+
+  console.log('Seeding database...');
+
+  // Create demo organization
+  const [org] = await db
+    .insert(organizations)
+    .values({
+      name: 'Lightboard Demo',
+      slug: 'demo',
+    })
+    .returning();
+
+  if (!org) throw new Error('Failed to create organization');
+  console.log(`Created org: ${org.name} (${org.id})`);
+
+  // Create admin user
+  const adminHash = await hashPassword('lightboard123');
+  const [admin] = await db
+    .insert(users)
+    .values({
+      orgId: org.id,
+      email: 'admin@lightboard.dev',
+      name: 'Admin User',
+      passwordHash: adminHash,
+      role: 'admin',
+    })
+    .returning();
+
+  if (!admin) throw new Error('Failed to create admin user');
+  console.log(`Created admin: ${admin.email}`);
+
+  // Create viewer user
+  const viewerHash = await hashPassword('lightboard123');
+  const [viewer] = await db
+    .insert(users)
+    .values({
+      orgId: org.id,
+      email: 'viewer@lightboard.dev',
+      name: 'Viewer User',
+      passwordHash: viewerHash,
+      role: 'viewer',
+    })
+    .returning();
+
+  if (!viewer) throw new Error('Failed to create viewer user');
+  console.log(`Created viewer: ${viewer.email}`);
+
+  console.log('Seed complete.');
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "drizzle"]
+}

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,14 +1,6 @@
 import * as React from 'react';
 import { cn } from '../utils';
 
-/** Button variant styles. */
-const variants = {
-  default: 'bg-neutral-900 text-white hover:bg-neutral-800 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-neutral-200',
-  outline: 'border border-neutral-200 bg-white hover:bg-neutral-100 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-800',
-  ghost: 'hover:bg-neutral-100 dark:hover:bg-neutral-800',
-  destructive: 'bg-red-500 text-white hover:bg-red-600 dark:bg-red-900 dark:hover:bg-red-800',
-} as const;
-
 /** Button size styles. */
 const sizes = {
   default: 'h-10 px-4 py-2',
@@ -19,21 +11,42 @@ const sizes = {
 
 /** Props for the Button component. */
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: keyof typeof variants;
+  variant?: 'default' | 'outline' | 'ghost' | 'destructive';
   size?: keyof typeof sizes;
 }
 
+/** Style maps for button variants using CSS variables. */
+const variantStyles: Record<string, React.CSSProperties> = {
+  default: {
+    backgroundColor: 'var(--color-primary)',
+    color: 'var(--color-primary-foreground)',
+  },
+  outline: {
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: 'var(--color-input)',
+    backgroundColor: 'transparent',
+  },
+  ghost: {
+    backgroundColor: 'transparent',
+  },
+  destructive: {
+    backgroundColor: 'var(--color-destructive)',
+    color: 'var(--color-destructive-foreground)',
+  },
+};
+
 /** A styled button component with variant and size support. */
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = 'default', size = 'default', ...props }, ref) => (
+  ({ className, variant = 'default', size = 'default', style, ...props }, ref) => (
     <button
       ref={ref}
       className={cn(
-        'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
-        variants[variant],
+        'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
         sizes[size],
         className,
       )}
+      style={{ ...variantStyles[variant], ...style }}
       {...props}
     />
   ),

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { cn } from '../utils';
+
+/** Button variant styles. */
+const variants = {
+  default: 'bg-neutral-900 text-white hover:bg-neutral-800 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-neutral-200',
+  outline: 'border border-neutral-200 bg-white hover:bg-neutral-100 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-800',
+  ghost: 'hover:bg-neutral-100 dark:hover:bg-neutral-800',
+  destructive: 'bg-red-500 text-white hover:bg-red-600 dark:bg-red-900 dark:hover:bg-red-800',
+} as const;
+
+/** Button size styles. */
+const sizes = {
+  default: 'h-10 px-4 py-2',
+  sm: 'h-9 px-3 text-sm',
+  lg: 'h-11 px-8',
+  icon: 'h-10 w-10',
+} as const;
+
+/** Props for the Button component. */
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: keyof typeof variants;
+  size?: keyof typeof sizes;
+}
+
+/** A styled button component with variant and size support. */
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', size = 'default', ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+        variants[variant],
+        sizes[size],
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Button.displayName = 'Button';

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -3,13 +3,18 @@ import { cn } from '../utils';
 
 /** A styled card container. */
 export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
+  ({ className, style, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn(
-        'rounded-lg border border-neutral-200 bg-white text-neutral-950 shadow-sm dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50',
-        className,
-      )}
+      className={cn('rounded-lg shadow-sm', className)}
+      style={{
+        backgroundColor: 'var(--color-card)',
+        color: 'var(--color-card-foreground)',
+        borderWidth: '1px',
+        borderStyle: 'solid',
+        borderColor: 'var(--color-border)',
+        ...style,
+      }}
       {...props}
     />
   ),
@@ -34,8 +39,13 @@ CardTitle.displayName = 'CardTitle';
 
 /** Card description element. */
 export const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => (
-    <p ref={ref} className={cn('text-sm text-neutral-500 dark:text-neutral-400', className)} {...props} />
+  ({ className, style, ...props }, ref) => (
+    <p
+      ref={ref}
+      className={cn('text-sm', className)}
+      style={{ color: 'var(--color-muted-foreground)', ...style }}
+      {...props}
+    />
   ),
 );
 CardDescription.displayName = 'CardDescription';

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { cn } from '../utils';
+
+/** A styled card container. */
+export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        'rounded-lg border border-neutral-200 bg-white text-neutral-950 shadow-sm dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Card.displayName = 'Card';
+
+/** Card header section. */
+export const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  ),
+);
+CardHeader.displayName = 'CardHeader';
+
+/** Card title element. */
+export const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn('text-2xl font-semibold leading-none tracking-tight', className)} {...props} />
+  ),
+);
+CardTitle.displayName = 'CardTitle';
+
+/** Card description element. */
+export const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn('text-sm text-neutral-500 dark:text-neutral-400', className)} {...props} />
+  ),
+);
+CardDescription.displayName = 'CardDescription';
+
+/** Card content section. */
+export const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  ),
+);
+CardContent.displayName = 'CardContent';
+
+/** Card footer section. */
+export const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  ),
+);
+CardFooter.displayName = 'CardFooter';

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -6,14 +6,21 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 /** A styled text input component. */
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => (
+  ({ className, type, style, ...props }, ref) => (
     <input
       type={type}
       ref={ref}
       className={cn(
-        'flex h-10 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-neutral-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:ring-offset-neutral-950 dark:placeholder:text-neutral-400 dark:focus-visible:ring-neutral-300',
+        'flex h-10 w-full rounded-md bg-transparent px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
+      style={{
+        borderWidth: '1px',
+        borderStyle: 'solid',
+        borderColor: 'var(--color-input)',
+        color: 'var(--color-foreground)',
+        ...style,
+      }}
       {...props}
     />
   ),

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { cn } from '../utils';
+
+/** Props for the Input component. */
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+/** A styled text input component. */
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => (
+    <input
+      type={type}
+      ref={ref}
+      className={cn(
+        'flex h-10 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-neutral-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:ring-offset-neutral-950 dark:placeholder:text-neutral-400 dark:focus-visible:ring-neutral-300',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Input.displayName = 'Input';

--- a/packages/ui/src/components/label.tsx
+++ b/packages/ui/src/components/label.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { cn } from '../utils';
+
+/** Props for the Label component. */
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+
+/** A styled form label component. */
+export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn(
+        'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Label.displayName = 'Label';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,3 +4,14 @@
  * Re-export all components from this barrel file.
  */
 export { cn } from './utils';
+export { Button, type ButtonProps } from './components/button';
+export { Input, type InputProps } from './components/input';
+export { Label, type LabelProps } from './components/label';
+export {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from './components/card';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       next-intl:
         specifier: ^4.1.0
         version: 4.8.3(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      next-view-transitions:
+        specifier: ^0.3.5
+        version: 0.3.5(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -2724,6 +2727,13 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  next-view-transitions@0.3.5:
+    resolution: {integrity: sha512-yP8OPNydLmKpmE94hLurLGEzPsUy1uyl9iSv8oxaC2JwhSXTD86SVwk1NMMQT7Ado4kMENDJ7fNBIXHy3GU/Lg==}
+    peerDependencies:
+      next: '>=14.0.0'
+      react: '>=18.2.0 || ^19.0.0'
+      react-dom: '>=18.2.0 || ^19.0.0'
 
   next@15.5.12:
     resolution: {integrity: sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==}
@@ -5679,6 +5689,12 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@swc/helpers'
+
+  next-view-transitions@0.3.5(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      next: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,12 +20,18 @@ importers:
 
   apps/web:
     dependencies:
+      '@lightboard/db':
+        specifier: workspace:*
+        version: link:../../packages/db
       '@lightboard/ui':
         specifier: workspace:*
         version: link:../../packages/ui
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.10.0
       lucide-react:
         specifier: ^0.500.0
         version: 0.500.0(react@19.2.4)
@@ -83,7 +89,44 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+
+  packages/db:
+    dependencies:
+      '@node-rs/argon2':
+        specifier: ^2.0.2
+        version: 2.0.2
+      '@oslojs/crypto':
+        specifier: ^1.0.1
+        version: 1.0.1
+      '@oslojs/encoding':
+        specifier: ^1.1.0
+        version: 1.1.0
+      drizzle-orm:
+        specifier: ^0.44.0
+        version: 0.44.7(@types/pg@8.18.0)(pg@8.20.0)
+      pg:
+        specifier: ^8.16.0
+        version: 8.20.0
+    devDependencies:
+      '@types/pg':
+        specifier: ^8.15.4
+        version: 8.18.0
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.6.1
+      drizzle-kit:
+        specifier: ^0.31.0
+        version: 0.31.9
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
 
   packages/ui:
     dependencies:
@@ -122,6 +165,9 @@ packages:
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
 
@@ -131,16 +177,54 @@ packages:
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.4':
@@ -149,16 +233,52 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.4':
     resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.4':
@@ -167,10 +287,34 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.4':
     resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.4':
@@ -179,10 +323,34 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.4':
     resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.4':
@@ -191,10 +359,34 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.4':
     resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.4':
@@ -203,10 +395,34 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.4':
     resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.4':
@@ -215,10 +431,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.4':
     resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.4':
@@ -227,16 +467,46 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.4':
     resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.4':
@@ -245,10 +515,28 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.4':
@@ -257,11 +545,29 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.4':
     resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
@@ -269,16 +575,52 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.4':
     resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.4':
@@ -509,6 +851,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -586,6 +931,97 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@node-rs/argon2-android-arm-eabi@2.0.2':
+    resolution: {integrity: sha512-DV/H8p/jt40lrao5z5g6nM9dPNPGEHL+aK6Iy/og+dbL503Uj0AHLqj1Hk9aVUSCNnsDdUEKp4TVMi0YakDYKw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@node-rs/argon2-android-arm64@2.0.2':
+    resolution: {integrity: sha512-1LKwskau+8O1ktKx7TbK7jx1oMOMt4YEXZOdSNIar1TQKxm6isZ0cRXgHLibPHEcNHgYRsJWDE9zvDGBB17QDg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@node-rs/argon2-darwin-arm64@2.0.2':
+    resolution: {integrity: sha512-3TTNL/7wbcpNju5YcqUrCgXnXUSbD7ogeAKatzBVHsbpjZQbNb1NDxDjqqrWoTt6XL3z9mJUMGwbAk7zQltHtA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@node-rs/argon2-darwin-x64@2.0.2':
+    resolution: {integrity: sha512-vNPfkLj5Ij5111UTiYuwgxMqE7DRbOS2y58O2DIySzSHbcnu+nipmRKg+P0doRq6eKIJStyBK8dQi5Ic8pFyDw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@node-rs/argon2-freebsd-x64@2.0.2':
+    resolution: {integrity: sha512-M8vQZk01qojQfCqQU0/O1j1a4zPPrz93zc9fSINY7Q/6RhQRBCYwDw7ltDCZXg5JRGlSaeS8cUXWyhPGar3cGg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@node-rs/argon2-linux-arm-gnueabihf@2.0.2':
+    resolution: {integrity: sha512-7EmmEPHLzcu0G2GDh30L6G48CH38roFC2dqlQJmtRCxs6no3tTE/pvgBGatTp/o2n2oyOJcfmgndVFcUpwMnww==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@node-rs/argon2-linux-arm64-gnu@2.0.2':
+    resolution: {integrity: sha512-6lsYh3Ftbk+HAIZ7wNuRF4SZDtxtFTfK+HYFAQQyW7Ig3LHqasqwfUKRXVSV5tJ+xTnxjqgKzvZSUJCAyIfHew==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@node-rs/argon2-linux-arm64-musl@2.0.2':
+    resolution: {integrity: sha512-p3YqVMNT/4DNR67tIHTYGbedYmXxW9QlFmF39SkXyEbGQwpgSf6pH457/fyXBIYznTU/smnG9EH+C1uzT5j4hA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@node-rs/argon2-linux-x64-gnu@2.0.2':
+    resolution: {integrity: sha512-ZM3jrHuJ0dKOhvA80gKJqBpBRmTJTFSo2+xVZR+phQcbAKRlDMSZMFDiKbSTnctkfwNFtjgDdh5g1vaEV04AvA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@node-rs/argon2-linux-x64-musl@2.0.2':
+    resolution: {integrity: sha512-of5uPqk7oCRF/44a89YlWTEfjsftPywyTULwuFDKyD8QtVZoonrJR6ZWvfFE/6jBT68S0okAkAzzMEdBVWdxWw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@node-rs/argon2-wasm32-wasi@2.0.2':
+    resolution: {integrity: sha512-U3PzLYKSQYzTERstgtHLd4ZTkOF9co57zTXT77r0cVUsleGZOrd6ut7rHzeWwoJSiHOVxxa0OhG1JVQeB7lLoQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@node-rs/argon2-win32-arm64-msvc@2.0.2':
+    resolution: {integrity: sha512-Eisd7/NM0m23ijrGr6xI2iMocdOuyl6gO27gfMfya4C5BODbUSP7ljKJ7LrA0teqZMdYHesRDzx36Js++/vhiQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@node-rs/argon2-win32-ia32-msvc@2.0.2':
+    resolution: {integrity: sha512-GsE2ezwAYwh72f9gIjbGTZOf4HxEksb5M2eCaj+Y5rGYVwAdt7C12Q2e9H5LRYxWcFvLH4m4jiSZpQQ4upnPAQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@node-rs/argon2-win32-x64-msvc@2.0.2':
+    resolution: {integrity: sha512-cJxWXanH4Ew9CfuZ4IAEiafpOBCe97bzoKowHCGk5lG/7kR4WF/eknnBlHW9m8q7t10mKq75kruPLtbSDqgRTw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-rs/argon2@2.0.2':
+    resolution: {integrity: sha512-t64wIsPEtNd4aUPuTAyeL2ubxATCBGmeluaKXEMAFk/8w6AJIVVkeLKMBpgLW6LU2t5cQxT+env/c6jxbtTQBg==}
+    engines: {node: '>= 10'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -601,6 +1037,18 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@oslojs/asn1@1.0.0':
+    resolution: {integrity: sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==}
+
+  '@oslojs/binary@1.0.0':
+    resolution: {integrity: sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==}
+
+  '@oslojs/crypto@1.0.1':
+    resolution: {integrity: sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==}
+
+  '@oslojs/encoding@1.1.0':
+    resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -1054,6 +1502,9 @@ packages:
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
+  '@types/pg@8.18.0':
+    resolution: {integrity: sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1361,6 +1812,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1402,6 +1856,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1470,6 +1928,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1484,6 +1946,106 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  drizzle-kit@0.31.9:
+    resolution: {integrity: sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==}
+    hasBin: true
+
+  drizzle-orm@0.44.7:
+    resolution: {integrity: sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1530,6 +2092,21 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild-register@3.6.0:
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    peerDependencies:
+      esbuild: '>=0.12 <1'
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -1825,6 +2402,10 @@ packages:
   intl-messageformat@11.1.2:
     resolution: {integrity: sha512-ucSrQmZGAxfiBHfBRXW/k7UC8MaGFlEj4Ry1tKiDcmgwQm1y3EDl40u+4VNHYomxJQMJi9NEI3riDRlth96jKg==}
 
+  ioredis@5.10.0:
+    resolution: {integrity: sha512-HVBe9OFuqs+Z6n64q09PQvP1/R4Bm+30PAyyD4wIEqssh3v9L21QjCVk4kRLucMBcDokJTcLjsGeVRlq/nH6DA==}
+    engines: {node: '>=12.22.0'}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -2061,6 +2642,12 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -2236,6 +2823,40 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2261,6 +2882,22 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2354,6 +2991,14 @@ packages:
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2463,11 +3108,25 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -2578,6 +3237,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   turbo-darwin-64@2.8.17:
     resolution: {integrity: sha512-ZFkv2hv7zHpAPEXBF6ouRRXshllOavYc+jjcrYyVHvxVTTwJWsBZwJ/gpPzmOKGvkSjsEyDO5V6aqqtZzwVF+Q==}
@@ -2759,6 +3423,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2777,6 +3445,8 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@emnapi/core@1.9.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
@@ -2793,79 +3463,233 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.13.6
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
     optional: true
 
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.4':
     optional: true
 
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
     optional: true
 
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
     optional: true
 
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
     optional: true
 
+  '@esbuild/linux-x64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
     optional: true
 
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
@@ -3052,6 +3876,8 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@ioredis/commands@1.5.1': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3108,6 +3934,67 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.12':
     optional: true
 
+  '@node-rs/argon2-android-arm-eabi@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-android-arm64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-darwin-arm64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-darwin-x64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-freebsd-x64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm-gnueabihf@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-gnu@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-musl@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-gnu@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-musl@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-wasm32-wasi@2.0.2':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@node-rs/argon2-win32-arm64-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-win32-ia32-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-win32-x64-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2@2.0.2':
+    optionalDependencies:
+      '@node-rs/argon2-android-arm-eabi': 2.0.2
+      '@node-rs/argon2-android-arm64': 2.0.2
+      '@node-rs/argon2-darwin-arm64': 2.0.2
+      '@node-rs/argon2-darwin-x64': 2.0.2
+      '@node-rs/argon2-freebsd-x64': 2.0.2
+      '@node-rs/argon2-linux-arm-gnueabihf': 2.0.2
+      '@node-rs/argon2-linux-arm64-gnu': 2.0.2
+      '@node-rs/argon2-linux-arm64-musl': 2.0.2
+      '@node-rs/argon2-linux-x64-gnu': 2.0.2
+      '@node-rs/argon2-linux-x64-musl': 2.0.2
+      '@node-rs/argon2-wasm32-wasi': 2.0.2
+      '@node-rs/argon2-win32-arm64-msvc': 2.0.2
+      '@node-rs/argon2-win32-ia32-msvc': 2.0.2
+      '@node-rs/argon2-win32-x64-msvc': 2.0.2
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3121,6 +4008,19 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@oslojs/asn1@1.0.0':
+    dependencies:
+      '@oslojs/binary': 1.0.0
+
+  '@oslojs/binary@1.0.0': {}
+
+  '@oslojs/crypto@1.0.1':
+    dependencies:
+      '@oslojs/asn1': 1.0.0
+      '@oslojs/binary': 1.0.0
+
+  '@oslojs/encoding@1.1.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -3433,6 +4333,12 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pg@8.18.0':
+    dependencies:
+      '@types/node': 22.19.15
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -3599,13 +4505,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3760,6 +4666,8 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  buffer-from@1.1.2: {}
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -3801,6 +4709,8 @@ snapshots:
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
+
+  cluster-key-slot@1.1.2: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -3864,6 +4774,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  denque@2.1.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -3873,6 +4785,22 @@ snapshots:
       esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
+
+  dotenv@16.6.1: {}
+
+  drizzle-kit@0.31.9:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      esbuild-register: 3.6.0(esbuild@0.25.12)
+    transitivePeerDependencies:
+      - supports-color
+
+  drizzle-orm@0.44.7(@types/pg@8.18.0)(pg@8.20.0):
+    optionalDependencies:
+      '@types/pg': 8.18.0
+      pg: 8.20.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3990,6 +4918,67 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild-register@3.6.0(esbuild@0.25.12):
+    dependencies:
+      debug: 4.4.3
+      esbuild: 0.25.12
+    transitivePeerDependencies:
+      - supports-color
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -4387,6 +5376,20 @@ snapshots:
       '@formatjs/icu-messageformat-parser': 3.5.1
       tslib: 2.8.1
 
+  ioredis@5.10.0:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -4607,6 +5610,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
+
   lodash.merge@4.6.2: {}
 
   loose-envify@1.4.0:
@@ -4784,6 +5791,41 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -4805,6 +5847,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -4840,6 +5892,12 @@ snapshots:
   react-is@17.0.2: {}
 
   react@19.2.4: {}
+
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5034,9 +6092,20 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  split2@4.2.0: {}
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   std-env@3.10.0: {}
 
@@ -5152,6 +6221,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   turbo-darwin-64@2.8.17:
     optional: true
 
@@ -5263,13 +6339,13 @@ snapshots:
       intl-messageformat: 11.1.2
       react: 19.2.4
 
-  vite-node@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1):
+  vite-node@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5284,7 +6360,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1):
+  vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5297,12 +6373,13 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.31.1
+      tsx: 4.21.0
 
-  vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1):
+  vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5320,8 +6397,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
-      vite-node: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
@@ -5390,5 +6467,7 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  xtend@4.0.2: {}
 
   yocto-queue@0.1.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,13 +37,13 @@ importers:
         version: 0.500.0(react@19.2.4)
       next:
         specifier: ^15.3.2
-        version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 15.5.12(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-intl:
         specifier: ^4.1.0
-        version: 4.8.3(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 4.8.3(next@15.5.12(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       next-view-transitions:
-        specifier: ^0.3.5
-        version: 0.3.5(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^0.3.0
+        version: 0.3.5(next@15.5.12(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -57,6 +57,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3.3.5
         version: 3.3.5
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.58.2
       '@tailwindcss/postcss':
         specifier: ^4.1.6
         version: 4.2.1
@@ -1140,6 +1143,11 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -2295,6 +2303,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2877,6 +2890,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   po-parser@2.1.1:
     resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
@@ -4092,6 +4115,10 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
 
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
@@ -5271,6 +5298,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5673,14 +5703,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.8.3: {}
 
-  next-intl@4.8.3(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  next-intl@4.8.3(next@15.5.12(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.18
       icu-minify: 4.8.3
       negotiator: 1.0.0
-      next: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 15.5.12(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-intl-swc-plugin-extractor: 4.8.3
       po-parser: 2.1.1
       react: 19.2.4
@@ -5690,13 +5720,13 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  next-view-transitions@0.3.5(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next-view-transitions@0.3.5(next@15.5.12(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      next: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 15.5.12(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@15.5.12(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 15.5.12
       '@swc/helpers': 0.5.15
@@ -5714,6 +5744,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.12
       '@next/swc-win32-arm64-msvc': 15.5.12
       '@next/swc-win32-x64-msvc': 15.5.12
+      '@playwright/test': 1.58.2
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5847,6 +5878,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   po-parser@2.1.1: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,12 @@
     },
     "test:e2e": {
       "dependsOn": ["build"]
+    },
+    "db:generate": {
+      "cache": false
+    },
+    "db:migrate": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## Summary
- **`packages/db/`**: Drizzle ORM package with 6 schema tables (organizations, users, sessions, data_sources, views, telemetry_events), all with `org_id` and RLS policies
- **Auth**: Argon2 password hashing + session tokens (Copenhagen Book pattern via oslo libs), 30-day sliding window expiry, API routes for register/login/logout/me
- **Middleware**: Next.js edge middleware for route protection + `withAuth` wrapper that validates sessions and sets Postgres RLS org context per-request
- **Rate limiting**: Redis token bucket (100 req/min API, 20 req/min query) per org with Lua script for atomicity
- **Docker Compose**: Postgres 16 + Redis 7 with init scripts creating `lightboard_app` role for RLS enforcement
- **UI**: shadcn-style Button, Input, Label, Card components; login + register pages with next-intl i18n
- **Crypto**: Per-org AES-256-GCM credential encryption with HKDF key derivation
- **Tests**: 11 unit tests (crypto roundtrip/tampering, password hash/verify, cn utility)

PR #29 now includes 13 E2E tests in CI with:

  - Postgres 16 + Redis 7 service containers in the e2e GitHub Actions job
  - Schema push before tests (creates tables + telemetry schema)
  - Playwright chromium installed in CI
  - Serial test execution — tests run in order since later tests depend on the registered user
  - Unique emails per run via Date.now() — no stale data conflicts
  - Register route hardened — catches DB unique constraint violations (500 → 409)

Closes #2

## Test plan
- [x] `pnpm typecheck` — all 3 packages clean
- [x] `pnpm test` — 11 tests pass (8 db + 3 web)
- [x] `pnpm build` — production build succeeds with all routes
- [x] CI passes on GitHub Actions
- [x] `docker compose up` starts Postgres + Redis
- [x] `pnpm --filter @lightboard/db db:push` applies schema to Postgres
- [x] `pnpm --filter @lightboard/db db:seed` creates demo org + users
- [x] Register flow creates org + user + session cookie
- [x] Login flow validates credentials + sets session
- [x] Dashboard routes redirect to /login when unauthenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)