### PR TITLE
feat(d3): Query IR package — types, schemas, and utilities

### DIFF
--- a/packages/query-ir/package.json
+++ b/packages/query-ir/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@lightboard/query-ir",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.2",
+    "vitest": "^3.1.0"
+  }
+}

--- a/packages/query-ir/src/describe.test.ts
+++ b/packages/query-ir/src/describe.test.ts
@@ -1,0 +1,145 @@
+import { describe as desc, expect, it } from 'vitest';
+import { describe } from './describe';
+import type { QueryIR } from './types';
+
+const baseIR: QueryIR = {
+  source: 'pg-main',
+  table: 'events',
+  select: [],
+  aggregations: [],
+  groupBy: [],
+  orderBy: [],
+  joins: [],
+};
+
+desc('describe', () => {
+  it('describes a minimal SELECT *', () => {
+    const result = describe(baseIR);
+    expect(result).toContain('SELECT *');
+    expect(result).toContain('FROM pg-main.events');
+  });
+
+  it('describes selected fields', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      select: [
+        { field: 'id' },
+        { field: 'name', alias: 'user_name' },
+        { field: 'email', table: 'u' },
+      ],
+    };
+    const result = describe(ir);
+    expect(result).toContain('SELECT id, name as user_name, u.email');
+  });
+
+  it('describes aggregations', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      aggregations: [
+        { function: 'sum', field: { field: 'amount' }, alias: 'total' },
+        { function: 'count', field: { field: '*' } },
+      ],
+      groupBy: [{ field: 'category' }],
+    };
+    const result = describe(ir);
+    expect(result).toContain('SUM(amount) as total');
+    expect(result).toContain('COUNT(*)');
+    expect(result).toContain('GROUP BY category');
+  });
+
+  it('describes filters', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      filter: {
+        and: [
+          { field: { field: 'status' }, operator: 'eq', value: 'active' },
+          { field: { field: 'age' }, operator: 'gte', value: 18 },
+        ],
+      },
+    };
+    const result = describe(ir);
+    expect(result).toContain('WHERE (status EQ "active" AND age GTE 18)');
+  });
+
+  it('describes is_null filter', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      filter: { field: { field: 'deleted_at' }, operator: 'is_null' },
+    };
+    const result = describe(ir);
+    expect(result).toContain('WHERE deleted_at IS NULL');
+  });
+
+  it('describes OR filters', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      filter: {
+        or: [
+          { field: { field: 'a' }, operator: 'eq', value: 1 },
+          { field: { field: 'b' }, operator: 'eq', value: 2 },
+        ],
+      },
+    };
+    const result = describe(ir);
+    expect(result).toContain('WHERE (a EQ 1 OR b EQ 2)');
+  });
+
+  it('describes IN filter with array', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      filter: { field: { field: 'status' }, operator: 'in', value: ['a', 'b', 'c'] },
+    };
+    const result = describe(ir);
+    expect(result).toContain('WHERE status IN (a, b, c)');
+  });
+
+  it('describes time range', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      timeRange: { field: { field: 'created_at' }, from: 'now-1h', to: 'now' },
+    };
+    const result = describe(ir);
+    expect(result).toContain('TIME created_at FROM now-1h TO now');
+  });
+
+  it('describes order by', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      orderBy: [
+        { field: { field: 'score' }, direction: 'desc' },
+        { field: { field: 'name' }, direction: 'asc' },
+      ],
+    };
+    const result = describe(ir);
+    expect(result).toContain('ORDER BY score DESC, name ASC');
+  });
+
+  it('describes limit and offset', () => {
+    const ir: QueryIR = { ...baseIR, limit: 50, offset: 100 };
+    const result = describe(ir);
+    expect(result).toContain('LIMIT 50');
+    expect(result).toContain('OFFSET 100');
+  });
+
+  it('describes joins', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      joins: [
+        {
+          type: 'left',
+          table: 'users',
+          alias: 'u',
+          on: { field: { field: 'user_id' }, operator: 'eq', value: 'u.id' },
+        },
+      ],
+    };
+    const result = describe(ir);
+    expect(result).toContain('LEFT JOIN users u ON');
+  });
+
+  it('describes table alias', () => {
+    const ir: QueryIR = { ...baseIR, tableAlias: 'e' };
+    const result = describe(ir);
+    expect(result).toContain('FROM pg-main.events e');
+  });
+});

--- a/packages/query-ir/src/describe.ts
+++ b/packages/query-ir/src/describe.ts
@@ -1,0 +1,94 @@
+import type { Aggregation, FieldRef, FilterClause, QueryIR } from './types';
+
+/** Formats a field reference as a readable string. */
+function describeField(ref: FieldRef): string {
+  const qualified = ref.table ? `${ref.table}.${ref.field}` : ref.field;
+  return ref.alias ? `${qualified} as ${ref.alias}` : qualified;
+}
+
+/** Formats an aggregation as a readable string. */
+function describeAgg(agg: Aggregation): string {
+  const fn = agg.function.toUpperCase();
+  const field = describeField(agg.field);
+  const base = `${fn}(${field})`;
+  return agg.alias ? `${base} as ${agg.alias}` : base;
+}
+
+/** Formats a filter clause as a readable string. */
+function describeFilter(clause: FilterClause): string {
+  if ('and' in clause) {
+    return `(${clause.and.map(describeFilter).join(' AND ')})`;
+  }
+  if ('or' in clause) {
+    return `(${clause.or.map(describeFilter).join(' OR ')})`;
+  }
+  const field = describeField(clause.field);
+  const op = clause.operator.toUpperCase().replace('_', ' ');
+  if (clause.operator === 'is_null' || clause.operator === 'is_not_null') {
+    return `${field} ${op}`;
+  }
+  const val = Array.isArray(clause.value)
+    ? `(${clause.value.join(', ')})`
+    : JSON.stringify(clause.value);
+  return `${field} ${op} ${val}`;
+}
+
+/**
+ * Produces a human-readable summary of a QueryIR.
+ * Useful for displaying what a query does to end users.
+ */
+export function describe(ir: QueryIR): string {
+  const parts: string[] = [];
+
+  // SELECT
+  if (ir.aggregations.length > 0) {
+    const aggs = ir.aggregations.map(describeAgg).join(', ');
+    const fields = ir.select.length > 0 ? ir.select.map(describeField).join(', ') + ', ' : '';
+    parts.push(`SELECT ${fields}${aggs}`);
+  } else if (ir.select.length > 0) {
+    parts.push(`SELECT ${ir.select.map(describeField).join(', ')}`);
+  } else {
+    parts.push('SELECT *');
+  }
+
+  // FROM
+  const table = ir.tableAlias ? `${ir.table} ${ir.tableAlias}` : ir.table;
+  parts.push(`FROM ${ir.source}.${table}`);
+
+  // JOINS
+  for (const join of ir.joins) {
+    const alias = join.alias ? ` ${join.alias}` : '';
+    parts.push(`${join.type.toUpperCase()} JOIN ${join.table}${alias} ON ${describeFilter(join.on)}`);
+  }
+
+  // WHERE
+  if (ir.filter) {
+    parts.push(`WHERE ${describeFilter(ir.filter)}`);
+  }
+
+  // TIME RANGE
+  if (ir.timeRange) {
+    parts.push(`TIME ${describeField(ir.timeRange.field)} FROM ${ir.timeRange.from} TO ${ir.timeRange.to}`);
+  }
+
+  // GROUP BY
+  if (ir.groupBy.length > 0) {
+    parts.push(`GROUP BY ${ir.groupBy.map(describeField).join(', ')}`);
+  }
+
+  // ORDER BY
+  if (ir.orderBy.length > 0) {
+    const orders = ir.orderBy.map((o) => `${describeField(o.field)} ${o.direction.toUpperCase()}`);
+    parts.push(`ORDER BY ${orders.join(', ')}`);
+  }
+
+  // LIMIT / OFFSET
+  if (ir.limit !== undefined) {
+    parts.push(`LIMIT ${ir.limit}`);
+  }
+  if (ir.offset !== undefined) {
+    parts.push(`OFFSET ${ir.offset}`);
+  }
+
+  return parts.join('\n');
+}

--- a/packages/query-ir/src/hash.test.ts
+++ b/packages/query-ir/src/hash.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { hash } from './hash';
+import type { QueryIR } from './types';
+
+describe('hash', () => {
+  const ir: QueryIR = {
+    source: 'pg-main',
+    table: 'events',
+    select: [{ field: 'id' }, { field: 'name' }],
+    aggregations: [],
+    groupBy: [],
+    orderBy: [],
+    joins: [],
+  };
+
+  it('produces a hex string', () => {
+    const h = hash(ir);
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic', () => {
+    expect(hash(ir)).toBe(hash(ir));
+  });
+
+  it('changes when IR changes', () => {
+    const modified = { ...ir, table: 'users' };
+    expect(hash(ir)).not.toBe(hash(modified));
+  });
+
+  it('is stable regardless of property order', () => {
+    const a: QueryIR = { source: 'x', table: 'y', select: [], aggregations: [], groupBy: [], orderBy: [], joins: [] };
+    const b: QueryIR = { table: 'y', source: 'x', select: [], joins: [], orderBy: [], groupBy: [], aggregations: [] };
+    expect(hash(a)).toBe(hash(b));
+  });
+});

--- a/packages/query-ir/src/hash.ts
+++ b/packages/query-ir/src/hash.ts
@@ -1,0 +1,11 @@
+import { createHash } from 'node:crypto';
+import type { QueryIR } from './types';
+
+/**
+ * Produces a stable SHA-256 hash of a QueryIR for use as a cache key.
+ * The IR is serialized with sorted keys to ensure deterministic output.
+ */
+export function hash(ir: QueryIR): string {
+  const json = JSON.stringify(ir, Object.keys(ir).sort());
+  return createHash('sha256').update(json).digest('hex');
+}

--- a/packages/query-ir/src/index.ts
+++ b/packages/query-ir/src/index.ts
@@ -1,0 +1,27 @@
+export { describe } from './describe';
+export { hash } from './hash';
+export { extractVariables, interpolateVariables, type VariableMap } from './interpolate';
+export {
+  aggregationFunctionSchema,
+  aggregationSchema,
+  fieldRefSchema,
+  filterClauseSchema,
+  filterConditionSchema,
+  filterOperatorSchema,
+  joinClauseSchema,
+  orderClauseSchema,
+  queryIRSchema,
+  timeRangeSchema,
+} from './schema';
+export type {
+  Aggregation,
+  AggregationFunction,
+  FieldRef,
+  FilterClause,
+  FilterCondition,
+  FilterOperator,
+  JoinClause,
+  OrderClause,
+  QueryIR,
+  TimeRange,
+} from './types';

--- a/packages/query-ir/src/interpolate.test.ts
+++ b/packages/query-ir/src/interpolate.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { extractVariables, interpolateVariables } from './interpolate';
+import type { QueryIR } from './types';
+
+const baseIR: QueryIR = {
+  source: 'pg-main',
+  table: 'events',
+  select: [],
+  aggregations: [],
+  groupBy: [],
+  orderBy: [],
+  joins: [],
+};
+
+describe('interpolateVariables', () => {
+  it('substitutes variables in filter values', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      filter: { field: { field: 'status' }, operator: 'eq', value: '$status' },
+    };
+    const result = interpolateVariables(ir, { status: 'active' });
+    expect((result.filter as any).value).toBe('active');
+  });
+
+  it('substitutes variables in time range', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      timeRange: {
+        field: { field: 'created_at' },
+        from: '$start_time',
+        to: '$end_time',
+      },
+    };
+    const result = interpolateVariables(ir, {
+      start_time: '2024-01-01',
+      end_time: '2024-12-31',
+    });
+    expect(result.timeRange!.from).toBe('2024-01-01');
+    expect(result.timeRange!.to).toBe('2024-12-31');
+  });
+
+  it('substitutes numeric variables as strings', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      filter: { field: { field: 'age' }, operator: 'gt', value: '$min_age' },
+    };
+    const result = interpolateVariables(ir, { min_age: 18 });
+    expect((result.filter as any).value).toBe('18');
+  });
+
+  it('substitutes null variables', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      filter: { field: { field: 'x' }, operator: 'eq', value: '$val' },
+    };
+    const result = interpolateVariables(ir, { val: null });
+    expect((result.filter as any).value).toBe('null');
+  });
+
+  it('leaves unmatched variables as-is', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      filter: { field: { field: 'x' }, operator: 'eq', value: '$unknown' },
+    };
+    const result = interpolateVariables(ir, {});
+    expect((result.filter as any).value).toBe('$unknown');
+  });
+
+  it('handles multiple variables in one string', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      filter: { field: { field: 'x' }, operator: 'like', value: '$prefix%$suffix' },
+    };
+    const result = interpolateVariables(ir, { prefix: 'hello', suffix: 'world' });
+    expect((result.filter as any).value).toBe('hello%world');
+  });
+
+  it('does not modify the original IR', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      filter: { field: { field: 'x' }, operator: 'eq', value: '$val' },
+    };
+    interpolateVariables(ir, { val: 'replaced' });
+    expect((ir.filter as any).value).toBe('$val');
+  });
+});
+
+describe('extractVariables', () => {
+  it('finds variables in filter values', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      filter: {
+        and: [
+          { field: { field: 'x' }, operator: 'eq', value: '$foo' },
+          { field: { field: 'y' }, operator: 'gt', value: '$bar' },
+        ],
+      },
+    };
+    const vars = extractVariables(ir);
+    expect(vars).toContain('foo');
+    expect(vars).toContain('bar');
+    expect(vars).toHaveLength(2);
+  });
+
+  it('finds variables in time range', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      timeRange: { field: { field: 'ts' }, from: '$start', to: '$end' },
+    };
+    const vars = extractVariables(ir);
+    expect(vars).toContain('start');
+    expect(vars).toContain('end');
+  });
+
+  it('deduplicates repeated variables', () => {
+    const ir: QueryIR = {
+      ...baseIR,
+      filter: {
+        and: [
+          { field: { field: 'a' }, operator: 'eq', value: '$x' },
+          { field: { field: 'b' }, operator: 'eq', value: '$x' },
+        ],
+      },
+    };
+    expect(extractVariables(ir)).toEqual(['x']);
+  });
+
+  it('returns empty array when no variables', () => {
+    expect(extractVariables(baseIR)).toEqual([]);
+  });
+});

--- a/packages/query-ir/src/interpolate.ts
+++ b/packages/query-ir/src/interpolate.ts
@@ -1,0 +1,37 @@
+import type { QueryIR } from './types';
+
+/** Variable map: keys are variable names (without $), values are substitution values. */
+export type VariableMap = Record<string, string | number | boolean | null>;
+
+const VARIABLE_PATTERN = /\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
+
+/**
+ * Substitutes `$variable_name` placeholders in string values throughout the IR.
+ * Returns a new IR with all matching variables replaced. Unmatched variables are left as-is.
+ */
+export function interpolateVariables(ir: QueryIR, vars: VariableMap): QueryIR {
+  return JSON.parse(JSON.stringify(ir), (_key, value) => {
+    if (typeof value !== 'string') return value;
+    return value.replace(VARIABLE_PATTERN, (match, name: string) => {
+      if (name in vars) {
+        const v = vars[name];
+        return v === null ? 'null' : String(v);
+      }
+      return match;
+    });
+  }) as QueryIR;
+}
+
+/**
+ * Extracts all variable names (without $) referenced in the IR.
+ */
+export function extractVariables(ir: QueryIR): string[] {
+  const json = JSON.stringify(ir);
+  const vars = new Set<string>();
+  const pattern = /\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(json)) !== null) {
+    if (match[1]) vars.add(match[1]);
+  }
+  return [...vars];
+}

--- a/packages/query-ir/src/schema.test.ts
+++ b/packages/query-ir/src/schema.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { filterClauseSchema, queryIRSchema } from './schema';
+
+describe('queryIRSchema', () => {
+  const minimal = {
+    source: 'pg-main',
+    table: 'events',
+  };
+
+  it('validates a minimal IR', () => {
+    const result = queryIRSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.source).toBe('pg-main');
+      expect(result.data.table).toBe('events');
+      expect(result.data.select).toEqual([]);
+      expect(result.data.aggregations).toEqual([]);
+      expect(result.data.groupBy).toEqual([]);
+      expect(result.data.orderBy).toEqual([]);
+      expect(result.data.joins).toEqual([]);
+    }
+  });
+
+  it('validates a full IR with all fields', () => {
+    const full = {
+      source: 'pg-main',
+      table: 'orders',
+      tableAlias: 'o',
+      select: [
+        { field: 'customer_id', table: 'o' },
+        { field: 'status', alias: 'order_status' },
+      ],
+      filter: {
+        and: [
+          { field: { field: 'status' }, operator: 'eq', value: 'active' },
+          { field: { field: 'amount' }, operator: 'gte', value: 100 },
+        ],
+      },
+      aggregations: [
+        { function: 'sum', field: { field: 'amount' }, alias: 'total' },
+        { function: 'count', field: { field: '*' }, alias: 'num_orders' },
+      ],
+      groupBy: [{ field: 'customer_id' }],
+      orderBy: [{ field: { field: 'total' }, direction: 'desc' }],
+      timeRange: {
+        field: { field: 'created_at' },
+        from: 'now-7d',
+        to: 'now',
+      },
+      joins: [
+        {
+          type: 'left',
+          table: 'customers',
+          alias: 'c',
+          on: { field: { field: 'id', table: 'c' }, operator: 'eq', value: '$customer_id' },
+        },
+      ],
+      limit: 100,
+      offset: 0,
+    };
+
+    const result = queryIRSchema.safeParse(full);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid source', () => {
+    const result = queryIRSchema.safeParse({ table: 'events' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid filter operator', () => {
+    const result = queryIRSchema.safeParse({
+      ...minimal,
+      filter: { field: { field: 'x' }, operator: 'invalid', value: 1 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid aggregation function', () => {
+    const result = queryIRSchema.safeParse({
+      ...minimal,
+      aggregations: [{ function: 'median', field: { field: 'x' } }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('validates percentile with params', () => {
+    const result = queryIRSchema.safeParse({
+      ...minimal,
+      aggregations: [
+        { function: 'percentile', field: { field: 'latency' }, params: { p: 99 } },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects negative limit', () => {
+    const result = queryIRSchema.safeParse({ ...minimal, limit: -1 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('filterClauseSchema', () => {
+  it('validates simple condition', () => {
+    const result = filterClauseSchema.safeParse({
+      field: { field: 'age' },
+      operator: 'gt',
+      value: 18,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('validates is_null without value', () => {
+    const result = filterClauseSchema.safeParse({
+      field: { field: 'deleted_at' },
+      operator: 'is_null',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('validates in operator with array', () => {
+    const result = filterClauseSchema.safeParse({
+      field: { field: 'status' },
+      operator: 'in',
+      value: ['active', 'pending'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('validates nested and/or combinators', () => {
+    const result = filterClauseSchema.safeParse({
+      and: [
+        { field: { field: 'a' }, operator: 'eq', value: 1 },
+        {
+          or: [
+            { field: { field: 'b' }, operator: 'gt', value: 10 },
+            { field: { field: 'c' }, operator: 'is_not_null' },
+          ],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('validates deeply nested combinators', () => {
+    const result = filterClauseSchema.safeParse({
+      or: [
+        {
+          and: [
+            { field: { field: 'x' }, operator: 'eq', value: 1 },
+            {
+              or: [
+                { field: { field: 'y' }, operator: 'lt', value: 5 },
+                { field: { field: 'z' }, operator: 'like', value: '%test%' },
+              ],
+            },
+          ],
+        },
+        { field: { field: 'w' }, operator: 'neq', value: 'deleted' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty and array', () => {
+    const result = filterClauseSchema.safeParse({ and: [] });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/query-ir/src/schema.ts
+++ b/packages/query-ir/src/schema.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod';
+import type { FilterClause } from './types';
+
+// ─── Field Reference ───────────────────────────────────────────────
+
+/** Schema for a field reference (column or expression). */
+export const fieldRefSchema = z.object({
+  field: z.string().describe('Column name or expression'),
+  table: z.string().optional().describe('Table or alias qualifier'),
+  alias: z.string().optional().describe('Output alias for this field'),
+});
+
+// ─── Filter Operators ──────────────────────────────────────────────
+
+/** All supported comparison operators. */
+export const filterOperatorSchema = z.enum([
+  'eq',
+  'neq',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'in',
+  'not_in',
+  'like',
+  'is_null',
+  'is_not_null',
+]);
+
+/** Schema for a single filter condition. */
+export const filterConditionSchema = z.object({
+  field: fieldRefSchema,
+  operator: filterOperatorSchema,
+  value: z
+    .union([z.string(), z.number(), z.boolean(), z.null(), z.array(z.union([z.string(), z.number()]))])
+    .optional()
+    .describe('Comparison value (omitted for is_null/is_not_null)'),
+});
+
+/** Schema for a filter clause (conditions combined with boolean logic). */
+export const filterClauseSchema: z.ZodType<FilterClause> = z.lazy(() =>
+  z.union([
+    filterConditionSchema,
+    z.object({
+      and: z.array(filterClauseSchema).min(1).describe('All conditions must match'),
+    }),
+    z.object({
+      or: z.array(filterClauseSchema).min(1).describe('Any condition must match'),
+    }),
+  ]),
+);
+
+// ─── Aggregation ───────────────────────────────────────────────────
+
+/** All supported aggregation functions. */
+export const aggregationFunctionSchema = z.enum([
+  'sum',
+  'avg',
+  'count',
+  'count_distinct',
+  'min',
+  'max',
+  'percentile',
+]);
+
+/** Schema for an aggregation expression. */
+export const aggregationSchema = z.object({
+  function: aggregationFunctionSchema,
+  field: fieldRefSchema,
+  alias: z.string().optional().describe('Output alias for aggregation result'),
+  params: z
+    .record(z.union([z.string(), z.number()]))
+    .optional()
+    .describe('Function-specific parameters (e.g. percentile value)'),
+});
+
+// ─── Order ─────────────────────────────────────────────────────────
+
+/** Schema for an ordering clause. */
+export const orderClauseSchema = z.object({
+  field: fieldRefSchema,
+  direction: z.enum(['asc', 'desc']).default('asc'),
+});
+
+// ─── Time Range ────────────────────────────────────────────────────
+
+/** Schema for a time range filter. */
+export const timeRangeSchema = z.object({
+  field: fieldRefSchema.describe('Timestamp field to filter on'),
+  from: z.string().describe('Start time (ISO 8601 or relative like "now-1h")'),
+  to: z.string().describe('End time (ISO 8601 or relative like "now")'),
+});
+
+// ─── Join ──────────────────────────────────────────────────────────
+
+/** Schema for a join clause. */
+export const joinClauseSchema = z.object({
+  type: z.enum(['inner', 'left', 'right', 'cross']).default('inner'),
+  table: z.string().describe('Table to join'),
+  alias: z.string().optional(),
+  on: filterClauseSchema.describe('Join condition'),
+});
+
+// ─── QueryIR ───────────────────────────────────────────────────────
+
+/** Schema for the full Query Intermediate Representation. */
+export const queryIRSchema = z.object({
+  source: z.string().describe('Data source ID or name'),
+  table: z.string().describe('Primary table or collection'),
+  tableAlias: z.string().optional(),
+  select: z.array(fieldRefSchema).default([]),
+  filter: filterClauseSchema.optional(),
+  aggregations: z.array(aggregationSchema).default([]),
+  groupBy: z.array(fieldRefSchema).default([]),
+  orderBy: z.array(orderClauseSchema).default([]),
+  timeRange: timeRangeSchema.optional(),
+  joins: z.array(joinClauseSchema).default([]),
+  limit: z.number().int().positive().optional(),
+  offset: z.number().int().min(0).optional(),
+});

--- a/packages/query-ir/src/types.ts
+++ b/packages/query-ir/src/types.ts
@@ -1,0 +1,85 @@
+/** A reference to a field (column or expression). */
+export interface FieldRef {
+  field: string;
+  table?: string;
+  alias?: string;
+}
+
+/** A comparison operator for filter conditions. */
+export type FilterOperator =
+  | 'eq'
+  | 'neq'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'in'
+  | 'not_in'
+  | 'like'
+  | 'is_null'
+  | 'is_not_null';
+
+/** A single filter condition. */
+export interface FilterCondition {
+  field: FieldRef;
+  operator: FilterOperator;
+  value?: string | number | boolean | null | (string | number)[];
+}
+
+/** A filter clause: a condition, or boolean combinator of clauses. */
+export type FilterClause = FilterCondition | { and: FilterClause[] } | { or: FilterClause[] };
+
+/** An aggregation function name. */
+export type AggregationFunction =
+  | 'sum'
+  | 'avg'
+  | 'count'
+  | 'count_distinct'
+  | 'min'
+  | 'max'
+  | 'percentile';
+
+/** An aggregation expression. */
+export interface Aggregation {
+  function: AggregationFunction;
+  field: FieldRef;
+  alias?: string;
+  params?: Record<string, string | number>;
+}
+
+/** An ordering clause. */
+export interface OrderClause {
+  field: FieldRef;
+  direction: 'asc' | 'desc';
+}
+
+/** A time range filter. */
+export interface TimeRange {
+  field: FieldRef;
+  from: string;
+  to: string;
+}
+
+/** A join clause. */
+export interface JoinClause {
+  type: 'inner' | 'left' | 'right' | 'cross';
+  table: string;
+  alias?: string;
+  on: FilterClause;
+}
+
+/** The full Query Intermediate Representation. */
+export interface QueryIR {
+  source: string;
+  table: string;
+  tableAlias?: string;
+  select: FieldRef[];
+  filter?: FilterClause;
+  aggregations: Aggregation[];
+  groupBy: FieldRef[];
+  orderBy: OrderClause[];
+  timeRange?: TimeRange;
+  joins: JoinClause[];
+  limit?: number;
+  offset?: number;
+}

--- a/packages/query-ir/tsconfig.json
+++ b/packages/query-ir/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,19 @@ importers:
         specifier: ^3.1.0
         version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
 
+  packages/query-ir:
+    dependencies:
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+
   packages/ui:
     dependencies:
       clsx:
@@ -3464,6 +3477,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -6526,3 +6542,5 @@ snapshots:
   xtend@4.0.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}


### PR DESCRIPTION
## Summary
- **`packages/query-ir/`** — The lingua franca for all Lightboard queries
- **Types**: `QueryIR`, `FieldRef`, `FilterClause` (nested and/or), `Aggregation`, `OrderClause`, `TimeRange`, `JoinClause`
- **Zod schemas**: Runtime validation for all IR structures including recursive filter clauses
- **Filter operators**: eq, neq, gt, gte, lt, lte, in, not_in, like, is_null, is_not_null
- **Aggregation functions**: sum, avg, count, count_distinct, min, max, percentile
- **Utilities**:
  - `hash(ir)` — stable SHA-256 cache key
  - `interpolateVariables(ir, vars)` — `$variable` substitution
  - `extractVariables(ir)` — find all referenced variables
  - `describe(ir)` — human-readable query summary

Closes #3

## Test plan
- [x] `pnpm --filter @lightboard/query-ir typecheck` — clean
- [x] `pnpm --filter @lightboard/query-ir test` — 40 tests pass
- [x] Full workspace `pnpm typecheck && pnpm test` — 51 tests pass
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)