### PR TITLE
feat(d4): Connector SDK + PostgreSQL connector

### DIFF
--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@lightboard/connector-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@lightboard/query-ir": "workspace:*",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.2",
+    "vitest": "^3.1.0"
+  }
+}

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -1,0 +1,15 @@
+export { ConnectorRegistry, defaultRegistry, type ConnectorFactory } from './registry';
+export { connectorConfigSchema, poolConfigSchema, postgresConnectionSchema } from './schemas';
+export type {
+  ArrowRecordBatch,
+  ArrowResult,
+  ColumnMetadata,
+  Connector,
+  ConnectorCapabilities,
+  ConnectorConfig,
+  HealthCheckResult,
+  QueryOptions,
+  RelationshipMetadata,
+  SchemaMetadata,
+  TableMetadata,
+} from './types';

--- a/packages/connector-sdk/src/registry.test.ts
+++ b/packages/connector-sdk/src/registry.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { ConnectorRegistry } from './registry';
+import type { Connector } from './types';
+
+function mockConnector(): Connector {
+  return {
+    type: 'mock',
+    connect: async () => {},
+    introspect: async () => ({ tables: [], relationships: [] }),
+    query: async () => ({ buffer: new Uint8Array(), rowCount: 0, columnCount: 0 }),
+    stream: async function* () {},
+    healthCheck: async () => ({ status: 'healthy', latencyMs: 1 }),
+    capabilities: () => ({
+      filter: true,
+      aggregation: true,
+      ordering: true,
+      pagination: true,
+      joins: false,
+      timeRange: false,
+      streaming: false,
+    }),
+    disconnect: async () => {},
+  };
+}
+
+describe('ConnectorRegistry', () => {
+  it('registers and creates a connector', () => {
+    const registry = new ConnectorRegistry();
+    registry.register('mock', mockConnector);
+    const connector = registry.create({ type: 'mock', name: 'test', connection: {} });
+    expect(connector.type).toBe('mock');
+  });
+
+  it('throws on duplicate registration', () => {
+    const registry = new ConnectorRegistry();
+    registry.register('mock', mockConnector);
+    expect(() => registry.register('mock', mockConnector)).toThrow('already registered');
+  });
+
+  it('throws on unknown type', () => {
+    const registry = new ConnectorRegistry();
+    expect(() => registry.create({ type: 'unknown', name: 'test', connection: {} })).toThrow(
+      'Unknown connector type',
+    );
+  });
+
+  it('checks if type exists', () => {
+    const registry = new ConnectorRegistry();
+    expect(registry.has('mock')).toBe(false);
+    registry.register('mock', mockConnector);
+    expect(registry.has('mock')).toBe(true);
+  });
+
+  it('lists registered types', () => {
+    const registry = new ConnectorRegistry();
+    registry.register('postgres', mockConnector);
+    registry.register('mysql', mockConnector);
+    expect(registry.types()).toEqual(['postgres', 'mysql']);
+  });
+
+  it('unregisters a type', () => {
+    const registry = new ConnectorRegistry();
+    registry.register('mock', mockConnector);
+    expect(registry.unregister('mock')).toBe(true);
+    expect(registry.has('mock')).toBe(false);
+    expect(registry.unregister('mock')).toBe(false);
+  });
+});

--- a/packages/connector-sdk/src/registry.ts
+++ b/packages/connector-sdk/src/registry.ts
@@ -1,0 +1,49 @@
+import type { Connector, ConnectorConfig } from './types';
+
+/** Factory function that creates a connector instance. */
+export type ConnectorFactory = () => Connector;
+
+/**
+ * Registry for looking up connector factories by type.
+ * Each connector type (postgres, mysql, etc.) registers a factory function.
+ */
+export class ConnectorRegistry {
+  private factories = new Map<string, ConnectorFactory>();
+
+  /** Register a connector factory for a given type. */
+  register(type: string, factory: ConnectorFactory): void {
+    if (this.factories.has(type)) {
+      throw new Error(`Connector type "${type}" is already registered`);
+    }
+    this.factories.set(type, factory);
+  }
+
+  /** Create a connector instance for the given config. */
+  create(config: ConnectorConfig): Connector {
+    const factory = this.factories.get(config.type);
+    if (!factory) {
+      throw new Error(
+        `Unknown connector type "${config.type}". Available: ${[...this.factories.keys()].join(', ')}`,
+      );
+    }
+    return factory();
+  }
+
+  /** Check if a connector type is registered. */
+  has(type: string): boolean {
+    return this.factories.has(type);
+  }
+
+  /** List all registered connector types. */
+  types(): string[] {
+    return [...this.factories.keys()];
+  }
+
+  /** Remove a registered connector type. */
+  unregister(type: string): boolean {
+    return this.factories.delete(type);
+  }
+}
+
+/** Default global connector registry. */
+export const defaultRegistry = new ConnectorRegistry();

--- a/packages/connector-sdk/src/schemas.ts
+++ b/packages/connector-sdk/src/schemas.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+/** Zod schema for connector pool settings. */
+export const poolConfigSchema = z.object({
+  min: z.number().int().min(0).optional(),
+  max: z.number().int().positive().optional(),
+  idleTimeoutMs: z.number().int().positive().optional(),
+  connectionTimeoutMs: z.number().int().positive().optional(),
+});
+
+/** Zod schema for connector configuration. */
+export const connectorConfigSchema = z.object({
+  type: z.string().min(1),
+  name: z.string().min(1),
+  connection: z.record(z.unknown()),
+  pool: poolConfigSchema.optional(),
+});
+
+/** Zod schema for Postgres-specific connection config. */
+export const postgresConnectionSchema = z.object({
+  host: z.string().min(1),
+  port: z.number().int().default(5432),
+  database: z.string().min(1),
+  user: z.string().min(1),
+  password: z.string(),
+  ssl: z.boolean().default(false),
+});

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -1,0 +1,133 @@
+import type { QueryIR } from '@lightboard/query-ir';
+
+/** Configuration for connecting to a data source. */
+export interface ConnectorConfig {
+  /** Connector type identifier (e.g. 'postgres', 'mysql'). */
+  type: string;
+  /** Display name for the connection. */
+  name: string;
+  /** Connection-specific configuration (host, port, database, etc.). */
+  connection: Record<string, unknown>;
+  /** Connection pool settings. */
+  pool?: {
+    min?: number;
+    max?: number;
+    idleTimeoutMs?: number;
+    connectionTimeoutMs?: number;
+  };
+}
+
+/** Column metadata from schema introspection. */
+export interface ColumnMetadata {
+  name: string;
+  type: string;
+  nullable: boolean;
+  primaryKey: boolean;
+  defaultValue?: string | null;
+}
+
+/** Foreign key relationship metadata. */
+export interface RelationshipMetadata {
+  constraintName: string;
+  sourceTable: string;
+  sourceColumn: string;
+  targetTable: string;
+  targetColumn: string;
+}
+
+/** Table metadata from schema introspection. */
+export interface TableMetadata {
+  name: string;
+  schema: string;
+  columns: ColumnMetadata[];
+  rowCount?: number;
+}
+
+/** Full schema metadata returned by introspection. */
+export interface SchemaMetadata {
+  tables: TableMetadata[];
+  relationships: RelationshipMetadata[];
+}
+
+/** Options for query execution. */
+export interface QueryOptions {
+  /** Query timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Maximum rows to return. */
+  limit?: number;
+  /** Template variables to interpolate before execution. */
+  variables?: Record<string, string | number | boolean | null>;
+}
+
+/** Result of a health check. */
+export interface HealthCheckResult {
+  status: 'healthy' | 'unhealthy';
+  latencyMs: number;
+  message?: string;
+}
+
+/** Declares what operations a connector supports. */
+export interface ConnectorCapabilities {
+  /** Supports filtering (WHERE). */
+  filter: boolean;
+  /** Supports aggregation (GROUP BY + aggregate functions). */
+  aggregation: boolean;
+  /** Supports ordering (ORDER BY). */
+  ordering: boolean;
+  /** Supports LIMIT/OFFSET. */
+  pagination: boolean;
+  /** Supports JOINs. */
+  joins: boolean;
+  /** Supports time range filtering. */
+  timeRange: boolean;
+  /** Supports streaming results. */
+  streaming: boolean;
+}
+
+/** Query result as serialized Arrow IPC buffer. */
+export interface ArrowResult {
+  /** Arrow IPC buffer containing the result data. */
+  buffer: Uint8Array;
+  /** Number of rows in the result. */
+  rowCount: number;
+  /** Number of columns in the result. */
+  columnCount: number;
+}
+
+/** A single Arrow record batch for streaming. */
+export interface ArrowRecordBatch {
+  /** Arrow IPC buffer for this batch. */
+  buffer: Uint8Array;
+  /** Number of rows in this batch. */
+  rowCount: number;
+}
+
+/**
+ * The Connector interface — the adapter contract for all data sources.
+ * Every data source (Postgres, MySQL, ClickHouse, REST, etc.) implements this.
+ */
+export interface Connector {
+  /** Connector type identifier. */
+  readonly type: string;
+
+  /** Establish the connection and initialize the pool. */
+  connect(config: ConnectorConfig): Promise<void>;
+
+  /** Return schema metadata (tables, columns, relationships). */
+  introspect(): Promise<SchemaMetadata>;
+
+  /** Execute a QueryIR and return the full result as Arrow IPC. */
+  query(ir: QueryIR, options?: QueryOptions): Promise<ArrowResult>;
+
+  /** Execute a QueryIR and stream results as Arrow record batches. */
+  stream(ir: QueryIR, options?: QueryOptions): AsyncIterable<ArrowRecordBatch>;
+
+  /** Check if the connection is alive. */
+  healthCheck(): Promise<HealthCheckResult>;
+
+  /** Declare what operations this connector supports. */
+  capabilities(): ConnectorCapabilities;
+
+  /** Close the connection and release resources. */
+  disconnect(): Promise<void>;
+}

--- a/packages/connector-sdk/tsconfig.json
+++ b/packages/connector-sdk/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/connectors/postgres/package.json
+++ b/packages/connectors/postgres/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@lightboard/connector-postgres",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@lightboard/connector-sdk": "workspace:*",
+    "@lightboard/query-ir": "workspace:*",
+    "apache-arrow": "^19.0.1",
+    "pg": "^8.16.0",
+    "pg-cursor": "^2.12.2"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.15.4",
+    "@types/pg-cursor": "^2.7.2",
+    "typescript": "^5.8.2",
+    "vitest": "^3.1.0"
+  }
+}

--- a/packages/connectors/postgres/src/arrow.test.ts
+++ b/packages/connectors/postgres/src/arrow.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { Bool, Float64, Int32, Int64, TimestampMillisecond, Utf8 } from 'apache-arrow';
+import { pgTypeToArrow, rowsToArrow } from './arrow';
+
+describe('pgTypeToArrow', () => {
+  it('maps integer types', () => {
+    expect(pgTypeToArrow('int4')).toBeInstanceOf(Int32);
+    expect(pgTypeToArrow('integer')).toBeInstanceOf(Int32);
+    expect(pgTypeToArrow('int2')).toBeInstanceOf(Int32);
+    expect(pgTypeToArrow('int8')).toBeInstanceOf(Int64);
+    expect(pgTypeToArrow('bigint')).toBeInstanceOf(Int64);
+  });
+
+  it('maps float types', () => {
+    expect(pgTypeToArrow('float4')).toBeInstanceOf(Float64);
+    expect(pgTypeToArrow('float8')).toBeInstanceOf(Float64);
+    expect(pgTypeToArrow('numeric')).toBeInstanceOf(Float64);
+    expect(pgTypeToArrow('double precision')).toBeInstanceOf(Float64);
+  });
+
+  it('maps boolean', () => {
+    expect(pgTypeToArrow('bool')).toBeInstanceOf(Bool);
+    expect(pgTypeToArrow('boolean')).toBeInstanceOf(Bool);
+  });
+
+  it('maps text types', () => {
+    expect(pgTypeToArrow('text')).toBeInstanceOf(Utf8);
+    expect(pgTypeToArrow('varchar')).toBeInstanceOf(Utf8);
+    expect(pgTypeToArrow('uuid')).toBeInstanceOf(Utf8);
+    expect(pgTypeToArrow('jsonb')).toBeInstanceOf(Utf8);
+  });
+
+  it('maps timestamp types', () => {
+    expect(pgTypeToArrow('timestamp')).toBeInstanceOf(TimestampMillisecond);
+    expect(pgTypeToArrow('timestamptz')).toBeInstanceOf(TimestampMillisecond);
+    expect(pgTypeToArrow('timestamp with time zone')).toBeInstanceOf(TimestampMillisecond);
+  });
+
+  it('falls back to Utf8 for unknown types', () => {
+    expect(pgTypeToArrow('custom_type')).toBeInstanceOf(Utf8);
+  });
+});
+
+describe('rowsToArrow', () => {
+  it('returns empty result for no rows', () => {
+    const result = rowsToArrow([], [{ name: 'id', dataTypeID: 23 }]);
+    expect(result.rowCount).toBe(0);
+    expect(result.buffer.length).toBe(0);
+  });
+
+  it('converts rows to Arrow IPC buffer', () => {
+    const rows = [
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ];
+    const fields = [
+      { name: 'id', dataTypeID: 23, pgType: 'int4' },
+      { name: 'name', dataTypeID: 25, pgType: 'text' },
+    ];
+    const result = rowsToArrow(rows, fields);
+    expect(result.rowCount).toBe(2);
+    expect(result.columnCount).toBe(2);
+    expect(result.buffer.length).toBeGreaterThan(0);
+  });
+
+  it('handles null values', () => {
+    const rows = [{ id: 1, name: null }];
+    const fields = [
+      { name: 'id', dataTypeID: 23, pgType: 'int4' },
+      { name: 'name', dataTypeID: 25, pgType: 'text' },
+    ];
+    const result = rowsToArrow(rows, fields);
+    expect(result.rowCount).toBe(1);
+  });
+});

--- a/packages/connectors/postgres/src/arrow.ts
+++ b/packages/connectors/postgres/src/arrow.ts
@@ -1,0 +1,95 @@
+import {
+  Bool,
+  type DataType,
+  Float64,
+  Int32,
+  Int64,
+  tableFromArrays,
+  tableToIPC,
+  TimestampMillisecond,
+  Utf8,
+} from 'apache-arrow';
+import type { ArrowRecordBatch, ArrowResult } from '@lightboard/connector-sdk';
+
+/** Maps PostgreSQL type names to Arrow data types. */
+const PG_TO_ARROW: Record<string, DataType> = {
+  int2: new Int32(),
+  int4: new Int32(),
+  int8: new Int64(),
+  smallint: new Int32(),
+  integer: new Int32(),
+  bigint: new Int64(),
+  float4: new Float64(),
+  float8: new Float64(),
+  real: new Float64(),
+  'double precision': new Float64(),
+  numeric: new Float64(),
+  decimal: new Float64(),
+  bool: new Bool(),
+  boolean: new Bool(),
+  text: new Utf8(),
+  varchar: new Utf8(),
+  'character varying': new Utf8(),
+  char: new Utf8(),
+  character: new Utf8(),
+  name: new Utf8(),
+  uuid: new Utf8(),
+  json: new Utf8(),
+  jsonb: new Utf8(),
+  timestamp: new TimestampMillisecond(),
+  timestamptz: new TimestampMillisecond(),
+  'timestamp without time zone': new TimestampMillisecond(),
+  'timestamp with time zone': new TimestampMillisecond(),
+  date: new Utf8(),
+  time: new Utf8(),
+  interval: new Utf8(),
+};
+
+/** Returns the Arrow DataType for a Postgres type name. Falls back to Utf8. */
+export function pgTypeToArrow(pgType: string): DataType {
+  return PG_TO_ARROW[pgType.toLowerCase()] ?? new Utf8();
+}
+
+/**
+ * Converts pg query result rows into an Arrow IPC buffer.
+ * Each column is mapped from its Postgres type to the corresponding Arrow type.
+ */
+export function rowsToArrow(
+  rows: Record<string, unknown>[],
+  fields: { name: string; dataTypeID: number; pgType?: string }[],
+): ArrowResult {
+  if (rows.length === 0) {
+    return { buffer: new Uint8Array(), rowCount: 0, columnCount: fields.length };
+  }
+
+  // Build column arrays keyed by field name
+  const columnData: Record<string, unknown[]> = {};
+  for (const f of fields) {
+    columnData[f.name] = rows.map((row) => {
+      const val = row[f.name];
+      if (val === null || val === undefined) return null;
+      if (val instanceof Date) return val.getTime();
+      return val;
+    });
+  }
+
+  const table = tableFromArrays(columnData);
+  const buffer = tableToIPC(table);
+
+  return {
+    buffer: new Uint8Array(buffer),
+    rowCount: rows.length,
+    columnCount: fields.length,
+  };
+}
+
+/**
+ * Converts a batch of rows into an Arrow record batch for streaming.
+ */
+export function rowsToArrowBatch(
+  rows: Record<string, unknown>[],
+  fields: { name: string; dataTypeID: number; pgType?: string }[],
+): ArrowRecordBatch {
+  const result = rowsToArrow(rows, fields);
+  return { buffer: result.buffer, rowCount: result.rowCount };
+}

--- a/packages/connectors/postgres/src/connector.ts
+++ b/packages/connectors/postgres/src/connector.ts
@@ -1,0 +1,280 @@
+import type {
+  ArrowRecordBatch,
+  ArrowResult,
+  Connector,
+  ConnectorCapabilities,
+  ConnectorConfig,
+  HealthCheckResult,
+  QueryOptions,
+  SchemaMetadata,
+} from '@lightboard/connector-sdk';
+import { postgresConnectionSchema } from '@lightboard/connector-sdk';
+import { interpolateVariables, type QueryIR } from '@lightboard/query-ir';
+import pg from 'pg';
+import Cursor from 'pg-cursor';
+import { rowsToArrow, rowsToArrowBatch } from './arrow';
+import { translateIR } from './translator';
+
+const PG_TYPE_QUERY = `
+  SELECT t.oid, t.typname
+  FROM pg_type t
+  JOIN pg_namespace n ON t.typnamespace = n.oid
+  WHERE n.nspname = 'pg_catalog'
+`;
+
+const INTROSPECT_TABLES = `
+  SELECT table_schema, table_name
+  FROM information_schema.tables
+  WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+    AND table_type = 'BASE TABLE'
+  ORDER BY table_schema, table_name
+`;
+
+const INTROSPECT_COLUMNS = `
+  SELECT
+    c.table_schema,
+    c.table_name,
+    c.column_name,
+    c.data_type,
+    c.is_nullable,
+    c.column_default,
+    CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END AS is_primary_key
+  FROM information_schema.columns c
+  LEFT JOIN (
+    SELECT kcu.table_schema, kcu.table_name, kcu.column_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+      AND tc.table_schema = kcu.table_schema
+    WHERE tc.constraint_type = 'PRIMARY KEY'
+  ) pk ON c.table_schema = pk.table_schema
+    AND c.table_name = pk.table_name
+    AND c.column_name = pk.column_name
+  WHERE c.table_schema NOT IN ('pg_catalog', 'information_schema')
+  ORDER BY c.table_schema, c.table_name, c.ordinal_position
+`;
+
+const INTROSPECT_RELATIONSHIPS = `
+  SELECT
+    tc.constraint_name,
+    kcu.table_name AS source_table,
+    kcu.column_name AS source_column,
+    ccu.table_name AS target_table,
+    ccu.column_name AS target_column
+  FROM information_schema.table_constraints tc
+  JOIN information_schema.key_column_usage kcu
+    ON tc.constraint_name = kcu.constraint_name
+    AND tc.table_schema = kcu.table_schema
+  JOIN information_schema.constraint_column_usage ccu
+    ON tc.constraint_name = ccu.constraint_name
+    AND tc.table_schema = ccu.table_schema
+  WHERE tc.constraint_type = 'FOREIGN KEY'
+    AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
+`;
+
+const DEFAULT_BATCH_SIZE = 1000;
+
+/** PostgreSQL connector implementing the Connector interface. */
+export class PostgresConnector implements Connector {
+  readonly type = 'postgres';
+  private pool: pg.Pool | null = null;
+  private typeMap = new Map<number, string>();
+
+  /** Establish the connection pool and load type mappings. */
+  async connect(config: ConnectorConfig): Promise<void> {
+    const conn = postgresConnectionSchema.parse(config.connection);
+    this.pool = new pg.Pool({
+      host: conn.host,
+      port: conn.port,
+      database: conn.database,
+      user: conn.user,
+      password: conn.password,
+      ssl: conn.ssl ? { rejectUnauthorized: false } : false,
+      min: config.pool?.min ?? 1,
+      max: config.pool?.max ?? 10,
+      idleTimeoutMillis: config.pool?.idleTimeoutMs ?? 30000,
+      connectionTimeoutMillis: config.pool?.connectionTimeoutMs ?? 5000,
+    });
+
+    // Load pg type OID → name mapping for Arrow type conversion
+    const result = await this.pool.query(PG_TYPE_QUERY);
+    for (const row of result.rows) {
+      this.typeMap.set(row.oid as number, row.typname as string);
+    }
+  }
+
+  /** Return schema metadata from information_schema. */
+  async introspect(): Promise<SchemaMetadata> {
+    const pool = this.getPool();
+
+    const [tablesResult, columnsResult, relsResult] = await Promise.all([
+      pool.query(INTROSPECT_TABLES),
+      pool.query(INTROSPECT_COLUMNS),
+      pool.query(INTROSPECT_RELATIONSHIPS),
+    ]);
+
+    const tableMap = new Map<string, { name: string; schema: string; columns: any[] }>();
+
+    for (const row of tablesResult.rows) {
+      const key = `${row.table_schema}.${row.table_name}`;
+      tableMap.set(key, {
+        name: row.table_name,
+        schema: row.table_schema,
+        columns: [],
+      });
+    }
+
+    for (const row of columnsResult.rows) {
+      const key = `${row.table_schema}.${row.table_name}`;
+      const table = tableMap.get(key);
+      if (table) {
+        table.columns.push({
+          name: row.column_name,
+          type: row.data_type,
+          nullable: row.is_nullable === 'YES',
+          primaryKey: row.is_primary_key === true || row.is_primary_key === 't',
+          defaultValue: row.column_default ?? null,
+        });
+      }
+    }
+
+    const relationships = relsResult.rows.map((row) => ({
+      constraintName: row.constraint_name,
+      sourceTable: row.source_table,
+      sourceColumn: row.source_column,
+      targetTable: row.target_table,
+      targetColumn: row.target_column,
+    }));
+
+    return {
+      tables: [...tableMap.values()],
+      relationships,
+    };
+  }
+
+  /** Execute a QueryIR and return the full result as Arrow IPC. */
+  async query(ir: QueryIR, options?: QueryOptions): Promise<ArrowResult> {
+    const pool = this.getPool();
+
+    const resolved = options?.variables
+      ? interpolateVariables(ir, options.variables)
+      : ir;
+
+    const { sql, params } = translateIR(resolved);
+    const client = await pool.connect();
+
+    try {
+      if (options?.timeoutMs) {
+        await client.query(`SET statement_timeout = ${options.timeoutMs}`);
+      }
+
+      const result = await client.query(sql, params);
+      const fields = result.fields.map((f) => ({
+        name: f.name,
+        dataTypeID: f.dataTypeID,
+        pgType: this.typeMap.get(f.dataTypeID) ?? 'text',
+      }));
+
+      return rowsToArrow(result.rows, fields);
+    } finally {
+      client.release();
+    }
+  }
+
+  /** Stream QueryIR results as Arrow record batches. */
+  async *stream(ir: QueryIR, options?: QueryOptions): AsyncIterable<ArrowRecordBatch> {
+    const pool = this.getPool();
+
+    const resolved = options?.variables
+      ? interpolateVariables(ir, options.variables)
+      : ir;
+
+    const { sql, params } = translateIR(resolved);
+    const client = await pool.connect();
+
+    try {
+      const cursor = client.query(new Cursor(sql, params));
+      let fields: { name: string; dataTypeID: number; pgType: string }[] | null = null;
+      const batchSize = DEFAULT_BATCH_SIZE;
+
+      while (true) {
+        const rows = await new Promise<Record<string, unknown>[]>((resolve, reject) => {
+          cursor.read(batchSize, (err: Error | undefined, result: Record<string, unknown>[], pgResult: any) => {
+            if (err) return reject(err);
+            if (!fields && pgResult?.fields) {
+              fields = pgResult.fields.map((f: any) => ({
+                name: f.name,
+                dataTypeID: f.dataTypeID,
+                pgType: this.typeMap.get(f.dataTypeID) ?? 'text',
+              }));
+            }
+            resolve(result);
+          });
+        });
+
+        if (rows.length === 0) break;
+        if (fields) {
+          yield rowsToArrowBatch(rows, fields);
+        }
+      }
+
+      cursor.close(() => {});
+    } finally {
+      client.release();
+    }
+  }
+
+  /** Check if the connection is alive with SELECT 1. */
+  async healthCheck(): Promise<HealthCheckResult> {
+    if (!this.pool) {
+      return { status: 'unhealthy', latencyMs: 0, message: 'Not connected' };
+    }
+
+    const start = performance.now();
+    try {
+      await this.pool.query('SELECT 1');
+      return { status: 'healthy', latencyMs: Math.round(performance.now() - start) };
+    } catch (err) {
+      return {
+        status: 'unhealthy',
+        latencyMs: Math.round(performance.now() - start),
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  /** Declare full SQL pushdown capabilities. */
+  capabilities(): ConnectorCapabilities {
+    return {
+      filter: true,
+      aggregation: true,
+      ordering: true,
+      pagination: true,
+      joins: true,
+      timeRange: true,
+      streaming: true,
+    };
+  }
+
+  /** Close the connection pool. */
+  async disconnect(): Promise<void> {
+    if (this.pool) {
+      await this.pool.end();
+      this.pool = null;
+      this.typeMap.clear();
+    }
+  }
+
+  /** Throws if not connected. */
+  private ensureConnected(): void {
+    if (!this.pool) {
+      throw new Error('PostgresConnector is not connected. Call connect() first.');
+    }
+  }
+
+  /** Returns the pool, throwing if not connected. */
+  private getPool(): pg.Pool {
+    this.ensureConnected();
+    return this.pool!;
+  }
+}

--- a/packages/connectors/postgres/src/index.ts
+++ b/packages/connectors/postgres/src/index.ts
@@ -1,0 +1,3 @@
+export { pgTypeToArrow, rowsToArrow, rowsToArrowBatch } from './arrow';
+export { PostgresConnector } from './connector';
+export { translateIR, type TranslationResult } from './translator';

--- a/packages/connectors/postgres/src/translator.test.ts
+++ b/packages/connectors/postgres/src/translator.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from 'vitest';
+import type { QueryIR } from '@lightboard/query-ir';
+import { translateIR } from './translator';
+
+const base: QueryIR = {
+  source: 'pg-main',
+  table: 'events',
+  select: [],
+  aggregations: [],
+  groupBy: [],
+  orderBy: [],
+  joins: [],
+};
+
+describe('translateIR', () => {
+  it('translates SELECT *', () => {
+    const { sql, params } = translateIR(base);
+    expect(sql).toBe('SELECT * FROM "events"');
+    expect(params).toEqual([]);
+  });
+
+  it('translates selected fields', () => {
+    const { sql } = translateIR({
+      ...base,
+      select: [{ field: 'id' }, { field: 'name', alias: 'user_name' }],
+    });
+    expect(sql).toContain('SELECT "id", "name" AS "user_name"');
+  });
+
+  it('translates table alias', () => {
+    const { sql } = translateIR({ ...base, tableAlias: 'e' });
+    expect(sql).toContain('FROM "events" "e"');
+  });
+
+  it('translates qualified field references', () => {
+    const { sql } = translateIR({
+      ...base,
+      select: [{ field: 'id', table: 'e' }],
+    });
+    expect(sql).toContain('"e"."id"');
+  });
+
+  // Filter operators
+  it('translates eq filter', () => {
+    const { sql, params } = translateIR({
+      ...base,
+      filter: { field: { field: 'status' }, operator: 'eq', value: 'active' },
+    });
+    expect(sql).toContain('WHERE "status" = $1');
+    expect(params).toEqual(['active']);
+  });
+
+  it('translates neq filter', () => {
+    const { sql, params } = translateIR({
+      ...base,
+      filter: { field: { field: 'status' }, operator: 'neq', value: 'deleted' },
+    });
+    expect(sql).toContain('"status" != $1');
+    expect(params).toEqual(['deleted']);
+  });
+
+  it('translates gt/gte/lt/lte filters', () => {
+    const { sql, params } = translateIR({
+      ...base,
+      filter: {
+        and: [
+          { field: { field: 'age' }, operator: 'gt', value: 18 },
+          { field: { field: 'score' }, operator: 'gte', value: 50 },
+          { field: { field: 'rank' }, operator: 'lt', value: 100 },
+          { field: { field: 'level' }, operator: 'lte', value: 5 },
+        ],
+      },
+    });
+    expect(sql).toContain('"age" > $1');
+    expect(sql).toContain('"score" >= $2');
+    expect(sql).toContain('"rank" < $3');
+    expect(sql).toContain('"level" <= $4');
+    expect(params).toEqual([18, 50, 100, 5]);
+  });
+
+  it('translates like filter', () => {
+    const { sql, params } = translateIR({
+      ...base,
+      filter: { field: { field: 'name' }, operator: 'like', value: '%test%' },
+    });
+    expect(sql).toContain('"name" LIKE $1');
+    expect(params).toEqual(['%test%']);
+  });
+
+  it('translates is_null filter', () => {
+    const { sql, params } = translateIR({
+      ...base,
+      filter: { field: { field: 'deleted_at' }, operator: 'is_null' },
+    });
+    expect(sql).toContain('"deleted_at" IS NULL');
+    expect(params).toEqual([]);
+  });
+
+  it('translates is_not_null filter', () => {
+    const { sql, params } = translateIR({
+      ...base,
+      filter: { field: { field: 'email' }, operator: 'is_not_null' },
+    });
+    expect(sql).toContain('"email" IS NOT NULL');
+    expect(params).toEqual([]);
+  });
+
+  it('translates in filter', () => {
+    const { sql, params } = translateIR({
+      ...base,
+      filter: { field: { field: 'status' }, operator: 'in', value: ['a', 'b', 'c'] },
+    });
+    expect(sql).toContain('"status" IN ($1, $2, $3)');
+    expect(params).toEqual(['a', 'b', 'c']);
+  });
+
+  it('translates not_in filter', () => {
+    const { sql, params } = translateIR({
+      ...base,
+      filter: { field: { field: 'type' }, operator: 'not_in', value: [1, 2] },
+    });
+    expect(sql).toContain('"type" NOT IN ($1, $2)');
+    expect(params).toEqual([1, 2]);
+  });
+
+  // Boolean combinators
+  it('translates AND combinator', () => {
+    const { sql } = translateIR({
+      ...base,
+      filter: {
+        and: [
+          { field: { field: 'a' }, operator: 'eq', value: 1 },
+          { field: { field: 'b' }, operator: 'eq', value: 2 },
+        ],
+      },
+    });
+    expect(sql).toContain('("a" = $1 AND "b" = $2)');
+  });
+
+  it('translates OR combinator', () => {
+    const { sql } = translateIR({
+      ...base,
+      filter: {
+        or: [
+          { field: { field: 'a' }, operator: 'eq', value: 1 },
+          { field: { field: 'b' }, operator: 'eq', value: 2 },
+        ],
+      },
+    });
+    expect(sql).toContain('("a" = $1 OR "b" = $2)');
+  });
+
+  it('translates nested AND/OR', () => {
+    const { sql, params } = translateIR({
+      ...base,
+      filter: {
+        and: [
+          { field: { field: 'x' }, operator: 'eq', value: 1 },
+          {
+            or: [
+              { field: { field: 'y' }, operator: 'gt', value: 10 },
+              { field: { field: 'z' }, operator: 'is_null' },
+            ],
+          },
+        ],
+      },
+    });
+    expect(sql).toContain('("x" = $1 AND ("y" > $2 OR "z" IS NULL))');
+    expect(params).toEqual([1, 10]);
+  });
+
+  // Aggregations
+  it('translates SUM aggregation', () => {
+    const { sql } = translateIR({
+      ...base,
+      aggregations: [{ function: 'sum', field: { field: 'amount' }, alias: 'total' }],
+    });
+    expect(sql).toContain('SUM("amount") AS "total"');
+  });
+
+  it('translates COUNT(*)', () => {
+    const { sql } = translateIR({
+      ...base,
+      aggregations: [{ function: 'count', field: { field: '*' } }],
+    });
+    expect(sql).toContain('COUNT(*)');
+  });
+
+  it('translates COUNT(DISTINCT)', () => {
+    const { sql } = translateIR({
+      ...base,
+      aggregations: [{ function: 'count_distinct', field: { field: 'user_id' }, alias: 'unique_users' }],
+    });
+    expect(sql).toContain('COUNT(DISTINCT "user_id") AS "unique_users"');
+  });
+
+  it('translates AVG, MIN, MAX', () => {
+    const { sql } = translateIR({
+      ...base,
+      aggregations: [
+        { function: 'avg', field: { field: 'score' } },
+        { function: 'min', field: { field: 'created_at' } },
+        { function: 'max', field: { field: 'updated_at' } },
+      ],
+    });
+    expect(sql).toContain('AVG("score")');
+    expect(sql).toContain('MIN("created_at")');
+    expect(sql).toContain('MAX("updated_at")');
+  });
+
+  it('translates PERCENTILE_CONT', () => {
+    const { sql } = translateIR({
+      ...base,
+      aggregations: [
+        { function: 'percentile', field: { field: 'latency' }, params: { p: 0.99 }, alias: 'p99' },
+      ],
+    });
+    expect(sql).toContain('PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY "latency") AS "p99"');
+  });
+
+  // GROUP BY
+  it('translates GROUP BY', () => {
+    const { sql } = translateIR({
+      ...base,
+      select: [{ field: 'category' }],
+      aggregations: [{ function: 'count', field: { field: '*' }, alias: 'cnt' }],
+      groupBy: [{ field: 'category' }],
+    });
+    expect(sql).toContain('GROUP BY "category"');
+  });
+
+  // ORDER BY
+  it('translates ORDER BY', () => {
+    const { sql } = translateIR({
+      ...base,
+      orderBy: [
+        { field: { field: 'score' }, direction: 'desc' },
+        { field: { field: 'name' }, direction: 'asc' },
+      ],
+    });
+    expect(sql).toContain('ORDER BY "score" DESC, "name" ASC');
+  });
+
+  // LIMIT & OFFSET
+  it('translates LIMIT and OFFSET', () => {
+    const { sql, params } = translateIR({ ...base, limit: 50, offset: 100 });
+    expect(sql).toContain('LIMIT $1 OFFSET $2');
+    expect(params).toEqual([50, 100]);
+  });
+
+  // Time range
+  it('translates time range', () => {
+    const { sql, params } = translateIR({
+      ...base,
+      timeRange: { field: { field: 'created_at' }, from: '2024-01-01', to: '2024-12-31' },
+    });
+    expect(sql).toContain('"created_at" >= $1 AND "created_at" <= $2');
+    expect(params).toEqual(['2024-01-01', '2024-12-31']);
+  });
+
+  // Joins
+  it('translates LEFT JOIN', () => {
+    const { sql, params } = translateIR({
+      ...base,
+      joins: [{
+        type: 'left',
+        table: 'users',
+        alias: 'u',
+        on: { field: { field: 'user_id', table: 'events' }, operator: 'eq', value: 'u.id' },
+      }],
+    });
+    expect(sql).toContain('LEFT JOIN "users" "u" ON "events"."user_id" = $1');
+    expect(params).toContain('u.id');
+  });
+
+  // Complex query
+  it('translates a complex multi-operation query', () => {
+    const { sql, params } = translateIR({
+      source: 'pg-main',
+      table: 'orders',
+      tableAlias: 'o',
+      select: [{ field: 'customer_id', table: 'o' }],
+      filter: { field: { field: 'status' }, operator: 'eq', value: 'completed' },
+      aggregations: [
+        { function: 'sum', field: { field: 'total' }, alias: 'revenue' },
+        { function: 'count', field: { field: '*' }, alias: 'order_count' },
+      ],
+      groupBy: [{ field: 'customer_id', table: 'o' }],
+      orderBy: [{ field: { field: 'revenue' }, direction: 'desc' }],
+      timeRange: { field: { field: 'created_at' }, from: '2024-01-01', to: '2024-06-30' },
+      joins: [],
+      limit: 10,
+    });
+
+    expect(sql).toContain('SELECT "o"."customer_id"');
+    expect(sql).toContain('SUM("total") AS "revenue"');
+    expect(sql).toContain('COUNT(*)');
+    expect(sql).toContain('FROM "orders" "o"');
+    expect(sql).toContain('WHERE "status" = $1');
+    expect(sql).toContain('"created_at" >= $2');
+    expect(sql).toContain('GROUP BY "o"."customer_id"');
+    expect(sql).toContain('ORDER BY "revenue" DESC');
+    expect(sql).toContain('LIMIT $4');
+    expect(params[0]).toBe('completed');
+  });
+
+  // Edge cases
+  it('handles empty filter (no WHERE)', () => {
+    const { sql } = translateIR(base);
+    expect(sql).not.toContain('WHERE');
+  });
+
+  it('handles filter + time range together', () => {
+    const { sql } = translateIR({
+      ...base,
+      filter: { field: { field: 'active' }, operator: 'eq', value: true },
+      timeRange: { field: { field: 'ts' }, from: 'now-1h', to: 'now' },
+    });
+    expect(sql).toContain('WHERE "active" = $1 AND "ts" >= $2 AND "ts" <= $3');
+  });
+});

--- a/packages/connectors/postgres/src/translator.ts
+++ b/packages/connectors/postgres/src/translator.ts
@@ -1,0 +1,205 @@
+import type {
+  Aggregation,
+  FieldRef,
+  FilterClause,
+  JoinClause,
+  OrderClause,
+  QueryIR,
+  TimeRange,
+} from '@lightboard/query-ir';
+
+/** Result of IR-to-SQL translation: parameterized SQL + values. */
+export interface TranslationResult {
+  sql: string;
+  params: unknown[];
+}
+
+/** Mutable context tracking parameter index during translation. */
+interface TranslationContext {
+  params: unknown[];
+  paramIndex: number;
+}
+
+/** Adds a parameter and returns its placeholder ($1, $2, etc.). */
+function addParam(ctx: TranslationContext, value: unknown): string {
+  ctx.params.push(value);
+  ctx.paramIndex++;
+  return `$${ctx.paramIndex}`;
+}
+
+/** Formats a field reference as qualified SQL. */
+function formatField(ref: FieldRef): string {
+  const qualified = ref.table ? `"${ref.table}"."${ref.field}"` : `"${ref.field}"`;
+  return ref.alias ? `${qualified} AS "${ref.alias}"` : qualified;
+}
+
+/** Formats a field reference without alias (for GROUP BY, ORDER BY). */
+function formatFieldRef(ref: FieldRef): string {
+  return ref.table ? `"${ref.table}"."${ref.field}"` : `"${ref.field}"`;
+}
+
+/** Translates a filter clause to SQL with parameterized values. */
+function translateFilter(clause: FilterClause, ctx: TranslationContext): string {
+  if ('and' in clause) {
+    const parts = clause.and.map((c) => translateFilter(c, ctx));
+    return `(${parts.join(' AND ')})`;
+  }
+  if ('or' in clause) {
+    const parts = clause.or.map((c) => translateFilter(c, ctx));
+    return `(${parts.join(' OR ')})`;
+  }
+
+  const field = formatFieldRef(clause.field);
+
+  switch (clause.operator) {
+    case 'eq':
+      return `${field} = ${addParam(ctx, clause.value)}`;
+    case 'neq':
+      return `${field} != ${addParam(ctx, clause.value)}`;
+    case 'gt':
+      return `${field} > ${addParam(ctx, clause.value)}`;
+    case 'gte':
+      return `${field} >= ${addParam(ctx, clause.value)}`;
+    case 'lt':
+      return `${field} < ${addParam(ctx, clause.value)}`;
+    case 'lte':
+      return `${field} <= ${addParam(ctx, clause.value)}`;
+    case 'like':
+      return `${field} LIKE ${addParam(ctx, clause.value)}`;
+    case 'is_null':
+      return `${field} IS NULL`;
+    case 'is_not_null':
+      return `${field} IS NOT NULL`;
+    case 'in': {
+      const values = clause.value as (string | number)[];
+      const placeholders = values.map((v) => addParam(ctx, v)).join(', ');
+      return `${field} IN (${placeholders})`;
+    }
+    case 'not_in': {
+      const values = clause.value as (string | number)[];
+      const placeholders = values.map((v) => addParam(ctx, v)).join(', ');
+      return `${field} NOT IN (${placeholders})`;
+    }
+    default:
+      throw new Error(`Unsupported filter operator: ${clause.operator}`);
+  }
+}
+
+/** Translates an aggregation to SQL. */
+function translateAggregation(agg: Aggregation): string {
+  const field = formatFieldRef(agg.field);
+  let expr: string;
+
+  switch (agg.function) {
+    case 'sum':
+      expr = `SUM(${field})`;
+      break;
+    case 'avg':
+      expr = `AVG(${field})`;
+      break;
+    case 'count':
+      expr = field === '"*"' ? 'COUNT(*)' : `COUNT(${field})`;
+      break;
+    case 'count_distinct':
+      expr = `COUNT(DISTINCT ${field})`;
+      break;
+    case 'min':
+      expr = `MIN(${field})`;
+      break;
+    case 'max':
+      expr = `MAX(${field})`;
+      break;
+    case 'percentile': {
+      const p = agg.params?.p ?? 0.5;
+      expr = `PERCENTILE_CONT(${p}) WITHIN GROUP (ORDER BY ${field})`;
+      break;
+    }
+    default:
+      throw new Error(`Unsupported aggregation: ${agg.function}`);
+  }
+
+  return agg.alias ? `${expr} AS "${agg.alias}"` : expr;
+}
+
+/** Translates a time range to a SQL WHERE clause fragment. */
+function translateTimeRange(range: TimeRange, ctx: TranslationContext): string {
+  const field = formatFieldRef(range.field);
+  const from = addParam(ctx, range.from);
+  const to = addParam(ctx, range.to);
+  return `${field} >= ${from} AND ${field} <= ${to}`;
+}
+
+/** Translates a join clause to SQL. */
+function translateJoin(join: JoinClause, ctx: TranslationContext): string {
+  const type = join.type.toUpperCase();
+  const alias = join.alias ? ` "${join.alias}"` : '';
+  const on = translateFilter(join.on, ctx);
+  return `${type} JOIN "${join.table}"${alias} ON ${on}`;
+}
+
+/** Translates an order clause to SQL. */
+function translateOrder(order: OrderClause): string {
+  return `${formatFieldRef(order.field)} ${order.direction.toUpperCase()}`;
+}
+
+/**
+ * Translates a QueryIR into parameterized PostgreSQL SQL.
+ * All user values are parameterized ($1, $2, etc.) to prevent SQL injection.
+ */
+export function translateIR(ir: QueryIR): TranslationResult {
+  const ctx: TranslationContext = { params: [], paramIndex: 0 };
+  const parts: string[] = [];
+
+  // SELECT
+  const selectParts: string[] = [];
+  if (ir.select.length > 0) {
+    selectParts.push(...ir.select.map(formatField));
+  }
+  if (ir.aggregations.length > 0) {
+    selectParts.push(...ir.aggregations.map(translateAggregation));
+  }
+  parts.push(`SELECT ${selectParts.length > 0 ? selectParts.join(', ') : '*'}`);
+
+  // FROM
+  const tableAlias = ir.tableAlias ? ` "${ir.tableAlias}"` : '';
+  parts.push(`FROM "${ir.table}"${tableAlias}`);
+
+  // JOINS
+  for (const join of ir.joins) {
+    parts.push(translateJoin(join, ctx));
+  }
+
+  // WHERE
+  const whereConditions: string[] = [];
+  if (ir.filter) {
+    whereConditions.push(translateFilter(ir.filter, ctx));
+  }
+  if (ir.timeRange) {
+    whereConditions.push(translateTimeRange(ir.timeRange, ctx));
+  }
+  if (whereConditions.length > 0) {
+    parts.push(`WHERE ${whereConditions.join(' AND ')}`);
+  }
+
+  // GROUP BY
+  if (ir.groupBy.length > 0) {
+    parts.push(`GROUP BY ${ir.groupBy.map(formatFieldRef).join(', ')}`);
+  }
+
+  // ORDER BY
+  if (ir.orderBy.length > 0) {
+    parts.push(`ORDER BY ${ir.orderBy.map(translateOrder).join(', ')}`);
+  }
+
+  // LIMIT
+  if (ir.limit !== undefined) {
+    parts.push(`LIMIT ${addParam(ctx, ir.limit)}`);
+  }
+
+  // OFFSET
+  if (ir.offset !== undefined) {
+    parts.push(`OFFSET ${addParam(ctx, ir.offset)}`);
+  }
+
+  return { sql: parts.join(' '), params: ctx.params };
+}

--- a/packages/connectors/postgres/tsconfig.json
+++ b/packages/connectors/postgres/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,53 @@ importers:
         specifier: ^3.1.0
         version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
 
+  packages/connector-sdk:
+    dependencies:
+      '@lightboard/query-ir':
+        specifier: workspace:*
+        version: link:../query-ir
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+
+  packages/connectors/postgres:
+    dependencies:
+      '@lightboard/connector-sdk':
+        specifier: workspace:*
+        version: link:../../connector-sdk
+      '@lightboard/query-ir':
+        specifier: workspace:*
+        version: link:../../query-ir
+      apache-arrow:
+        specifier: ^19.0.1
+        version: 19.0.1
+      pg:
+        specifier: ^8.16.0
+        version: 8.20.0
+      pg-cursor:
+        specifier: ^2.12.2
+        version: 2.19.0(pg@8.20.0)
+    devDependencies:
+      '@types/pg':
+        specifier: ^8.15.4
+        version: 8.18.0
+      '@types/pg-cursor':
+        specifier: ^2.7.2
+        version: 2.7.2
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+
   packages/db:
     dependencies:
       '@node-rs/argon2':
@@ -1511,6 +1558,12 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/command-line-args@5.2.3':
+    resolution: {integrity: sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==}
+
+  '@types/command-line-usage@5.0.4':
+    resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1523,8 +1576,14 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/node@20.19.37':
+    resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
+
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@types/pg-cursor@2.7.2':
+    resolution: {integrity: sha512-m3xT8bVFCvx98LuzbvXyuCdT/Hjdd/v8ml4jL4K1QF70Y8clOfCFdgoaEB1FWdcSwcpoFYZTJQaMD9/GQ27efQ==}
 
   '@types/pg@8.18.0':
     resolution: {integrity: sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==}
@@ -1753,6 +1812,10 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  apache-arrow@19.0.1:
+    resolution: {integrity: sha512-APmMLzS4qbTivLrPdQXexGM4JRr+0g62QDaobzEvip/FdQIrv2qLy0mD5Qdmw4buydtVJgbFeKR8f59I6PPGDg==}
+    hasBin: true
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1762,6 +1825,10 @@ packages:
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
+
+  array-back@6.2.2:
+    resolution: {integrity: sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==}
+    engines: {node: '>=12.17'}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -1866,6 +1933,10 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chalk-template@0.4.0:
+    resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
+    engines: {node: '>=12'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1891,6 +1962,19 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  command-line-args@6.0.1:
+    resolution: {integrity: sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==}
+    engines: {node: '>=12.20'}
+    peerDependencies:
+      '@75lb/nature': latest
+    peerDependenciesMeta:
+      '@75lb/nature':
+        optional: true
+
+  command-line-usage@7.0.4:
+    resolution: {integrity: sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==}
+    engines: {node: '>=12.20.0'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -2301,6 +2385,15 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-replace@5.0.2:
+    resolution: {integrity: sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@75lb/nature': latest
+    peerDependenciesMeta:
+      '@75lb/nature':
+        optional: true
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -2308,6 +2401,9 @@ packages:
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
+
+  flatbuffers@24.12.23:
+    resolution: {integrity: sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==}
 
   flatted@3.4.1:
     resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
@@ -2562,6 +2658,10 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  json-bignum@0.0.3:
+    resolution: {integrity: sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==}
+    engines: {node: '>=0.8'}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -2670,6 +2770,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
@@ -2864,6 +2967,11 @@ packages:
 
   pg-connection-string@2.12.0:
     resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-cursor@2.19.0:
+    resolution: {integrity: sha512-J5cF1MUz7LRJ9emOqF/06QjabMHMZy587rSPF0UuA8rCwKeeYl2co8Pp+6k5UU9YrAYHMzWkLxilfZB0hqsWWw==}
+    peerDependencies:
+      pg: ^8
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -3236,6 +3344,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  table-layout@4.1.1:
+    resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
+    engines: {node: '>=12.17'}
+
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
@@ -3347,6 +3459,10 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  typical@7.3.0:
+    resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
+    engines: {node: '>=12.17'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -3468,6 +3584,10 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wordwrapjs@5.1.1:
+    resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
+    engines: {node: '>=12.17'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -4374,6 +4494,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/command-line-args@5.2.3': {}
+
+  '@types/command-line-usage@5.0.4': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -4382,9 +4506,18 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/node@20.19.37':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg-cursor@2.7.2':
+    dependencies:
+      '@types/node': 22.19.15
+      '@types/pg': 8.18.0
 
   '@types/pg@8.18.0':
     dependencies:
@@ -4613,6 +4746,20 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  apache-arrow@19.0.1:
+    dependencies:
+      '@swc/helpers': 0.5.15
+      '@types/command-line-args': 5.2.3
+      '@types/command-line-usage': 5.0.4
+      '@types/node': 20.19.37
+      command-line-args: 6.0.1
+      command-line-usage: 7.0.4
+      flatbuffers: 24.12.23
+      json-bignum: 0.0.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
   argparse@2.0.1: {}
 
   aria-query@5.3.0:
@@ -4620,6 +4767,8 @@ snapshots:
       dequal: 2.0.3
 
   aria-query@5.3.2: {}
+
+  array-back@6.2.2: {}
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -4752,6 +4901,10 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chalk-template@0.4.0:
+    dependencies:
+      chalk: 4.1.2
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4770,6 +4923,20 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  command-line-args@6.0.1:
+    dependencies:
+      array-back: 6.2.2
+      find-replace: 5.0.2
+      lodash.camelcase: 4.3.0
+      typical: 7.3.0
+
+  command-line-usage@7.0.4:
+    dependencies:
+      array-back: 6.2.2
+      chalk-template: 0.4.0
+      table-layout: 4.1.1
+      typical: 7.3.0
 
   concat-map@0.0.1: {}
 
@@ -5298,6 +5465,8 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-replace@5.0.2: {}
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -5307,6 +5476,8 @@ snapshots:
     dependencies:
       flatted: 3.4.1
       keyv: 4.5.4
+
+  flatbuffers@24.12.23: {}
 
   flatted@3.4.1: {}
 
@@ -5581,6 +5752,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  json-bignum@0.0.3: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -5665,6 +5838,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.camelcase@4.3.0: {}
 
   lodash.defaults@4.2.0: {}
 
@@ -5858,6 +6033,10 @@ snapshots:
     optional: true
 
   pg-connection-string@2.12.0: {}
+
+  pg-cursor@2.19.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
 
   pg-int8@1.0.1: {}
 
@@ -6254,6 +6433,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  table-layout@4.1.1:
+    dependencies:
+      array-back: 6.2.2
+      wordwrapjs: 5.1.1
+
   tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.1: {}
@@ -6364,6 +6548,8 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typescript@5.9.3: {}
+
+  typical@7.3.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -6538,6 +6724,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wordwrapjs@5.1.1: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "packages/connectors/*"


### PR DESCRIPTION
## Summary
- **`packages/connector-sdk/`** — Adapter interface for all data sources
  - `Connector` interface: connect, introspect, query, stream, healthCheck, capabilities, disconnect
  - Types: ConnectorConfig, SchemaMetadata, ArrowResult, QueryOptions, HealthCheckResult, ConnectorCapabilities
  - ConnectorRegistry for factory-based lookup
  - Zod validation schemas
- **`packages/connectors/postgres/`** — PostgreSQL connector
  - IR-to-SQL translator with parameterized queries covering all operators, aggregations (incl. PERCENTILE_CONT), nested boolean combinators, JOINs, time ranges
  - Arrow IPC result conversion (pg type → Arrow type mapping)
  - Connection pooling (pg-pool), schema introspection (information_schema), streaming (pg-cursor)
  - Health check, full SQL pushdown capabilities
- Updated `pnpm-workspace.yaml` to include `packages/connectors/*`

Closes #4, closes #13, closes #14, closes #15, closes #16

## Test plan
- [x] `pnpm typecheck` — all 6 packages clean
- [x] `pnpm test` — 94 tests pass (37 postgres + 6 sdk + 40 query-ir + 8 db + 3 web)
- [x] CI passes

No UI changes — browser testing skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)