### PR TITLE
feat(d5): DuckDB compute engine for Tier 2 processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@duckdb/node-api",
       "@node-rs/argon2",
       "@parcel/watcher",
       "@swc/core",

--- a/packages/compute/package.json
+++ b/packages/compute/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@lightboard/compute",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@duckdb/node-api": "^1.5.0-r.1",
+    "apache-arrow": "^19.0.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.2",
+    "vitest": "^3.1.0"
+  }
+}

--- a/packages/compute/src/engine.test.ts
+++ b/packages/compute/src/engine.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { tableFromArrays, tableToIPC } from 'apache-arrow';
+import { ComputeEngine } from './engine';
+
+const engine = new ComputeEngine();
+
+describe('ComputeEngine', () => {
+  describe('query', () => {
+    it('executes a simple SQL query', async () => {
+      const result = await engine.query('SELECT 1 AS value, 2 AS other');
+      expect(result.rowCount).toBe(1);
+      expect(result.columnNames).toEqual(['value', 'other']);
+      expect(result.buffer.length).toBeGreaterThan(0);
+    });
+
+    it('executes range query', async () => {
+      const result = await engine.query('SELECT * FROM range(10) t(id)');
+      expect(result.rowCount).toBe(10);
+      expect(result.columnNames).toEqual(['id']);
+    });
+
+    it('executes aggregation query', async () => {
+      const result = await engine.query(
+        "SELECT COUNT(*) AS cnt, SUM(i) AS total FROM range(100) t(i)",
+      );
+      expect(result.rowCount).toBe(1);
+      expect(result.columnNames).toContain('cnt');
+      expect(result.columnNames).toContain('total');
+    });
+
+    it('returns empty result for no rows', async () => {
+      const result = await engine.query('SELECT 1 WHERE false');
+      expect(result.rowCount).toBe(0);
+    });
+  });
+
+  describe('crossSourceJoin', () => {
+    it('joins two Arrow tables', async () => {
+      const usersTable = tableFromArrays({
+        id: [1, 2, 3],
+        name: ['Alice', 'Bob', 'Charlie'],
+      });
+      const ordersTable = tableFromArrays({
+        user_id: [1, 1, 2],
+        amount: [100, 200, 50],
+      });
+
+      const result = await engine.crossSourceJoin(
+        [
+          { name: 'users', buffer: new Uint8Array(tableToIPC(usersTable)) },
+          { name: 'orders', buffer: new Uint8Array(tableToIPC(ordersTable)) },
+        ],
+        `SELECT u.name, SUM(o.amount) AS total
+         FROM users u
+         JOIN orders o ON u.id = o.user_id
+         GROUP BY u.name
+         ORDER BY total DESC`,
+      );
+
+      expect(result.rowCount).toBe(2);
+      expect(result.columnNames).toEqual(['name', 'total']);
+    });
+
+    it('handles empty Arrow table input', async () => {
+      const emptyTable = tableFromArrays({ id: new Int32Array(0) });
+      const result = await engine.crossSourceJoin(
+        [{ name: 'empty', buffer: new Uint8Array(tableToIPC(emptyTable)) }],
+        'SELECT COUNT(*) AS cnt FROM empty',
+      );
+      expect(result.rowCount).toBe(1);
+    });
+  });
+});

--- a/packages/compute/src/engine.ts
+++ b/packages/compute/src/engine.ts
@@ -1,0 +1,221 @@
+import { DuckDBInstance } from '@duckdb/node-api';
+import { tableFromArrays, tableFromIPC, tableToIPC } from 'apache-arrow';
+
+/** Result from a compute query. */
+export interface ComputeResult {
+  /** Arrow IPC buffer containing the result data. */
+  buffer: Uint8Array;
+  /** Number of rows in the result. */
+  rowCount: number;
+  /** Column names in the result. */
+  columnNames: string[];
+}
+
+/** Input for cross-source join: a named Arrow table. */
+export interface ArrowTableInput {
+  /** Table name to register in DuckDB. */
+  name: string;
+  /** Arrow IPC buffer containing the table data. */
+  buffer: Uint8Array;
+}
+
+/**
+ * DuckDB-based compute engine for Tier 2 computation.
+ * Creates ephemeral in-memory instances per request for tenant isolation.
+ * Input/output is always Apache Arrow IPC — no JSON data processing.
+ */
+export class ComputeEngine {
+  /**
+   * Executes a SQL query against an ephemeral DuckDB instance.
+   * The instance is created and destroyed within this call.
+   */
+  async query(sql: string): Promise<ComputeResult> {
+    const instance = await DuckDBInstance.create();
+    const connection = await instance.connect();
+
+    try {
+      const reader = await connection.runAndReadAll(sql);
+      return this.readerToResult(reader);
+    } finally {
+      connection.closeSync();
+    }
+  }
+
+  /**
+   * Registers Arrow IPC tables in DuckDB and executes a join query.
+   * Useful for cross-source joins where data comes from different connectors.
+   */
+  async crossSourceJoin(tables: ArrowTableInput[], sql: string): Promise<ComputeResult> {
+    const instance = await DuckDBInstance.create();
+    const connection = await instance.connect();
+
+    try {
+      for (const table of tables) {
+        await this.registerArrowTable(connection, table.name, table.buffer);
+      }
+
+      const reader = await connection.runAndReadAll(sql);
+      return this.readerToResult(reader);
+    } finally {
+      connection.closeSync();
+    }
+  }
+
+  /**
+   * Loads a CSV file into DuckDB and returns the result as Arrow IPC.
+   * Optionally executes a query against the loaded data.
+   */
+  async queryCSV(csvPath: string, sql?: string): Promise<ComputeResult> {
+    const instance = await DuckDBInstance.create();
+    const connection = await instance.connect();
+
+    try {
+      await connection.run(
+        `CREATE TABLE csv_data AS SELECT * FROM read_csv_auto('${escapePath(csvPath)}')`,
+      );
+
+      const querySQL = sql ?? 'SELECT * FROM csv_data';
+      const reader = await connection.runAndReadAll(querySQL);
+      return this.readerToResult(reader);
+    } finally {
+      connection.closeSync();
+    }
+  }
+
+  /**
+   * Loads a Parquet file into DuckDB and returns the result as Arrow IPC.
+   * Optionally executes a query against the loaded data.
+   */
+  async queryParquet(parquetPath: string, sql?: string): Promise<ComputeResult> {
+    const instance = await DuckDBInstance.create();
+    const connection = await instance.connect();
+
+    try {
+      await connection.run(
+        `CREATE TABLE parquet_data AS SELECT * FROM read_parquet('${escapePath(parquetPath)}')`,
+      );
+
+      const querySQL = sql ?? 'SELECT * FROM parquet_data';
+      const reader = await connection.runAndReadAll(querySQL);
+      return this.readerToResult(reader);
+    } finally {
+      connection.closeSync();
+    }
+  }
+
+  /**
+   * Introspects a CSV file and returns its schema (column names and types).
+   */
+  async introspectCSV(csvPath: string): Promise<{ name: string; type: string }[]> {
+    const instance = await DuckDBInstance.create();
+    const connection = await instance.connect();
+
+    try {
+      const reader = await connection.runAndReadAll(
+        `DESCRIBE SELECT * FROM read_csv_auto('${escapePath(csvPath)}')`,
+      );
+      const rows = reader.getRowObjects() as Record<string, unknown>[];
+      return rows.map((row) => ({
+        name: String(row['column_name'] ?? ''),
+        type: String(row['column_type'] ?? ''),
+      }));
+    } finally {
+      connection.closeSync();
+    }
+  }
+
+  /**
+   * Registers an Arrow IPC buffer as a named table in a DuckDB connection.
+   * Converts Arrow data to SQL INSERT statements for DuckDB ingestion.
+   */
+  private async registerArrowTable(
+    connection: Awaited<ReturnType<DuckDBInstance['connect']>>,
+    name: string,
+    buffer: Uint8Array,
+  ): Promise<void> {
+    const arrowTable = tableFromIPC(buffer);
+    const fields = arrowTable.schema.fields;
+    const numRows = arrowTable.numRows;
+
+    if (numRows === 0 || fields.length === 0) {
+      const colDefs = fields.length > 0
+        ? fields.map((f) => `"${f.name}" VARCHAR`).join(', ')
+        : '"_empty" VARCHAR';
+      await connection.run(`CREATE TABLE "${name}" (${colDefs})`);
+      return;
+    }
+
+    // Build CREATE TABLE + INSERT using VALUES
+    const rows = arrowTable.toArray();
+    const columns = fields.map((f) => f.name);
+
+    // Infer SQL types from first row
+    const firstRow = rows[0] as Record<string, unknown>;
+    const colDefs = columns.map((col) => {
+      const val = firstRow[col];
+      let type = 'VARCHAR';
+      if (typeof val === 'number') type = 'DOUBLE';
+      else if (typeof val === 'bigint') type = 'BIGINT';
+      else if (typeof val === 'boolean') type = 'BOOLEAN';
+      return `"${col}" ${type}`;
+    }).join(', ');
+
+    await connection.run(`CREATE TABLE "${name}" (${colDefs})`);
+
+    // Insert in batches using VALUES clause
+    const BATCH_SIZE = 500;
+    for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+      const batch = rows.slice(i, i + BATCH_SIZE);
+      const valueRows = batch.map((row) => {
+        const obj = row as Record<string, unknown>;
+        const vals = columns.map((col) => {
+          const v = obj[col];
+          if (v === null || v === undefined) return 'NULL';
+          if (typeof v === 'number' || typeof v === 'bigint') return String(v);
+          if (typeof v === 'boolean') return v ? 'TRUE' : 'FALSE';
+          return `'${String(v).replace(/'/g, "''")}'`;
+        });
+        return `(${vals.join(', ')})`;
+      });
+
+      await connection.run(
+        `INSERT INTO "${name}" VALUES ${valueRows.join(', ')}`,
+      );
+    }
+  }
+
+  /** Converts a DuckDB reader result to a ComputeResult with Arrow IPC. */
+  private readerToResult(reader: { getRowObjects: () => unknown[]; columnNames: () => string[] }): ComputeResult {
+    const rows = reader.getRowObjects() as Record<string, unknown>[];
+    const columnNames = reader.columnNames();
+
+    if (rows.length === 0) {
+      return { buffer: new Uint8Array(), rowCount: 0, columnNames };
+    }
+
+    // Build column arrays for Arrow table
+    const columnData: Record<string, unknown[]> = {};
+    for (const col of columnNames) {
+      columnData[col] = rows.map((row) => {
+        const val = row[col];
+        if (val instanceof Date) return val.getTime();
+        if (typeof val === 'bigint') return Number(val);
+        return val ?? null;
+      });
+    }
+
+    const table = tableFromArrays(columnData);
+    const ipcBuffer = tableToIPC(table);
+
+    return {
+      buffer: new Uint8Array(ipcBuffer),
+      rowCount: rows.length,
+      columnNames,
+    };
+  }
+}
+
+/** Escapes a file path for use in DuckDB SQL (prevents injection). */
+function escapePath(path: string): string {
+  return path.replace(/'/g, "''");
+}

--- a/packages/compute/src/index.ts
+++ b/packages/compute/src/index.ts
@@ -1,0 +1,1 @@
+export { ComputeEngine, type ArrowTableInput, type ComputeResult } from './engine';

--- a/packages/compute/tsconfig.json
+++ b/packages/compute/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,22 @@ importers:
         specifier: ^3.1.0
         version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
 
+  packages/compute:
+    dependencies:
+      '@duckdb/node-api':
+        specifier: ^1.5.0-r.1
+        version: 1.5.0-r.1
+      apache-arrow:
+        specifier: ^19.0.1
+        version: 19.0.1
+    devDependencies:
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+
   packages/connector-sdk:
     dependencies:
       '@lightboard/query-ir':
@@ -233,6 +249,42 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@duckdb/node-api@1.5.0-r.1':
+    resolution: {integrity: sha512-VjvjqlCyqUJ22bydG/+9Jj5l0CEvx9QUn1SATBkKFY0+x6n4uHzt0kp/FKwXK9LNduXX6KCKtdF+6v5BcHScfA==}
+
+  '@duckdb/node-bindings-darwin-arm64@1.5.0-r.1':
+    resolution: {integrity: sha512-s7CB9Y10f3dg2W4jdp6zipogxamq1pPQVt/r+YigZrHqk7HvytUeRH1VOI/3wuGTTlR8mAnIXj2MJIrmMujX4w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@duckdb/node-bindings-darwin-x64@1.5.0-r.1':
+    resolution: {integrity: sha512-2KxnGvg9o/Y915hwr1Mpb6Cbfrvt/w+/Fv0RZ2VXeQuxqNCMOoJd/7yQ8ffWXJRuOFU/vRmsR88koIjW+yJibA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@duckdb/node-bindings-linux-arm64@1.5.0-r.1':
+    resolution: {integrity: sha512-FpmcfJqhKoInjEa1o5dsWPQAFWYgu1eZgJP94nz6d+cKfdXEZKT6vGIwokZRzDqKLG1ZAOBZO2IhxzmW8IbbfA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@duckdb/node-bindings-linux-x64@1.5.0-r.1':
+    resolution: {integrity: sha512-A4Zgsaq6szEKiMyF1eWkoaHw0OMA0a8Zl8Ev0GcZSRjI4iGHgBQ1f/Zi/w3QKyz7OtjIiZ+pQ1XYyG4QoF6OKA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@duckdb/node-bindings-win32-arm64@1.5.0-r.1':
+    resolution: {integrity: sha512-ctCJ2HWpyiN3FNiCQ40RWALZLwKtJ8Aq4Anen2ush1I0a2E52T//jitLzl7DcX0quzew5eci1MQ+H5T1nVhzFA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@duckdb/node-bindings-win32-x64@1.5.0-r.1':
+    resolution: {integrity: sha512-725LoefejBlyG/bUcMfqVJkZ8KnZRLa0xOkszw9Q+V5G26iagJY3dgtGJAvwTeVJvXigSEVc5yD9Cj6kWR67vA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@duckdb/node-bindings@1.5.0-r.1':
+    resolution: {integrity: sha512-ViyoHROp0HhQ0ATT8z6h7SV6vEOxNjN8mJcdkst+3rJIU3Rd/gKs8exJO23LxFsjBuAiDpndpEwFihTAdfwJZg==}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -3615,6 +3667,37 @@ snapshots:
   '@babel/runtime@7.28.6': {}
 
   '@drizzle-team/brocli@0.10.2': {}
+
+  '@duckdb/node-api@1.5.0-r.1':
+    dependencies:
+      '@duckdb/node-bindings': 1.5.0-r.1
+
+  '@duckdb/node-bindings-darwin-arm64@1.5.0-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-darwin-x64@1.5.0-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-linux-arm64@1.5.0-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-linux-x64@1.5.0-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-win32-arm64@1.5.0-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-win32-x64@1.5.0-r.1':
+    optional: true
+
+  '@duckdb/node-bindings@1.5.0-r.1':
+    optionalDependencies:
+      '@duckdb/node-bindings-darwin-arm64': 1.5.0-r.1
+      '@duckdb/node-bindings-darwin-x64': 1.5.0-r.1
+      '@duckdb/node-bindings-linux-arm64': 1.5.0-r.1
+      '@duckdb/node-bindings-linux-x64': 1.5.0-r.1
+      '@duckdb/node-bindings-win32-arm64': 1.5.0-r.1
+      '@duckdb/node-bindings-win32-x64': 1.5.0-r.1
 
   '@emnapi/core@1.9.0':
     dependencies:


### PR DESCRIPTION
## Summary
- **`packages/compute/`** — Ephemeral DuckDB instances for cross-source computation
- **ComputeEngine** class with:
  - `query(sql)` — execute SQL against in-memory DuckDB
  - `crossSourceJoin(tables, sql)` — register Arrow IPC tables from different connectors and run join queries
  - `queryCSV(path, sql?)` — load and query CSV files via `read_csv_auto`
  - `queryParquet(path, sql?)` — load and query Parquet files
  - `introspectCSV(path)` — return column names and types
- All I/O is Apache Arrow IPC — no JSON data processing
- Ephemeral per-request instances for tenant isolation
- Uses `@duckdb/node-api` (v1.5.0) — the recommended Node.js client

Closes #5

## Test plan
- [x] `pnpm typecheck` — all 7 packages clean
- [x] `pnpm test` — 100 tests pass (6 compute + 37 postgres + 6 sdk + 40 query-ir + 8 db + 3 web)
- [x] CI passes

No UI changes — browser testing skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)