### PR TITLE
feat(d6): viz-core — chart theme, panels, and 4 chart types

### DIFF
--- a/packages/viz-core/package.json
+++ b/packages/viz-core/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@lightboard/viz-core",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@visx/axis": "^3.12.0",
+    "@visx/grid": "^3.12.0",
+    "@visx/group": "^3.3.0",
+    "@visx/responsive": "^3.12.0",
+    "@visx/scale": "^3.5.0",
+    "@visx/shape": "^3.5.0",
+    "@visx/tooltip": "^3.3.0",
+    "@tanstack/react-table": "^8.21.0",
+    "d3-array": "^3.2.4",
+    "d3-time-format": "^4.1.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.0",
+    "@types/d3-array": "^3.2.1",
+    "@types/d3-time-format": "^4.0.3",
+    "@types/react": "^19.1.2",
+    "jsdom": "^26.1.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "typescript": "^5.8.2",
+    "vitest": "^3.1.0"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/packages/viz-core/src/auto-viz/auto-viz.test.ts
+++ b/packages/viz-core/src/auto-viz/auto-viz.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { selectVisualization, type ColumnInfo } from './index';
+
+describe('selectVisualization', () => {
+  it('returns data-table for no columns', () => {
+    const result = selectVisualization([]);
+    expect(result.pluginId).toBe('data-table');
+  });
+
+  it('returns stat-card for single numeric column', () => {
+    const cols: ColumnInfo[] = [{ name: 'count', type: 'numeric' }];
+    const result = selectVisualization(cols);
+    expect(result.pluginId).toBe('stat-card');
+    expect(result.confidence).toBeGreaterThan(0.8);
+  });
+
+  it('returns time-series-line for time + numeric', () => {
+    const cols: ColumnInfo[] = [
+      { name: 'timestamp', type: 'time' },
+      { name: 'value', type: 'numeric' },
+    ];
+    const result = selectVisualization(cols);
+    expect(result.pluginId).toBe('time-series-line');
+  });
+
+  it('returns time-series-line for time + multiple numerics', () => {
+    const cols: ColumnInfo[] = [
+      { name: 'ts', type: 'time' },
+      { name: 'cpu', type: 'numeric' },
+      { name: 'memory', type: 'numeric' },
+    ];
+    const result = selectVisualization(cols);
+    expect(result.pluginId).toBe('time-series-line');
+  });
+
+  it('returns bar-chart for categorical + numeric', () => {
+    const cols: ColumnInfo[] = [
+      { name: 'country', type: 'categorical' },
+      { name: 'population', type: 'numeric' },
+    ];
+    const result = selectVisualization(cols);
+    expect(result.pluginId).toBe('bar-chart');
+  });
+
+  it('returns bar-chart for categorical + multiple numerics', () => {
+    const cols: ColumnInfo[] = [
+      { name: 'product', type: 'categorical' },
+      { name: 'sales', type: 'numeric' },
+      { name: 'profit', type: 'numeric' },
+    ];
+    const result = selectVisualization(cols);
+    expect(result.pluginId).toBe('bar-chart');
+  });
+
+  it('prefers time-series-line over bar-chart when time + categorical + numeric', () => {
+    const cols: ColumnInfo[] = [
+      { name: 'ts', type: 'time' },
+      { name: 'category', type: 'categorical' },
+      { name: 'value', type: 'numeric' },
+    ];
+    const result = selectVisualization(cols);
+    expect(result.pluginId).toBe('time-series-line');
+  });
+
+  it('returns data-table for multiple numerics without pattern', () => {
+    const cols: ColumnInfo[] = [
+      { name: 'a', type: 'numeric' },
+      { name: 'b', type: 'numeric' },
+      { name: 'c', type: 'numeric' },
+    ];
+    const result = selectVisualization(cols);
+    expect(result.pluginId).toBe('data-table');
+  });
+
+  it('returns data-table for all categorical columns', () => {
+    const cols: ColumnInfo[] = [
+      { name: 'name', type: 'categorical' },
+      { name: 'city', type: 'categorical' },
+    ];
+    const result = selectVisualization(cols);
+    expect(result.pluginId).toBe('data-table');
+  });
+
+  it('returns data-table for unknown types', () => {
+    const cols: ColumnInfo[] = [
+      { name: 'x', type: 'unknown' },
+      { name: 'y', type: 'unknown' },
+    ];
+    const result = selectVisualization(cols);
+    expect(result.pluginId).toBe('data-table');
+  });
+
+  it('returns data-table for single categorical column', () => {
+    const cols: ColumnInfo[] = [{ name: 'name', type: 'categorical' }];
+    const result = selectVisualization(cols);
+    expect(result.pluginId).toBe('data-table');
+  });
+
+  it('returns data-table for boolean only', () => {
+    const cols: ColumnInfo[] = [{ name: 'active', type: 'boolean' }];
+    const result = selectVisualization(cols);
+    expect(result.pluginId).toBe('data-table');
+  });
+
+  it('always returns a confidence score', () => {
+    const cases: ColumnInfo[][] = [
+      [],
+      [{ name: 'x', type: 'numeric' }],
+      [{ name: 'ts', type: 'time' }, { name: 'v', type: 'numeric' }],
+    ];
+    for (const cols of cases) {
+      const result = selectVisualization(cols);
+      expect(result.confidence).toBeGreaterThan(0);
+      expect(result.confidence).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('always returns a reason', () => {
+    const result = selectVisualization([{ name: 'x', type: 'numeric' }]);
+    expect(result.reason.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/viz-core/src/auto-viz/index.ts
+++ b/packages/viz-core/src/auto-viz/index.ts
@@ -1,0 +1,71 @@
+import type { ColumnType } from '../panel/types';
+
+/** Column metadata used for auto-viz selection. */
+export interface ColumnInfo {
+  name: string;
+  type: ColumnType;
+}
+
+/** Result of auto-viz selection. */
+export interface VizRecommendation {
+  pluginId: string;
+  confidence: number;
+  reason: string;
+}
+
+const TIME_TYPES = new Set<ColumnType>(['time']);
+const NUMERIC_TYPES = new Set<ColumnType>(['numeric']);
+const CATEGORICAL_TYPES = new Set<ColumnType>(['categorical']);
+
+/**
+ * Selects the best visualization type based on column metadata.
+ * Uses heuristic rules, not ML. The agent can override by specifying chart type explicitly.
+ */
+export function selectVisualization(columns: ColumnInfo[]): VizRecommendation {
+  if (columns.length === 0) {
+    return { pluginId: 'data-table', confidence: 0.5, reason: 'No columns provided' };
+  }
+
+  const timeColumns = columns.filter((c) => TIME_TYPES.has(c.type));
+  const numericColumns = columns.filter((c) => NUMERIC_TYPES.has(c.type));
+  const categoricalColumns = columns.filter((c) => CATEGORICAL_TYPES.has(c.type));
+
+  // 1 numeric only → StatCard
+  if (columns.length === 1 && numericColumns.length === 1) {
+    return { pluginId: 'stat-card', confidence: 0.9, reason: 'Single numeric value' };
+  }
+
+  // 1 time + 1+ numeric → TimeSeriesLine
+  if (timeColumns.length >= 1 && numericColumns.length >= 1) {
+    return {
+      pluginId: 'time-series-line',
+      confidence: 0.85,
+      reason: `Time column (${timeColumns[0]!.name}) with ${numericColumns.length} numeric series`,
+    };
+  }
+
+  // 1 categorical + 1+ numeric → BarChart
+  if (categoricalColumns.length >= 1 && numericColumns.length >= 1) {
+    return {
+      pluginId: 'bar-chart',
+      confidence: 0.8,
+      reason: `Categorical column (${categoricalColumns[0]!.name}) with ${numericColumns.length} numeric values`,
+    };
+  }
+
+  // Only numeric columns (2+) → could be stat or table
+  if (numericColumns.length >= 2 && columns.length === numericColumns.length) {
+    return {
+      pluginId: 'data-table',
+      confidence: 0.6,
+      reason: 'Multiple numeric columns without clear axis pattern',
+    };
+  }
+
+  // Fallback → DataTable
+  return {
+    pluginId: 'data-table',
+    confidence: 0.5,
+    reason: 'No clear visualization pattern detected',
+  };
+}

--- a/packages/viz-core/src/charts/BarChart/index.tsx
+++ b/packages/viz-core/src/charts/BarChart/index.tsx
@@ -1,0 +1,231 @@
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import { GridRows } from '@visx/grid';
+import { Group } from '@visx/group';
+import { scaleBand, scaleLinear, scaleOrdinal } from '@visx/scale';
+import { Bar, BarGroup, BarStack } from '@visx/shape';
+import { useTooltip, TooltipWithBounds, defaultStyles } from '@visx/tooltip';
+import { max } from 'd3-array';
+import { useMemo } from 'react';
+import type { PanelPlugin, PanelProps } from '../../panel/types';
+
+/** Configuration for BarChart. */
+export interface BarChartConfig {
+  xField: string;
+  yFields: string[];
+  orientation?: 'vertical' | 'horizontal';
+  mode?: 'grouped' | 'stacked';
+  showGrid?: boolean;
+  barRadius?: number;
+}
+
+/** BarChart component. */
+export function BarChart({
+  data,
+  config,
+  width,
+  height,
+  theme,
+  onInteraction,
+}: PanelProps<Record<string, unknown>[], BarChartConfig>) {
+  const {
+    xField,
+    yFields,
+    mode = 'grouped',
+    showGrid = true,
+    barRadius = 2,
+  } = config;
+  const margin = theme.spacing.padding;
+  const innerWidth = Math.max(0, width - margin.left - margin.right);
+  const innerHeight = Math.max(0, height - margin.top - margin.bottom);
+
+  const categories = useMemo(
+    () => data.map((d) => String(d[xField])),
+    [data, xField],
+  );
+
+  const xScale = useMemo(
+    () => scaleBand({ domain: categories, range: [0, innerWidth], padding: 0.2 }),
+    [categories, innerWidth],
+  );
+
+  const allValues = useMemo(() => {
+    if (mode === 'stacked') {
+      return data.map((d) => yFields.reduce((sum, f) => sum + (Number(d[f]) || 0), 0));
+    }
+    return data.flatMap((d) => yFields.map((f) => Number(d[f]) || 0));
+  }, [data, yFields, mode]);
+
+  const yScale = useMemo(
+    () => scaleLinear({ domain: [0, max(allValues) ?? 0], range: [innerHeight, 0], nice: true }),
+    [allValues, innerHeight],
+  );
+
+  const colorScale = useMemo(
+    () =>
+      scaleOrdinal({
+        domain: yFields,
+        range: theme.colors.series.slice(0, yFields.length),
+      }),
+    [yFields, theme.colors.series],
+  );
+
+  const { tooltipOpen, tooltipData, tooltipLeft, tooltipTop, showTooltip, hideTooltip } =
+    useTooltip<{ category: string; field: string; value: number }>();
+
+  if (width < 10 || height < 10) return null;
+
+  return (
+    <>
+      <svg width={width} height={height}>
+        <Group left={margin.left} top={margin.top}>
+          {showGrid && (
+            <GridRows scale={yScale} width={innerWidth} stroke={theme.colors.grid} strokeOpacity={0.5} />
+          )}
+
+          {mode === 'grouped' ? (
+            // Grouped bars
+            data.map((d, i) => {
+              const category = String(d[xField]);
+              const x0 = xScale(category) ?? 0;
+              const barGroupWidth = xScale.bandwidth();
+              const barWidth = barGroupWidth / yFields.length;
+
+              return yFields.map((field, j) => {
+                const value = Number(d[field]) || 0;
+                const barHeight = innerHeight - (yScale(value) ?? 0);
+                const color = theme.colors.series[j % theme.colors.series.length];
+
+                return (
+                  <Bar
+                    key={`${i}-${j}`}
+                    x={x0 + j * barWidth}
+                    y={yScale(value) ?? 0}
+                    width={barWidth - 1}
+                    height={barHeight}
+                    fill={color}
+                    rx={barRadius}
+                    onMouseEnter={() =>
+                      showTooltip({
+                        tooltipData: { category, field, value },
+                        tooltipLeft: x0 + j * barWidth + barWidth / 2,
+                        tooltipTop: yScale(value) ?? 0,
+                      })
+                    }
+                    onMouseLeave={hideTooltip}
+                    onClick={() =>
+                      onInteraction?.({ type: 'click', payload: { category, field, value, row: d } })
+                    }
+                  />
+                );
+              });
+            })
+          ) : (
+            // Stacked bars
+            data.map((d, i) => {
+              const category = String(d[xField]);
+              const x = xScale(category) ?? 0;
+              let cumY = innerHeight;
+
+              return yFields.map((field, j) => {
+                const value = Number(d[field]) || 0;
+                const barHeight = innerHeight - (yScale(value) ?? innerHeight);
+                cumY -= barHeight;
+                const color = theme.colors.series[j % theme.colors.series.length];
+
+                return (
+                  <Bar
+                    key={`${i}-${j}`}
+                    x={x}
+                    y={cumY}
+                    width={xScale.bandwidth()}
+                    height={barHeight}
+                    fill={color}
+                    rx={j === yFields.length - 1 ? barRadius : 0}
+                    onMouseEnter={() =>
+                      showTooltip({
+                        tooltipData: { category, field, value },
+                        tooltipLeft: x + xScale.bandwidth() / 2,
+                        tooltipTop: cumY,
+                      })
+                    }
+                    onMouseLeave={hideTooltip}
+                    onClick={() =>
+                      onInteraction?.({ type: 'click', payload: { category, field, value, row: d } })
+                    }
+                  />
+                );
+              });
+            })
+          )}
+
+          <AxisBottom
+            top={innerHeight}
+            scale={xScale}
+            stroke={theme.colors.axis}
+            tickStroke={theme.colors.axis}
+            tickLabelProps={() => ({
+              fill: theme.colors.text,
+              fontSize: theme.typography.fontSize.axis,
+              textAnchor: 'middle' as const,
+            })}
+          />
+
+          <AxisLeft
+            scale={yScale}
+            stroke={theme.colors.axis}
+            tickStroke={theme.colors.axis}
+            tickLabelProps={() => ({
+              fill: theme.colors.text,
+              fontSize: theme.typography.fontSize.axis,
+              textAnchor: 'end' as const,
+              dx: '-0.25em',
+              dy: '0.33em',
+            })}
+          />
+        </Group>
+      </svg>
+
+      {tooltipOpen && tooltipData && (
+        <TooltipWithBounds
+          left={(tooltipLeft ?? 0) + margin.left}
+          top={(tooltipTop ?? 0) + margin.top}
+          style={{
+            ...defaultStyles,
+            backgroundColor: theme.colors.tooltipBackground,
+            color: theme.colors.tooltipText,
+            fontSize: theme.typography.fontSize.tooltip,
+          }}
+        >
+          <div><strong>{tooltipData.category}</strong></div>
+          <div style={{ color: colorScale(tooltipData.field) }}>
+            {tooltipData.field}: {tooltipData.value}
+          </div>
+        </TooltipWithBounds>
+      )}
+    </>
+  );
+}
+
+/** BarChart panel plugin registration. */
+export const barChartPlugin: PanelPlugin<Record<string, unknown>[], BarChartConfig> = {
+  id: 'bar-chart',
+  name: 'Bar Chart',
+  configSchema: {
+    type: 'object',
+    properties: {
+      xField: { type: 'string' },
+      yFields: { type: 'array', items: { type: 'string' } },
+      orientation: { type: 'string', enum: ['vertical', 'horizontal'] },
+      mode: { type: 'string', enum: ['grouped', 'stacked'] },
+      showGrid: { type: 'boolean' },
+      barRadius: { type: 'number' },
+    },
+    required: ['xField', 'yFields'],
+  },
+  dataShape: {
+    minColumns: 2,
+    requiredTypes: ['categorical', 'numeric'],
+    description: 'Categorical x-axis with one or more numeric y-values',
+  },
+  Component: BarChart as any,
+};

--- a/packages/viz-core/src/charts/DataTable/index.tsx
+++ b/packages/viz-core/src/charts/DataTable/index.tsx
@@ -1,0 +1,192 @@
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+  type SortingState,
+} from '@tanstack/react-table';
+import { useMemo, useState } from 'react';
+import type { PanelPlugin, PanelProps } from '../../panel/types';
+
+/** Configuration for DataTable. */
+export interface DataTableConfig {
+  columns?: { field: string; header?: string; width?: number }[];
+  pageSize?: number;
+  sortable?: boolean;
+}
+
+/** DataTable component — sortable, paginated tabular data. */
+export function DataTable({
+  data,
+  config,
+  width,
+  height,
+  theme,
+  onInteraction,
+}: PanelProps<Record<string, unknown>[], DataTableConfig>) {
+  const { columns: configColumns, pageSize = 20, sortable = true } = config;
+  const [sorting, setSorting] = useState<SortingState>([]);
+
+  const columnHelper = createColumnHelper<Record<string, unknown>>();
+
+  const columns = useMemo(() => {
+    if (configColumns && configColumns.length > 0) {
+      return configColumns.map((col) =>
+        columnHelper.accessor((row) => row[col.field], {
+          id: col.field,
+          header: col.header ?? col.field,
+          size: col.width,
+          cell: (info) => formatCellValue(info.getValue()),
+        }),
+      );
+    }
+    // Auto-detect columns from first row
+    const firstRow = data[0];
+    if (!firstRow) return [];
+    return Object.keys(firstRow).map((key) =>
+      columnHelper.accessor((row) => row[key], {
+        id: key,
+        header: key,
+        cell: (info) => formatCellValue(info.getValue()),
+      }),
+    );
+  }, [configColumns, data, columnHelper]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting },
+    onSortingChange: sortable ? setSorting : undefined,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: sortable ? getSortedRowModel() : undefined,
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize } },
+  });
+
+  const headerGroups = table.getHeaderGroups();
+  const rows = table.getRowModel().rows;
+
+  return (
+    <div
+      style={{
+        width,
+        height,
+        overflow: 'auto',
+        fontFamily: theme.typography.fontFamily,
+        fontSize: theme.typography.fontSize.label,
+        color: theme.colors.text,
+      }}
+    >
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          {headerGroups.map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th
+                  key={header.id}
+                  onClick={sortable ? header.column.getToggleSortingHandler() : undefined}
+                  style={{
+                    padding: '8px 12px',
+                    textAlign: 'left',
+                    borderBottom: `1px solid ${theme.colors.grid}`,
+                    cursor: sortable ? 'pointer' : 'default',
+                    userSelect: 'none',
+                    whiteSpace: 'nowrap',
+                    fontWeight: 600,
+                  }}
+                >
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                  {header.column.getIsSorted() === 'asc' && ' ↑'}
+                  {header.column.getIsSorted() === 'desc' && ' ↓'}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.id}
+              onClick={() =>
+                onInteraction?.({ type: 'click', payload: { row: row.original, index: row.index } })
+              }
+              style={{ cursor: onInteraction ? 'pointer' : 'default' }}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <td
+                  key={cell.id}
+                  style={{
+                    padding: '6px 12px',
+                    borderBottom: `1px solid ${theme.colors.grid}`,
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {table.getPageCount() > 1 && (
+        <div style={{ display: 'flex', justifyContent: 'center', gap: 8, padding: 8 }}>
+          <button
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+            style={{ opacity: table.getCanPreviousPage() ? 1 : 0.5 }}
+          >
+            ←
+          </button>
+          <span>
+            {table.getState().pagination.pageIndex + 1} / {table.getPageCount()}
+          </span>
+          <button
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+            style={{ opacity: table.getCanNextPage() ? 1 : 0.5 }}
+          >
+            →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Formats a cell value for display. */
+function formatCellValue(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (value instanceof Date) return value.toLocaleString();
+  if (typeof value === 'number') return new Intl.NumberFormat().format(value);
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+/** DataTable panel plugin registration. */
+export const dataTablePlugin: PanelPlugin<Record<string, unknown>[], DataTableConfig> = {
+  id: 'data-table',
+  name: 'Data Table',
+  configSchema: {
+    type: 'object',
+    properties: {
+      columns: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: { field: { type: 'string' }, header: { type: 'string' }, width: { type: 'number' } },
+        },
+      },
+      pageSize: { type: 'number' },
+      sortable: { type: 'boolean' },
+    },
+  },
+  dataShape: {
+    minColumns: 1,
+    description: 'Any tabular data — the fallback visualization',
+  },
+  Component: DataTable as any,
+};

--- a/packages/viz-core/src/charts/StatCard/index.tsx
+++ b/packages/viz-core/src/charts/StatCard/index.tsx
@@ -1,0 +1,129 @@
+import { LinePath } from '@visx/shape';
+import { scaleLinear } from '@visx/scale';
+import { useMemo } from 'react';
+import type { PanelPlugin, PanelProps } from '../../panel/types';
+
+/** Configuration for StatCard. */
+export interface StatCardConfig {
+  valueField: string;
+  label?: string;
+  sparklineField?: string;
+  format?: Intl.NumberFormatOptions;
+  thresholds?: { value: number; color: string }[];
+}
+
+/** StatCard component — big number display with optional sparkline. */
+export function StatCard({
+  data,
+  config,
+  width,
+  height,
+  theme,
+}: PanelProps<Record<string, unknown>[], StatCardConfig>) {
+  const { valueField, label, sparklineField, format, thresholds } = config;
+
+  const value = useMemo(() => {
+    const lastRow = data[data.length - 1];
+    return lastRow ? Number(lastRow[valueField]) || 0 : 0;
+  }, [data, valueField]);
+
+  const formattedValue = useMemo(() => {
+    const opts = format ?? { maximumFractionDigits: 2 };
+    return new Intl.NumberFormat(undefined, opts).format(value);
+  }, [value, format]);
+
+  const valueColor = useMemo(() => {
+    if (!thresholds || thresholds.length === 0) return theme.colors.text;
+    const sorted = [...thresholds].sort((a, b) => b.value - a.value);
+    for (const t of sorted) {
+      if (value >= t.value) return t.color;
+    }
+    return theme.colors.text;
+  }, [value, thresholds, theme.colors.text]);
+
+  const sparklineData = useMemo(() => {
+    if (!sparklineField) return null;
+    return data.map((d, i) => ({ x: i, y: Number(d[sparklineField]) || 0 }));
+  }, [data, sparklineField]);
+
+  const sparkHeight = Math.max(0, height * 0.3);
+  const sparkWidth = Math.max(0, width - 32);
+
+  const sparkScaleX = useMemo(
+    () => scaleLinear({ domain: [0, (sparklineData?.length ?? 1) - 1], range: [0, sparkWidth] }),
+    [sparklineData, sparkWidth],
+  );
+
+  const sparkScaleY = useMemo(() => {
+    if (!sparklineData) return scaleLinear({ domain: [0, 1], range: [sparkHeight, 0] });
+    const vals = sparklineData.map((d) => d.y);
+    return scaleLinear({
+      domain: [Math.min(...vals), Math.max(...vals)],
+      range: [sparkHeight, 0],
+    });
+  }, [sparklineData, sparkHeight]);
+
+  return (
+    <div
+      style={{
+        width,
+        height,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily: theme.typography.fontFamily,
+        color: theme.colors.text,
+      }}
+    >
+      {label && (
+        <div style={{ fontSize: theme.typography.fontSize.label, opacity: 0.7, marginBottom: 4 }}>
+          {label}
+        </div>
+      )}
+      <div style={{ fontSize: Math.min(height * 0.3, 48), fontWeight: 700, color: valueColor }}>
+        {formattedValue}
+      </div>
+      {sparklineData && sparklineData.length > 1 && (
+        <svg width={sparkWidth} height={sparkHeight} style={{ marginTop: 8 }}>
+          <LinePath
+            data={sparklineData}
+            x={(d) => sparkScaleX(d.x) ?? 0}
+            y={(d) => sparkScaleY(d.y) ?? 0}
+            stroke={theme.colors.series[0]}
+            strokeWidth={1.5}
+          />
+        </svg>
+      )}
+    </div>
+  );
+}
+
+/** StatCard panel plugin registration. */
+export const statCardPlugin: PanelPlugin<Record<string, unknown>[], StatCardConfig> = {
+  id: 'stat-card',
+  name: 'Stat Card',
+  configSchema: {
+    type: 'object',
+    properties: {
+      valueField: { type: 'string' },
+      label: { type: 'string' },
+      sparklineField: { type: 'string' },
+      format: { type: 'object' },
+      thresholds: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: { value: { type: 'number' }, color: { type: 'string' } },
+        },
+      },
+    },
+    required: ['valueField'],
+  },
+  dataShape: {
+    minColumns: 1,
+    requiredTypes: ['numeric'],
+    description: 'Single numeric value, optionally with sparkline series',
+  },
+  Component: StatCard as any,
+};

--- a/packages/viz-core/src/charts/TimeSeriesLine/index.tsx
+++ b/packages/viz-core/src/charts/TimeSeriesLine/index.tsx
@@ -1,0 +1,232 @@
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import { GridRows } from '@visx/grid';
+import { Group } from '@visx/group';
+import { scaleLinear, scaleTime } from '@visx/scale';
+import { LinePath, AreaClosed } from '@visx/shape';
+import { useTooltip, TooltipWithBounds, defaultStyles } from '@visx/tooltip';
+import { extent, max, bisector } from 'd3-array';
+import { timeFormat } from 'd3-time-format';
+import { useCallback, useMemo } from 'react';
+import type { PanelPlugin, PanelProps } from '../../panel/types';
+import type { ChartTheme } from '../../theme/types';
+
+/** Data point for time series. */
+export interface TimeSeriesPoint {
+  time: Date | number | string;
+  [series: string]: unknown;
+}
+
+/** Configuration for TimeSeriesLine chart. */
+export interface TimeSeriesLineConfig {
+  xField: string;
+  yFields: string[];
+  showArea?: boolean;
+  showGrid?: boolean;
+  showPoints?: boolean;
+  dateFormat?: string;
+}
+
+/** TimeSeriesLine chart component. */
+export function TimeSeriesLine({
+  data,
+  config,
+  width,
+  height,
+  theme,
+  onInteraction,
+}: PanelProps<TimeSeriesPoint[], TimeSeriesLineConfig>) {
+  const { xField, yFields, showArea = false, showGrid = true, dateFormat = '%b %d' } = config;
+  const margin = theme.spacing.padding;
+  const innerWidth = Math.max(0, width - margin.left - margin.right);
+  const innerHeight = Math.max(0, height - margin.top - margin.bottom);
+
+  type ParsedRow = Record<string, unknown> & { _time: Date };
+  const parsedData = useMemo(
+    (): ParsedRow[] => data.map((d) => {
+      const row = d as Record<string, unknown>;
+      return Object.assign({} as ParsedRow, row, { _time: new Date(row[xField] as string | number | Date) });
+    }),
+    [data, xField],
+  );
+
+  const xScale = useMemo(
+    () =>
+      scaleTime({
+        domain: extent(parsedData, (d) => d._time) as [Date, Date],
+        range: [0, innerWidth],
+      }),
+    [parsedData, innerWidth],
+  );
+
+  const allValues = useMemo(
+    () => parsedData.flatMap((d) => yFields.map((f) => Number(d[f]) || 0)),
+    [parsedData, yFields],
+  );
+
+  const yScale = useMemo(
+    () =>
+      scaleLinear({
+        domain: [0, max(allValues) ?? 0],
+        range: [innerHeight, 0],
+        nice: true,
+      }),
+    [allValues, innerHeight],
+  );
+
+  const { tooltipOpen, tooltipData, tooltipLeft, tooltipTop, showTooltip, hideTooltip } =
+    useTooltip<TimeSeriesPoint>();
+
+  const bisectDate = bisector<(typeof parsedData)[0], Date>((d) => d._time).left;
+
+  const handleMouseMove = useCallback(
+    (event: React.MouseEvent<SVGRectElement>) => {
+      const svg = event.currentTarget.closest('svg');
+      if (!svg) return;
+      const point = svg.createSVGPoint();
+      point.x = event.clientX;
+      point.y = event.clientY;
+      const svgPoint = point.matrixTransform(svg.getScreenCTM()?.inverse());
+      const x0 = xScale.invert(svgPoint.x - margin.left);
+      const idx = bisectDate(parsedData, x0, 1);
+      const d = parsedData[idx - 1];
+      if (!d) return;
+      showTooltip({
+        tooltipData: d as unknown as TimeSeriesPoint,
+        tooltipLeft: xScale(d._time),
+        tooltipTop: margin.top,
+      });
+    },
+    [xScale, parsedData, bisectDate, margin, showTooltip],
+  );
+
+  if (width < 10 || height < 10) return null;
+
+  const formatDate = timeFormat(dateFormat);
+
+  return (
+    <>
+      <svg width={width} height={height}>
+        <Group left={margin.left} top={margin.top}>
+          {showGrid && (
+            <GridRows
+              scale={yScale}
+              width={innerWidth}
+              stroke={theme.colors.grid}
+              strokeOpacity={0.5}
+            />
+          )}
+
+          {yFields.map((field, i) => {
+            const color = theme.colors.series[i % theme.colors.series.length];
+            return (
+              <g key={field}>
+                {showArea && (
+                  <AreaClosed
+                    data={parsedData}
+                    x={(d) => xScale(d._time) ?? 0}
+                    y={(d) => yScale(Number(d[field]) || 0) ?? 0}
+                    yScale={yScale}
+                    fill={color}
+                    fillOpacity={0.1}
+                  />
+                )}
+                <LinePath
+                  data={parsedData}
+                  x={(d) => xScale(d._time) ?? 0}
+                  y={(d) => yScale(Number(d[field]) || 0) ?? 0}
+                  stroke={color}
+                  strokeWidth={2}
+                />
+              </g>
+            );
+          })}
+
+          <AxisBottom
+            top={innerHeight}
+            scale={xScale}
+            stroke={theme.colors.axis}
+            tickStroke={theme.colors.axis}
+            tickLabelProps={() => ({
+              fill: theme.colors.text,
+              fontSize: theme.typography.fontSize.axis,
+              textAnchor: 'middle' as const,
+            })}
+            tickFormat={(v) => formatDate(v as Date)}
+          />
+
+          <AxisLeft
+            scale={yScale}
+            stroke={theme.colors.axis}
+            tickStroke={theme.colors.axis}
+            tickLabelProps={() => ({
+              fill: theme.colors.text,
+              fontSize: theme.typography.fontSize.axis,
+              textAnchor: 'end' as const,
+              dx: '-0.25em',
+              dy: '0.33em',
+            })}
+          />
+
+          <rect
+            width={innerWidth}
+            height={innerHeight}
+            fill="transparent"
+            onMouseMove={handleMouseMove}
+            onMouseLeave={hideTooltip}
+            onClick={() => {
+              if (tooltipData && onInteraction) {
+                onInteraction({ type: 'click', payload: tooltipData });
+              }
+            }}
+          />
+        </Group>
+      </svg>
+
+      {tooltipOpen && tooltipData && (
+        <TooltipWithBounds
+          left={(tooltipLeft ?? 0) + margin.left}
+          top={tooltipTop ?? 0}
+          style={{
+            ...defaultStyles,
+            backgroundColor: theme.colors.tooltipBackground,
+            color: theme.colors.tooltipText,
+            fontSize: theme.typography.fontSize.tooltip,
+          }}
+        >
+          <div>
+            <strong>{formatDate(new Date(tooltipData[xField] as string))}</strong>
+          </div>
+          {yFields.map((field, i) => (
+            <div key={field} style={{ color: theme.colors.series[i % theme.colors.series.length] }}>
+              {field}: {String(tooltipData[field])}
+            </div>
+          ))}
+        </TooltipWithBounds>
+      )}
+    </>
+  );
+}
+
+/** TimeSeriesLine panel plugin registration. */
+export const timeSeriesLinePlugin: PanelPlugin<TimeSeriesPoint[], TimeSeriesLineConfig> = {
+  id: 'time-series-line',
+  name: 'Time Series Line',
+  configSchema: {
+    type: 'object',
+    properties: {
+      xField: { type: 'string' },
+      yFields: { type: 'array', items: { type: 'string' } },
+      showArea: { type: 'boolean' },
+      showGrid: { type: 'boolean' },
+      showPoints: { type: 'boolean' },
+      dateFormat: { type: 'string' },
+    },
+    required: ['xField', 'yFields'],
+  },
+  dataShape: {
+    minColumns: 2,
+    requiredTypes: ['time', 'numeric'],
+    description: 'Time-based x-axis with one or more numeric y-series',
+  },
+  Component: TimeSeriesLine as any,
+};

--- a/packages/viz-core/src/index.ts
+++ b/packages/viz-core/src/index.ts
@@ -1,0 +1,17 @@
+// Theme
+export { ChartThemeProvider, useChartTheme } from './theme';
+export { darkTheme, lightTheme } from './theme';
+export type { ChartColors, ChartSpacing, ChartTheme, ChartTypography } from './theme';
+
+// Panel protocol
+export { defaultPanelRegistry, PanelRegistry } from './panel';
+export type { ColumnType, DataShapeDeclaration, PanelInteractionEvent, PanelPlugin, PanelProps } from './panel';
+
+// Charts
+export { TimeSeriesLine, timeSeriesLinePlugin, type TimeSeriesLineConfig, type TimeSeriesPoint } from './charts/TimeSeriesLine';
+export { BarChart, barChartPlugin, type BarChartConfig } from './charts/BarChart';
+export { StatCard, statCardPlugin, type StatCardConfig } from './charts/StatCard';
+export { DataTable, dataTablePlugin, type DataTableConfig } from './charts/DataTable';
+
+// Auto-viz
+export { selectVisualization, type ColumnInfo, type VizRecommendation } from './auto-viz';

--- a/packages/viz-core/src/panel/index.ts
+++ b/packages/viz-core/src/panel/index.ts
@@ -1,0 +1,8 @@
+export { defaultPanelRegistry, PanelRegistry } from './registry';
+export type {
+  ColumnType,
+  DataShapeDeclaration,
+  PanelInteractionEvent,
+  PanelPlugin,
+  PanelProps,
+} from './types';

--- a/packages/viz-core/src/panel/registry.test.ts
+++ b/packages/viz-core/src/panel/registry.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { PanelRegistry } from './registry';
+import type { PanelPlugin } from './types';
+
+const mockPlugin: PanelPlugin = {
+  id: 'mock-chart',
+  name: 'Mock Chart',
+  configSchema: {},
+  dataShape: { minColumns: 1, description: 'Mock' },
+  Component: () => null,
+};
+
+describe('PanelRegistry', () => {
+  it('registers and retrieves a plugin', () => {
+    const registry = new PanelRegistry();
+    registry.register(mockPlugin);
+    expect(registry.get('mock-chart')).toBe(mockPlugin);
+  });
+
+  it('throws on duplicate registration', () => {
+    const registry = new PanelRegistry();
+    registry.register(mockPlugin);
+    expect(() => registry.register(mockPlugin)).toThrow('already registered');
+  });
+
+  it('returns undefined for unknown id', () => {
+    const registry = new PanelRegistry();
+    expect(registry.get('unknown')).toBeUndefined();
+  });
+
+  it('checks if plugin exists', () => {
+    const registry = new PanelRegistry();
+    expect(registry.has('mock-chart')).toBe(false);
+    registry.register(mockPlugin);
+    expect(registry.has('mock-chart')).toBe(true);
+  });
+
+  it('lists all registered ids', () => {
+    const registry = new PanelRegistry();
+    registry.register(mockPlugin);
+    registry.register({ ...mockPlugin, id: 'other', name: 'Other' });
+    expect(registry.ids()).toEqual(['mock-chart', 'other']);
+  });
+
+  it('lists all plugins', () => {
+    const registry = new PanelRegistry();
+    registry.register(mockPlugin);
+    expect(registry.all()).toHaveLength(1);
+  });
+
+  it('unregisters a plugin', () => {
+    const registry = new PanelRegistry();
+    registry.register(mockPlugin);
+    expect(registry.unregister('mock-chart')).toBe(true);
+    expect(registry.has('mock-chart')).toBe(false);
+  });
+});

--- a/packages/viz-core/src/panel/registry.ts
+++ b/packages/viz-core/src/panel/registry.ts
@@ -1,0 +1,45 @@
+import type { PanelPlugin } from './types';
+
+/**
+ * Registry for panel plugins. Charts register themselves at startup,
+ * and the host looks up panels by ID to render them.
+ */
+export class PanelRegistry {
+  private plugins = new Map<string, PanelPlugin>();
+
+  /** Register a panel plugin. */
+  register(plugin: PanelPlugin): void {
+    if (this.plugins.has(plugin.id)) {
+      throw new Error(`Panel plugin "${plugin.id}" is already registered`);
+    }
+    this.plugins.set(plugin.id, plugin);
+  }
+
+  /** Look up a panel plugin by ID. */
+  get(id: string): PanelPlugin | undefined {
+    return this.plugins.get(id);
+  }
+
+  /** Check if a panel plugin is registered. */
+  has(id: string): boolean {
+    return this.plugins.has(id);
+  }
+
+  /** List all registered panel plugin IDs. */
+  ids(): string[] {
+    return [...this.plugins.keys()];
+  }
+
+  /** List all registered panel plugins. */
+  all(): PanelPlugin[] {
+    return [...this.plugins.values()];
+  }
+
+  /** Remove a panel plugin. */
+  unregister(id: string): boolean {
+    return this.plugins.delete(id);
+  }
+}
+
+/** Default global panel registry. */
+export const defaultPanelRegistry = new PanelRegistry();

--- a/packages/viz-core/src/panel/types.ts
+++ b/packages/viz-core/src/panel/types.ts
@@ -1,0 +1,53 @@
+import type { ComponentType } from 'react';
+import type { ChartTheme } from '../theme/types';
+
+/** Column type classification for data shape declarations. */
+export type ColumnType = 'time' | 'numeric' | 'categorical' | 'boolean' | 'unknown';
+
+/** Declares what data shape a panel expects. */
+export interface DataShapeDeclaration {
+  /** Minimum required columns. */
+  minColumns: number;
+  /** Maximum supported columns (undefined = unlimited). */
+  maxColumns?: number;
+  /** Required column types. */
+  requiredTypes?: ColumnType[];
+  /** Description of expected data shape. */
+  description: string;
+}
+
+/** Event emitted when a user interacts with a panel (click, brush, etc.). */
+export interface PanelInteractionEvent {
+  type: 'click' | 'brush' | 'hover';
+  payload: Record<string, unknown>;
+}
+
+/** Props passed to every panel component by the host. */
+export interface PanelProps<TData = Record<string, unknown>[], TConfig = Record<string, unknown>> {
+  /** The data to visualize. */
+  data: TData;
+  /** Panel-specific configuration. */
+  config: TConfig;
+  /** Available width in pixels. */
+  width: number;
+  /** Available height in pixels. */
+  height: number;
+  /** Current chart theme. */
+  theme: ChartTheme;
+  /** Callback for interaction events. */
+  onInteraction?: (event: PanelInteractionEvent) => void;
+}
+
+/** The adapter interface for visualization components. */
+export interface PanelPlugin<TData = Record<string, unknown>[], TConfig = Record<string, unknown>> {
+  /** Unique identifier for this panel type. */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** JSON Schema for the panel's configuration. */
+  configSchema: Record<string, unknown>;
+  /** Declaration of what data shape this panel expects. */
+  dataShape: DataShapeDeclaration;
+  /** The React component that renders the panel. */
+  Component: ComponentType<PanelProps<TData, TConfig>>;
+}

--- a/packages/viz-core/src/theme/context.tsx
+++ b/packages/viz-core/src/theme/context.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { darkTheme, lightTheme } from './defaults';
+import type { ChartTheme } from './types';
+
+const ChartThemeContext = createContext<ChartTheme>(lightTheme);
+
+/** Props for ChartThemeProvider. */
+interface ChartThemeProviderProps {
+  theme?: ChartTheme;
+  mode?: 'light' | 'dark';
+  children: ReactNode;
+}
+
+/** Provides chart theme to all descendant chart components. */
+export function ChartThemeProvider({ theme, mode, children }: ChartThemeProviderProps) {
+  const resolvedTheme = useMemo(() => {
+    if (theme) return theme;
+    return mode === 'dark' ? darkTheme : lightTheme;
+  }, [theme, mode]);
+
+  return (
+    <ChartThemeContext.Provider value={resolvedTheme}>
+      {children}
+    </ChartThemeContext.Provider>
+  );
+}
+
+/** Hook to access the current chart theme. */
+export function useChartTheme(): ChartTheme {
+  return useContext(ChartThemeContext);
+}

--- a/packages/viz-core/src/theme/defaults.ts
+++ b/packages/viz-core/src/theme/defaults.ts
@@ -1,0 +1,44 @@
+import type { ChartTheme } from './types';
+
+/** Default light chart theme. */
+export const lightTheme: ChartTheme = {
+  colors: {
+    series: [
+      '#e76f51', '#2a9d8f', '#264653', '#e9c46a', '#f4a261',
+      '#606c38', '#283618', '#bc6c25', '#4361ee', '#7209b7',
+    ],
+    axis: '#6b7280',
+    grid: '#e5e7eb',
+    text: '#1f2937',
+    background: '#ffffff',
+    tooltipBackground: '#1f2937',
+    tooltipText: '#f9fafb',
+  },
+  typography: {
+    fontFamily: 'system-ui, -apple-system, sans-serif',
+    fontSize: { axis: 11, label: 12, title: 14, tooltip: 12 },
+  },
+  spacing: {
+    padding: { top: 20, right: 20, bottom: 40, left: 50 },
+    tickLength: 5,
+    legendGap: 16,
+  },
+};
+
+/** Default dark chart theme. */
+export const darkTheme: ChartTheme = {
+  colors: {
+    series: [
+      '#f4a261', '#2a9d8f', '#e9c46a', '#e76f51', '#4cc9f0',
+      '#80b918', '#f72585', '#7209b7', '#3a86ff', '#06d6a0',
+    ],
+    axis: '#9ca3af',
+    grid: '#374151',
+    text: '#f3f4f6',
+    background: '#111827',
+    tooltipBackground: '#f9fafb',
+    tooltipText: '#1f2937',
+  },
+  typography: lightTheme.typography,
+  spacing: lightTheme.spacing,
+};

--- a/packages/viz-core/src/theme/index.ts
+++ b/packages/viz-core/src/theme/index.ts
@@ -1,0 +1,3 @@
+export { ChartThemeProvider, useChartTheme } from './context';
+export { darkTheme, lightTheme } from './defaults';
+export type { ChartColors, ChartSpacing, ChartTheme, ChartTypography } from './types';

--- a/packages/viz-core/src/theme/theme.test.tsx
+++ b/packages/viz-core/src/theme/theme.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { ChartThemeProvider, useChartTheme } from './context';
+import { darkTheme, lightTheme } from './defaults';
+
+describe('ChartTheme', () => {
+  it('provides light theme by default', () => {
+    const { result } = renderHook(() => useChartTheme());
+    expect(result.current.colors.background).toBe(lightTheme.colors.background);
+  });
+
+  it('provides dark theme when mode is dark', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ChartThemeProvider mode="dark">{children}</ChartThemeProvider>
+    );
+    const { result } = renderHook(() => useChartTheme(), { wrapper });
+    expect(result.current.colors.background).toBe(darkTheme.colors.background);
+  });
+
+  it('allows custom theme override', () => {
+    const custom = { ...lightTheme, colors: { ...lightTheme.colors, background: '#ff0000' } };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ChartThemeProvider theme={custom}>{children}</ChartThemeProvider>
+    );
+    const { result } = renderHook(() => useChartTheme(), { wrapper });
+    expect(result.current.colors.background).toBe('#ff0000');
+  });
+
+  it('light theme has 10 series colors', () => {
+    expect(lightTheme.colors.series).toHaveLength(10);
+  });
+
+  it('dark theme has 10 series colors', () => {
+    expect(darkTheme.colors.series).toHaveLength(10);
+  });
+
+  it('themes have all required spacing properties', () => {
+    for (const theme of [lightTheme, darkTheme]) {
+      expect(theme.spacing.padding).toHaveProperty('top');
+      expect(theme.spacing.padding).toHaveProperty('right');
+      expect(theme.spacing.padding).toHaveProperty('bottom');
+      expect(theme.spacing.padding).toHaveProperty('left');
+      expect(theme.spacing.tickLength).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/viz-core/src/theme/types.ts
+++ b/packages/viz-core/src/theme/types.ts
@@ -1,0 +1,42 @@
+/** Color palette for chart rendering. */
+export interface ChartColors {
+  /** Series colors for multi-line/bar charts. */
+  series: string[];
+  /** Axis line and tick color. */
+  axis: string;
+  /** Grid line color. */
+  grid: string;
+  /** Text/label color. */
+  text: string;
+  /** Chart background color. */
+  background: string;
+  /** Tooltip background. */
+  tooltipBackground: string;
+  /** Tooltip text color. */
+  tooltipText: string;
+}
+
+/** Typography settings for chart labels and text. */
+export interface ChartTypography {
+  fontFamily: string;
+  fontSize: {
+    axis: number;
+    label: number;
+    title: number;
+    tooltip: number;
+  };
+}
+
+/** Spacing settings for chart elements. */
+export interface ChartSpacing {
+  padding: { top: number; right: number; bottom: number; left: number };
+  tickLength: number;
+  legendGap: number;
+}
+
+/** Complete chart theme definition. */
+export interface ChartTheme {
+  colors: ChartColors;
+  typography: ChartTypography;
+  spacing: ChartSpacing;
+}

--- a/packages/viz-core/tsconfig.json
+++ b/packages/viz-core/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/viz-core/vitest.config.ts
+++ b/packages/viz-core/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)
 
   packages/compute:
     dependencies:
@@ -111,7 +111,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)
 
   packages/connector-sdk:
     dependencies:
@@ -127,7 +127,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)
 
   packages/connectors/postgres:
     dependencies:
@@ -158,7 +158,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)
 
   packages/db:
     dependencies:
@@ -195,7 +195,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)
 
   packages/query-ir:
     dependencies:
@@ -208,7 +208,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)
 
   packages/ui:
     dependencies:
@@ -229,11 +229,75 @@ importers:
         specifier: ^5.8.2
         version: 5.9.3
 
+  packages/viz-core:
+    dependencies:
+      '@tanstack/react-table':
+        specifier: ^8.21.0
+        version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@visx/axis':
+        specifier: ^3.12.0
+        version: 3.12.0(react@19.2.4)
+      '@visx/grid':
+        specifier: ^3.12.0
+        version: 3.12.0(react@19.2.4)
+      '@visx/group':
+        specifier: ^3.3.0
+        version: 3.12.0(react@19.2.4)
+      '@visx/responsive':
+        specifier: ^3.12.0
+        version: 3.12.0(react@19.2.4)
+      '@visx/scale':
+        specifier: ^3.5.0
+        version: 3.12.0
+      '@visx/shape':
+        specifier: ^3.5.0
+        version: 3.12.0(react@19.2.4)
+      '@visx/tooltip':
+        specifier: ^3.3.0
+        version: 3.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      d3-array:
+        specifier: ^3.2.4
+        version: 3.2.4
+      d3-time-format:
+        specifier: ^4.1.0
+        version: 4.1.0
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@types/d3-array':
+        specifier: ^3.2.1
+        version: 3.2.2
+      '@types/d3-time-format':
+        specifier: ^4.0.3
+        version: 4.0.3
+      '@types/react':
+        specifier: ^19.1.2
+        version: 19.2.14
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
+      react:
+        specifier: ^19.1.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)
+
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -246,6 +310,34 @@ packages:
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -1582,6 +1674,17 @@ packages:
   '@tailwindcss/postcss@4.2.1':
     resolution: {integrity: sha512-OEwGIBnXnj7zJeonOh6ZG9woofIjGrd2BORfvE5p9USYKDCZoQmfqLcfNiRWoJlRWLdNPn2IgVZuWAOM4iTYMw==}
 
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -1616,17 +1719,62 @@ packages:
   '@types/command-line-usage@5.0.4':
     resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==}
 
+  '@types/d3-array@3.0.3':
+    resolution: {integrity: sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.0':
+    resolution: {integrity: sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==}
+
+  '@types/d3-delaunay@6.0.1':
+    resolution: {integrity: sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==}
+
+  '@types/d3-format@3.0.1':
+    resolution: {integrity: sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-interpolate@3.0.1':
+    resolution: {integrity: sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==}
+
+  '@types/d3-path@1.0.11':
+    resolution: {integrity: sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==}
+
+  '@types/d3-scale@4.0.2':
+    resolution: {integrity: sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==}
+
+  '@types/d3-shape@1.3.12':
+    resolution: {integrity: sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==}
+
+  '@types/d3-time-format@2.1.0':
+    resolution: {integrity: sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.0':
+    resolution: {integrity: sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/lodash@4.17.24':
+    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
@@ -1810,6 +1958,60 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@visx/axis@3.12.0':
+    resolution: {integrity: sha512-8MoWpfuaJkhm2Yg+HwyytK8nk+zDugCqTT/tRmQX7gW4LYrHYLXFUXOzbDyyBakCVaUbUaAhVFxpMASJiQKf7A==}
+    peerDependencies:
+      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+
+  '@visx/bounds@3.12.0':
+    resolution: {integrity: sha512-peAlNCUbYaaZ0IO6c1lDdEAnZv2iGPDiLIM8a6gu7CaMhtXZJkqrTh+AjidNcIqITktrICpGxJE/Qo9D099dvQ==}
+    peerDependencies:
+      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react-dom: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+
+  '@visx/curve@3.12.0':
+    resolution: {integrity: sha512-Ng1mefXIzoIoAivw7dJ+ZZYYUbfuwXgZCgQynShr6ZIVw7P4q4HeQfJP3W24ON+1uCSrzoycHSXRelhR9SBPcw==}
+
+  '@visx/grid@3.12.0':
+    resolution: {integrity: sha512-L4ex2ooSYhwNIxJ3XFIKRhoSvEGjPc2Y3YCrtNB4TV5Ofdj4q0UMOsxfrH23Pr8HSHuQhb6VGMgYoK0LuWqDmQ==}
+    peerDependencies:
+      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+
+  '@visx/group@3.12.0':
+    resolution: {integrity: sha512-Dye8iS1alVXPv7nj/7M37gJe6sSKqJLH7x6sEWAsRQ9clI0kFvjbKcKgF+U3aAVQr0NCohheFV+DtR8trfK/Ag==}
+    peerDependencies:
+      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+
+  '@visx/point@3.12.0':
+    resolution: {integrity: sha512-I6UrHoJAEVbx3RORQNupgTiX5EzjuZpiwLPxn8L2mI5nfERotPKi1Yus12Cq2WtXqEBR/WgqTnoImlqOXBykcA==}
+
+  '@visx/responsive@3.12.0':
+    resolution: {integrity: sha512-GV1BTYwAGlk/K5c9vH8lS2syPnTuIqEacI7L6LRPbsuaLscXMNi+i9fZyzo0BWvAdtRV8v6Urzglo++lvAXT1Q==}
+    peerDependencies:
+      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+
+  '@visx/scale@3.12.0':
+    resolution: {integrity: sha512-+ubijrZ2AwWCsNey0HGLJ0YKNeC/XImEFsr9rM+Uef1CM3PNM43NDdNTrdBejSlzRq0lcfQPWYMYQFSlkLcPOg==}
+
+  '@visx/shape@3.12.0':
+    resolution: {integrity: sha512-/1l0lrpX9tPic6SJEalryBKWjP/ilDRnQA+BGJTI1tj7i23mJ/J0t4nJHyA1GrL4QA/bM/qTJ35eyz5dEhJc4g==}
+    peerDependencies:
+      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+
+  '@visx/text@3.12.0':
+    resolution: {integrity: sha512-0rbDYQlbuKPhBqXkkGYKFec1gQo05YxV45DORzr6hCyaizdJk1G+n9VkuKSHKBy1vVQhBA0W3u/WXd7tiODQPA==}
+    peerDependencies:
+      react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
+
+  '@visx/tooltip@3.12.0':
+    resolution: {integrity: sha512-pWhsYhgl0Shbeqf80qy4QCB6zpq6tQtMQQxKlh3UiKxzkkfl+Metaf9p0/S0HexNi4vewOPOo89xWx93hBeh3A==}
+    peerDependencies:
+      react: ^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react-dom: ^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0
+
+  '@visx/vendor@3.12.0':
+    resolution: {integrity: sha512-SVO+G0xtnL9dsNpGDcjCgoiCnlB3iLSM9KLz1sLbSrV7RaVXwY3/BTm2X9OWN1jH2a9M+eHt6DJ6sE6CXm4cUg==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -1848,6 +2050,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -1937,6 +2143,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  balanced-match@0.4.2:
+    resolution: {integrity: sha512-STw03mQKnGUYtoNjmowo4F2cRmIIxYEGiMsjjwla/u5P1lxadj/05WkNaFjNiKTgJkj8KiXbgAiRTmcQRwQNtg==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1997,6 +2206,9 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -2035,11 +2247,65 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.1:
+    resolution: {integrity: sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==}
+    engines: {node: '>=12'}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.2:
+    resolution: {integrity: sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.0:
+    resolution: {integrity: sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -2087,6 +2353,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delaunator@5.0.1:
+    resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
 
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
@@ -2217,6 +2486,10 @@ packages:
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
@@ -2553,6 +2826,22 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   icu-minify@4.8.3:
     resolution: {integrity: sha512-65Av7FLosNk7bPbmQx5z5XG2Y3T2GFppcjiXh4z1idHeVgQxlDpAmkGoYI0eFzAvrOnjpWTL5FmPDhsdfRMPEA==}
 
@@ -2575,6 +2864,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   intl-messageformat@11.1.2:
     resolution: {integrity: sha512-ucSrQmZGAxfiBHfBRXW/k7UC8MaGFlEj4Ry1tKiDcmgwQm1y3EDl40u+4VNHYomxJQMJi9NEI3riDRlth96jKg==}
@@ -2650,6 +2943,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -2709,6 +3005,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-bignum@0.0.3:
     resolution: {integrity: sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==}
@@ -2835,12 +3140,18 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lucide-react@0.500.0:
     resolution: {integrity: sha512-IyGvnYOSBKiF7rFI3p0tDw4ZI+TKnn1b5LPF2/q3NBmA7zYaDagevs1eMNyPRpKdFXxgma6rEu6+2ylJaaGnJA==}
@@ -2853,6 +3164,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-expression-evaluator@1.4.0:
+    resolution: {integrity: sha512-4vRUvPyxdO8cWULGTh9dZWL2tZK6LDBvj+OGHBER7poH9Qdt7kXEoj20wiz4lQUbUXQZFjPbe5mVDo9nutizCw==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2944,6 +3258,9 @@ packages:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2995,6 +3312,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3194,6 +3514,15 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -3205,6 +3534,12 @@ packages:
   redis-parser@3.0.0:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
+
+  reduce-css-calc@1.3.0:
+    resolution: {integrity: sha512-0dVfwYVOlf/LBA2ec4OwQ6p3X9mYxn/wOl2xTcLwjnPYrkgEfPx3VI4eGCH3rQLlPISG5v9I9bkZosKsNRTRKA==}
+
+  reduce-function-call@1.0.3:
+    resolution: {integrity: sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -3235,10 +3570,16 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  robust-predicates@3.0.2:
+    resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3254,6 +3595,13 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3396,6 +3744,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   table-layout@4.1.1:
     resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
     engines: {node: '>=12.17'}
@@ -3432,9 +3783,24 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -3607,6 +3973,27 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -3641,6 +4028,25 @@ packages:
     resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
     engines: {node: '>=12.17'}
 
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -3656,6 +4062,14 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -3665,6 +4079,26 @@ snapshots:
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/runtime@7.28.6': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -4544,6 +4978,14 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.1
 
+  '@tanstack/react-table@8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@tanstack/table-core@8.21.3': {}
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -4581,13 +5023,51 @@ snapshots:
 
   '@types/command-line-usage@5.0.4': {}
 
+  '@types/d3-array@3.0.3': {}
+
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.0': {}
+
+  '@types/d3-delaunay@6.0.1': {}
+
+  '@types/d3-format@3.0.1': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-interpolate@3.0.1':
+    dependencies:
+      '@types/d3-color': 3.1.0
+
+  '@types/d3-path@1.0.11': {}
+
+  '@types/d3-scale@4.0.2':
+    dependencies:
+      '@types/d3-time': 3.0.0
+
+  '@types/d3-shape@1.3.12':
+    dependencies:
+      '@types/d3-path': 1.0.11
+
+  '@types/d3-time-format@2.1.0': {}
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.0': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/lodash@4.17.24': {}
 
   '@types/node@20.19.37':
     dependencies:
@@ -4766,6 +5246,122 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@visx/axis@3.12.0(react@19.2.4)':
+    dependencies:
+      '@types/react': 19.2.14
+      '@visx/group': 3.12.0(react@19.2.4)
+      '@visx/point': 3.12.0
+      '@visx/scale': 3.12.0
+      '@visx/shape': 3.12.0(react@19.2.4)
+      '@visx/text': 3.12.0(react@19.2.4)
+      classnames: 2.5.1
+      prop-types: 15.8.1
+      react: 19.2.4
+
+  '@visx/bounds@3.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@visx/curve@3.12.0':
+    dependencies:
+      '@types/d3-shape': 1.3.12
+      d3-shape: 1.3.7
+
+  '@visx/grid@3.12.0(react@19.2.4)':
+    dependencies:
+      '@types/react': 19.2.14
+      '@visx/curve': 3.12.0
+      '@visx/group': 3.12.0(react@19.2.4)
+      '@visx/point': 3.12.0
+      '@visx/scale': 3.12.0
+      '@visx/shape': 3.12.0(react@19.2.4)
+      classnames: 2.5.1
+      prop-types: 15.8.1
+      react: 19.2.4
+
+  '@visx/group@3.12.0(react@19.2.4)':
+    dependencies:
+      '@types/react': 19.2.14
+      classnames: 2.5.1
+      prop-types: 15.8.1
+      react: 19.2.4
+
+  '@visx/point@3.12.0': {}
+
+  '@visx/responsive@3.12.0(react@19.2.4)':
+    dependencies:
+      '@types/lodash': 4.17.24
+      '@types/react': 19.2.14
+      lodash: 4.17.23
+      prop-types: 15.8.1
+      react: 19.2.4
+
+  '@visx/scale@3.12.0':
+    dependencies:
+      '@visx/vendor': 3.12.0
+
+  '@visx/shape@3.12.0(react@19.2.4)':
+    dependencies:
+      '@types/d3-path': 1.0.11
+      '@types/d3-shape': 1.3.12
+      '@types/lodash': 4.17.24
+      '@types/react': 19.2.14
+      '@visx/curve': 3.12.0
+      '@visx/group': 3.12.0(react@19.2.4)
+      '@visx/scale': 3.12.0
+      classnames: 2.5.1
+      d3-path: 1.0.9
+      d3-shape: 1.3.7
+      lodash: 4.17.23
+      prop-types: 15.8.1
+      react: 19.2.4
+
+  '@visx/text@3.12.0(react@19.2.4)':
+    dependencies:
+      '@types/lodash': 4.17.24
+      '@types/react': 19.2.14
+      classnames: 2.5.1
+      lodash: 4.17.23
+      prop-types: 15.8.1
+      react: 19.2.4
+      reduce-css-calc: 1.3.0
+
+  '@visx/tooltip@3.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@types/react': 19.2.14
+      '@visx/bounds': 3.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      classnames: 2.5.1
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-use-measure: 2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
+  '@visx/vendor@3.12.0':
+    dependencies:
+      '@types/d3-array': 3.0.3
+      '@types/d3-color': 3.1.0
+      '@types/d3-delaunay': 6.0.1
+      '@types/d3-format': 3.0.1
+      '@types/d3-geo': 3.1.0
+      '@types/d3-interpolate': 3.0.1
+      '@types/d3-scale': 4.0.2
+      '@types/d3-time': 3.0.0
+      '@types/d3-time-format': 2.1.0
+      d3-array: 3.2.1
+      d3-color: 3.1.0
+      d3-delaunay: 6.0.2
+      d3-format: 3.1.0
+      d3-geo: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      internmap: 2.0.3
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -4813,6 +5409,8 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  agent-base@7.1.4: {}
 
   ajv@6.14.0:
     dependencies:
@@ -4934,6 +5532,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  balanced-match@0.4.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -4995,6 +5595,8 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  classnames@2.5.1: {}
+
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
@@ -5029,9 +5631,65 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
 
+  d3-array@3.2.1:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-delaunay@6.0.2:
+    dependencies:
+      delaunator: 5.0.1
+
+  d3-format@3.1.0: {}
+
+  d3-geo@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -5077,6 +5735,10 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  delaunator@5.0.1:
+    dependencies:
+      robust-predicates: 3.0.2
+
   denque@2.1.0: {}
 
   dequal@2.0.3: {}
@@ -5117,6 +5779,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@6.0.1: {}
 
   es-abstract@1.24.1:
     dependencies:
@@ -5658,6 +6322,28 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   icu-minify@4.8.3:
     dependencies:
       '@formatjs/icu-messageformat-parser': 3.5.1
@@ -5678,6 +6364,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   intl-messageformat@11.1.2:
     dependencies:
@@ -5773,6 +6461,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -5834,6 +6524,33 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.19.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   json-bignum@0.0.3: {}
 
@@ -5930,11 +6647,15 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash@4.17.23: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
 
   loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
 
   lucide-react@0.500.0(react@19.2.4):
     dependencies:
@@ -5945,6 +6666,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-expression-evaluator@1.4.0: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -6033,6 +6756,8 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
+  nwsapi@2.2.23: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -6101,6 +6826,10 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   path-exists@4.0.0: {}
 
@@ -6224,6 +6953,12 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-use-measure@2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
   react@19.2.4: {}
 
   redis-errors@1.2.0: {}
@@ -6231,6 +6966,16 @@ snapshots:
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
+
+  reduce-css-calc@1.3.0:
+    dependencies:
+      balanced-match: 0.4.2
+      math-expression-evaluator: 1.4.0
+      reduce-function-call: 1.0.3
+
+  reduce-function-call@1.0.3:
+    dependencies:
+      balanced-match: 1.0.2
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -6273,6 +7018,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  robust-predicates@3.0.2: {}
+
   rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -6304,6 +7051,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -6326,6 +7075,12 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -6516,6 +7271,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   table-layout@4.1.1:
     dependencies:
       array-back: 6.2.2
@@ -6542,9 +7299,23 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -6715,7 +7486,7 @@ snapshots:
       lightningcss: 1.31.1
       tsx: 4.21.0
 
-  vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0):
+  vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -6742,6 +7513,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -6755,6 +7527,23 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -6809,6 +7598,12 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wordwrapjs@5.1.1: {}
+
+  ws@8.19.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary
- **Chart theme system**: `ChartThemeProvider` + `useChartTheme()` hook, light/dark themes with 10 series colors, typography, spacing
- **Panel adapter protocol**: `PanelPlugin` interface (id, configSchema, dataShape, Component), `PanelRegistry` for chart type lookup
- **TimeSeriesLine**: visx line/area chart, time x-axis, multi-series, tooltips, responsive
- **BarChart**: grouped/stacked modes, categorical x-axis, tooltips, click events
- **StatCard**: big number display, optional sparkline, color thresholds, `Intl.NumberFormat`
- **DataTable**: TanStack Table, sortable columns, pagination, auto-detected columns
- **Auto-viz selector**: `selectVisualization()` recommends chart type from column metadata with confidence score

Closes #6, closes #17, closes #18, closes #19, closes #20, closes #21

## Test plan
- [x] `pnpm typecheck` — all 8 packages clean
- [x] `pnpm test` — 127 tests pass (27 viz-core + 37 postgres + 6 sdk + 40 query-ir + 6 compute + 8 db + 3 web)
- [x] CI passes

Charts are in `packages/viz-core/` only — not yet wired into the web app (that's D9). No browser testing needed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)