### PR TITLE
feat(d8): AI agent — tool use, streaming, and conversation management

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@lightboard/agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.52.0",
+    "@lightboard/connector-sdk": "workspace:*",
+    "@lightboard/query-ir": "workspace:*",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.2",
+    "vitest": "^3.1.0"
+  }
+}

--- a/packages/agent/src/agent.test.ts
+++ b/packages/agent/src/agent.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Agent, type AgentEvent } from './agent';
+import type { LLMProvider, StreamEvent, ToolContext } from './index';
+
+/** Creates a mock provider that yields predefined events. */
+function mockProvider(eventSequences: StreamEvent[][]): LLMProvider {
+  let callIndex = 0;
+  return {
+    name: 'mock',
+    async *chat() {
+      const events = eventSequences[callIndex] ?? [{ type: 'message_end', stopReason: 'end_turn' }];
+      callIndex++;
+      for (const event of events) {
+        yield event;
+      }
+    },
+  };
+}
+
+function mockToolContext(): ToolContext {
+  return {
+    getSchema: vi.fn().mockResolvedValue({
+      tables: [
+        {
+          name: 'orders',
+          columns: [
+            { name: 'id', type: 'integer' },
+            { name: 'created_at', type: 'timestamp' },
+            { name: 'amount', type: 'numeric' },
+            { name: 'status', type: 'varchar' },
+            { name: 'region', type: 'varchar' },
+          ],
+        },
+      ],
+    }),
+    executeQuery: vi.fn().mockResolvedValue({
+      rows: [
+        { region: 'North', total: 5000 },
+        { region: 'South', total: 3200 },
+        { region: 'East', total: 4100 },
+      ],
+      rowCount: 3,
+    }),
+  };
+}
+
+async function collectEvents(agent: Agent, message: string): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of agent.chat(message)) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe('Agent', () => {
+  it('streams text response without tool calls', async () => {
+    const agent = new Agent({
+      provider: mockProvider([
+        [
+          { type: 'text_delta', text: 'Hello! ' },
+          { type: 'text_delta', text: 'How can I help?' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [],
+    });
+
+    const events = await collectEvents(agent, 'hi');
+    const textEvents = events.filter((e) => e.type === 'text');
+    expect(textEvents).toHaveLength(2);
+    expect(events.some((e) => e.type === 'done')).toBe(true);
+  });
+
+  it('executes tool calls and continues', async () => {
+    const agent = new Agent({
+      provider: mockProvider([
+        // Round 1: agent calls get_schema
+        [
+          { type: 'text_delta', text: 'Let me check the schema.' },
+          { type: 'tool_call_start', id: 'tc_1', name: 'get_schema' },
+          { type: 'tool_call_end', id: 'tc_1', name: 'get_schema', input: { source_id: 'pg-main' } },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Round 2: agent responds with text
+        [
+          { type: 'text_delta', text: 'I found the orders table.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [{ id: 'pg-main', name: 'Main DB', type: 'postgres' }],
+    });
+
+    const events = await collectEvents(agent, 'Show me the orders data');
+
+    expect(events.some((e) => e.type === 'tool_start')).toBe(true);
+    expect(events.some((e) => e.type === 'tool_end')).toBe(true);
+    expect(events.some((e) => e.type === 'done')).toBe(true);
+  });
+
+  it('handles create_view tool call', async () => {
+    const agent = new Agent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'create_view' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'create_view',
+            input: {
+              view_spec: {
+                title: 'Sales by Region',
+                query: { source: 'pg-main', table: 'orders' },
+                chart: { type: 'bar-chart', config: { xField: 'region', yFields: ['total'] } },
+                controls: [
+                  { type: 'dropdown', label: 'Status', variable: 'status' },
+                ],
+              },
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'Here is your chart.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [{ id: 'pg-main', name: 'Main DB', type: 'postgres' }],
+    });
+
+    const events = await collectEvents(agent, 'Show sales by region');
+    const toolEnd = events.find((e) => e.type === 'tool_end') as Extract<AgentEvent, { type: 'tool_end' }>;
+    expect(toolEnd).toBeDefined();
+    expect(toolEnd.name).toBe('create_view');
+    expect(toolEnd.isError).toBe(false);
+
+    const parsed = JSON.parse(toolEnd.result);
+    expect(parsed.viewSpec.chart.type).toBe('bar-chart');
+  });
+
+  it('handles tool errors gracefully', async () => {
+    const ctx = mockToolContext();
+    (ctx.getSchema as any).mockRejectedValue(new Error('Connection refused'));
+
+    const agent = new Agent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'get_schema' },
+          { type: 'tool_call_end', id: 'tc_1', name: 'get_schema', input: { source_id: 'broken' } },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'The connection failed, let me try again.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: ctx,
+      dataSources: [],
+    });
+
+    const events = await collectEvents(agent, 'query the broken db');
+    const toolEnd = events.find((e) => e.type === 'tool_end') as Extract<AgentEvent, { type: 'tool_end' }>;
+    expect(toolEnd.isError).toBe(true);
+    expect(toolEnd.result).toContain('Connection refused');
+  });
+
+  it('stops after max tool rounds', async () => {
+    // Provider that always returns tool calls
+    const infiniteToolProvider: LLMProvider = {
+      name: 'mock',
+      async *chat() {
+        yield { type: 'tool_call_start' as const, id: 'tc', name: 'get_schema' };
+        yield { type: 'tool_call_end' as const, id: 'tc', name: 'get_schema', input: { source_id: 'x' } };
+        yield { type: 'message_end' as const, stopReason: 'tool_use' };
+      },
+    };
+
+    const agent = new Agent({
+      provider: infiniteToolProvider,
+      toolContext: mockToolContext(),
+      dataSources: [],
+      maxToolRounds: 3,
+    });
+
+    const events = await collectEvents(agent, 'infinite loop');
+    const done = events.filter((e) => e.type === 'done');
+    expect(done).toHaveLength(1);
+    expect((done[0] as Extract<AgentEvent, { type: 'done' }>).stopReason).toBe('max_tool_rounds');
+  });
+
+  it('resets conversation', async () => {
+    const agent = new Agent({
+      provider: mockProvider([
+        [{ type: 'text_delta', text: 'Hi' }, { type: 'message_end', stopReason: 'end_turn' }],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [],
+    });
+
+    await collectEvents(agent, 'hello');
+    expect(agent.getHistory().length).toBeGreaterThan(0);
+
+    agent.reset();
+    expect(agent.getHistory()).toHaveLength(0);
+  });
+
+  it('stores conversation history across turns', async () => {
+    const agent = new Agent({
+      provider: mockProvider([
+        [{ type: 'text_delta', text: 'First reply' }, { type: 'message_end', stopReason: 'end_turn' }],
+        [{ type: 'text_delta', text: 'Second reply' }, { type: 'message_end', stopReason: 'end_turn' }],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [],
+    });
+
+    await collectEvents(agent, 'first message');
+    await collectEvents(agent, 'second message');
+
+    const history = agent.getHistory();
+    expect(history.length).toBe(4); // 2 user + 2 assistant
+  });
+});

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,0 +1,166 @@
+import { ConversationManager } from './conversation/manager';
+import type { LLMProvider, Message, StreamEvent, ToolCallResult } from './provider/types';
+import { buildSystemPrompt } from './prompt/system';
+import { agentTools } from './tools/definitions';
+import { ToolRouter, type ToolContext } from './tools/router';
+
+/** Events emitted by the agent during a conversation turn. */
+export type AgentEvent =
+  | { type: 'text'; text: string }
+  | { type: 'tool_start'; name: string; id: string }
+  | { type: 'tool_end'; name: string; result: string; isError: boolean }
+  | { type: 'done'; stopReason: string };
+
+/** Data sources available to the agent. */
+export interface AgentDataSource {
+  id: string;
+  name: string;
+  type: string;
+}
+
+/** Configuration for creating an Agent. */
+export interface AgentConfig {
+  provider: LLMProvider;
+  toolContext: ToolContext;
+  dataSources: AgentDataSource[];
+  maxToolRounds?: number;
+}
+
+/**
+ * The Lightboard AI agent. Receives natural language questions,
+ * uses tool calling to explore data, and produces ViewSpecs.
+ *
+ * Supports streaming responses and multi-turn tool use with
+ * automatic error self-correction.
+ */
+export class Agent {
+  private provider: LLMProvider;
+  private toolRouter: ToolRouter;
+  private conversation: ConversationManager;
+  private dataSources: AgentDataSource[];
+  private maxToolRounds: number;
+
+  constructor(config: AgentConfig) {
+    this.provider = config.provider;
+    this.toolRouter = new ToolRouter(config.toolContext);
+    this.conversation = new ConversationManager();
+    this.dataSources = config.dataSources;
+    this.maxToolRounds = config.maxToolRounds ?? 10;
+  }
+
+  /**
+   * Process a user message and stream the agent's response.
+   * The agent may make multiple tool calls before producing a final response.
+   */
+  async *chat(
+    userMessage: string,
+    currentView?: Record<string, unknown> | null,
+  ): AsyncIterable<AgentEvent> {
+    this.conversation.addMessage({ role: 'user', content: userMessage });
+
+    const systemPrompt = buildSystemPrompt({
+      dataSources: this.dataSources,
+      currentView,
+    });
+
+    for (let round = 0; round < this.maxToolRounds; round++) {
+      const toolCalls: ToolCallResult[] = [];
+      const toolInputBuffers = new Map<string, string>();
+      let textContent = '';
+      let hasToolCalls = false;
+
+      // Stream LLM response
+      const stream = this.provider.chat(
+        this.conversation.getMessages(),
+        agentTools,
+        { system: systemPrompt },
+      );
+
+      for await (const event of stream) {
+        switch (event.type) {
+          case 'text_delta':
+            textContent += event.text;
+            yield { type: 'text', text: event.text };
+            break;
+
+          case 'tool_call_start':
+            hasToolCalls = true;
+            toolInputBuffers.set(event.id, '');
+            yield { type: 'tool_start', name: event.name, id: event.id };
+            // Store the tool name for later
+            toolCalls.push({ id: event.id, name: event.name, input: {} });
+            break;
+
+          case 'tool_call_delta':
+            const existing = toolInputBuffers.get(event.id) ?? '';
+            toolInputBuffers.set(event.id, existing + event.input);
+            break;
+
+          case 'tool_call_end':
+            const tc = toolCalls.find((t) => t.id === event.id);
+            if (tc) tc.input = event.input;
+            break;
+
+          case 'message_end':
+            // If no tool calls were made via tool_call_end events,
+            // try parsing accumulated input buffers
+            if (hasToolCalls) {
+              for (const tc of toolCalls) {
+                if (Object.keys(tc.input).length === 0) {
+                  const raw = toolInputBuffers.get(tc.id);
+                  if (raw) {
+                    try { tc.input = JSON.parse(raw); } catch { /* ignore */ }
+                  }
+                }
+              }
+            }
+            break;
+        }
+      }
+
+      // Store assistant message
+      this.conversation.addMessage({
+        role: 'assistant',
+        content: textContent,
+        toolCalls: hasToolCalls ? toolCalls : undefined,
+      });
+
+      // If no tool calls, we're done
+      if (!hasToolCalls) {
+        yield { type: 'done', stopReason: 'end_turn' };
+        return;
+      }
+
+      // Execute tool calls and feed results back
+      const toolResults = [];
+      for (const tc of toolCalls) {
+        const result = await this.toolRouter.execute(tc.name, tc.input);
+        toolResults.push({
+          toolCallId: tc.id,
+          content: result.content,
+          isError: result.isError,
+        });
+        yield { type: 'tool_end', name: tc.name, result: result.content, isError: result.isError };
+      }
+
+      // Add tool results as user message for next round
+      this.conversation.addMessage({
+        role: 'user',
+        content: '',
+        toolResults,
+      });
+    }
+
+    yield { type: 'done', stopReason: 'max_tool_rounds' };
+  }
+
+  /** Reset the conversation history. */
+  reset(): void {
+    this.conversation.clear();
+  }
+
+  /** Get the conversation history. */
+  getHistory(): Message[] {
+    return this.conversation.getMessages();
+  }
+}

--- a/packages/agent/src/conversation/index.ts
+++ b/packages/agent/src/conversation/index.ts
@@ -1,0 +1,1 @@
+export { ConversationManager } from './manager';

--- a/packages/agent/src/conversation/manager.test.ts
+++ b/packages/agent/src/conversation/manager.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { ConversationManager } from './manager';
+
+describe('ConversationManager', () => {
+  it('stores and retrieves messages', () => {
+    const mgr = new ConversationManager();
+    mgr.addMessage({ role: 'user', content: 'Hello' });
+    mgr.addMessage({ role: 'assistant', content: 'Hi there!' });
+
+    expect(mgr.length).toBe(2);
+    expect(mgr.getMessages()).toHaveLength(2);
+  });
+
+  it('returns last message', () => {
+    const mgr = new ConversationManager();
+    mgr.addMessage({ role: 'user', content: 'First' });
+    mgr.addMessage({ role: 'user', content: 'Second' });
+    expect(mgr.lastMessage()?.content).toBe('Second');
+  });
+
+  it('returns undefined for empty conversation', () => {
+    const mgr = new ConversationManager();
+    expect(mgr.lastMessage()).toBeUndefined();
+  });
+
+  it('clears conversation', () => {
+    const mgr = new ConversationManager();
+    mgr.addMessage({ role: 'user', content: 'Hello' });
+    mgr.clear();
+    expect(mgr.length).toBe(0);
+  });
+
+  it('truncates when exceeding max messages', () => {
+    const mgr = new ConversationManager({ maxMessages: 5 });
+
+    for (let i = 0; i < 10; i++) {
+      mgr.addMessage({ role: 'user', content: `Message ${i}` });
+    }
+
+    // Should be truncated to ~5 messages
+    expect(mgr.length).toBeLessThanOrEqual(6); // 2 first + 1 summary + 3 recent
+  });
+
+  it('preserves first two messages on truncation', () => {
+    const mgr = new ConversationManager({ maxMessages: 5 });
+
+    mgr.addMessage({ role: 'user', content: 'First' });
+    mgr.addMessage({ role: 'assistant', content: 'Second' });
+
+    for (let i = 0; i < 10; i++) {
+      mgr.addMessage({ role: 'user', content: `Extra ${i}` });
+    }
+
+    const messages = mgr.getMessages();
+    expect(messages[0]!.content).toBe('First');
+    expect(messages[1]!.content).toBe('Second');
+  });
+
+  it('returns copies of messages (immutable)', () => {
+    const mgr = new ConversationManager();
+    mgr.addMessage({ role: 'user', content: 'Hello' });
+
+    const msgs = mgr.getMessages();
+    msgs.push({ role: 'user', content: 'injected' });
+    expect(mgr.length).toBe(1); // Original unchanged
+  });
+});

--- a/packages/agent/src/conversation/manager.ts
+++ b/packages/agent/src/conversation/manager.ts
@@ -1,0 +1,66 @@
+import type { Message } from '../provider/types';
+
+const DEFAULT_MAX_MESSAGES = 50;
+const SUMMARY_THRESHOLD = 40;
+
+/**
+ * Manages conversation history with context window management.
+ * Stores messages, handles truncation, and injects context.
+ */
+export class ConversationManager {
+  private messages: Message[] = [];
+  private maxMessages: number;
+
+  constructor(options?: { maxMessages?: number }) {
+    this.maxMessages = options?.maxMessages ?? DEFAULT_MAX_MESSAGES;
+  }
+
+  /** Add a message to the conversation. */
+  addMessage(message: Message): void {
+    this.messages.push(message);
+    this.truncateIfNeeded();
+  }
+
+  /** Get the full conversation history. */
+  getMessages(): Message[] {
+    return [...this.messages];
+  }
+
+  /** Get the message count. */
+  get length(): number {
+    return this.messages.length;
+  }
+
+  /** Clear the conversation history. */
+  clear(): void {
+    this.messages = [];
+  }
+
+  /** Get the last message in the conversation. */
+  lastMessage(): Message | undefined {
+    return this.messages[this.messages.length - 1];
+  }
+
+  /**
+   * Truncates conversation history when it exceeds the threshold.
+   * Keeps the first message (usually sets context) and the most recent messages.
+   */
+  private truncateIfNeeded(): void {
+    if (this.messages.length <= this.maxMessages) return;
+
+    // Keep the first 2 messages (initial context) and the last N
+    const keepRecent = this.maxMessages - 2;
+    const first = this.messages.slice(0, 2);
+    const recent = this.messages.slice(-keepRecent);
+
+    // Insert a summary marker
+    this.messages = [
+      ...first,
+      {
+        role: 'system' as const,
+        content: `[Previous ${this.messages.length - keepRecent - 2} messages truncated for context window management]`,
+      },
+      ...recent,
+    ];
+  }
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,0 +1,15 @@
+export { Agent, type AgentConfig, type AgentDataSource, type AgentEvent } from './agent';
+export { ConversationManager } from './conversation';
+export {
+  ClaudeProvider,
+  type ClaudeProviderConfig,
+  LLMError,
+  type LLMProvider,
+  type Message,
+  OpenAICompatibleProvider,
+  type OpenAICompatibleConfig,
+  type StreamEvent,
+  type ToolDefinition,
+} from './provider';
+export { buildSystemPrompt } from './prompt';
+export { agentTools, ToolRouter, type ToolContext, type ToolExecutionResult } from './tools';

--- a/packages/agent/src/prompt/index.ts
+++ b/packages/agent/src/prompt/index.ts
@@ -1,0 +1,1 @@
+export { buildSystemPrompt } from './system';

--- a/packages/agent/src/prompt/system.test.ts
+++ b/packages/agent/src/prompt/system.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { buildSystemPrompt } from './system';
+
+describe('buildSystemPrompt', () => {
+  it('includes core instructions', () => {
+    const prompt = buildSystemPrompt({ dataSources: [] });
+    expect(prompt).toContain('data exploration assistant');
+    expect(prompt).toContain('QueryIR');
+    expect(prompt).toContain('get_schema');
+  });
+
+  it('includes data source list', () => {
+    const prompt = buildSystemPrompt({
+      dataSources: [
+        { id: 'pg-1', name: 'Production DB', type: 'postgres' },
+        { id: 'csv-1', name: 'Sales CSV', type: 'csv' },
+      ],
+    });
+    expect(prompt).toContain('Production DB');
+    expect(prompt).toContain('pg-1');
+    expect(prompt).toContain('Sales CSV');
+  });
+
+  it('includes current view state when provided', () => {
+    const prompt = buildSystemPrompt({
+      dataSources: [],
+      currentView: { title: 'My Chart', chart: { type: 'bar-chart' } },
+    });
+    expect(prompt).toContain('Current view state');
+    expect(prompt).toContain('My Chart');
+    expect(prompt).toContain('bar-chart');
+  });
+
+  it('omits view section when no current view', () => {
+    const prompt = buildSystemPrompt({ dataSources: [] });
+    expect(prompt).not.toContain('Current view state');
+  });
+
+  it('mentions all chart types', () => {
+    const prompt = buildSystemPrompt({ dataSources: [] });
+    expect(prompt).toContain('time-series-line');
+    expect(prompt).toContain('bar-chart');
+    expect(prompt).toContain('stat-card');
+    expect(prompt).toContain('data-table');
+  });
+
+  it('mentions self-correction', () => {
+    const prompt = buildSystemPrompt({ dataSources: [] });
+    expect(prompt).toContain('Self-correct');
+  });
+});

--- a/packages/agent/src/prompt/system.ts
+++ b/packages/agent/src/prompt/system.ts
@@ -1,0 +1,79 @@
+/**
+ * Builds the system prompt for the Lightboard agent.
+ * Includes context about available data sources and current view state.
+ */
+export function buildSystemPrompt(context: {
+  dataSources: { id: string; name: string; type: string }[];
+  currentView?: Record<string, unknown> | null;
+}): string {
+  const parts = [CORE_INSTRUCTIONS];
+
+  if (context.dataSources.length > 0) {
+    const sourceList = context.dataSources
+      .map((s) => `  - "${s.name}" (id: ${s.id}, type: ${s.type})`)
+      .join('\n');
+    parts.push(`\nAvailable data sources:\n${sourceList}`);
+  }
+
+  if (context.currentView) {
+    parts.push(`\nCurrent view state:\n${JSON.stringify(context.currentView, null, 2)}`);
+  }
+
+  return parts.join('\n');
+}
+
+const CORE_INSTRUCTIONS = `You are Lightboard's data exploration assistant. You help users understand their data by creating interactive visualizations.
+
+## How to work
+
+1. **Always introspect first**: When a user asks about data, use \`get_schema\` to see what tables and columns are available before writing any queries.
+
+2. **Use QueryIR, never raw SQL**: All queries must use the QueryIR format. Never write SQL directly.
+
+3. **Create thoughtful views**: When creating a view with \`create_view\`, include interactive controls:
+   - Add dropdown controls for categorical columns (e.g., region, status, category)
+   - Add date_range controls for time-based columns
+   - Use template variables ($variable_name) in the query that map to controls
+   - Choose the right chart type based on the data:
+     - Time + numeric → time-series-line
+     - Categorical + numeric → bar-chart
+     - Single numeric → stat-card
+     - No clear pattern → data-table
+
+4. **Handle follow-ups**: When the user asks to modify (e.g., "show as bar chart", "filter by region", "zoom to last 7 days"), use \`modify_view\` to patch the existing view rather than creating a new one.
+
+5. **Self-correct on errors**: If a query fails, analyze the error message and try a different approach. Common fixes:
+   - Column not found → re-check schema with get_schema
+   - Type mismatch → adjust filter values or aggregations
+   - Timeout → add a LIMIT or narrow the time range
+
+## QueryIR structure
+
+\`\`\`
+{
+  source: "data-source-id",
+  table: "table_name",
+  select: [{ field: "column_name", alias: "display_name" }],
+  filter: { field: { field: "column" }, operator: "eq", value: "value" },
+  aggregations: [{ function: "count", field: { field: "*" }, alias: "total" }],
+  groupBy: [{ field: "category_column" }],
+  orderBy: [{ field: { field: "total" }, direction: "desc" }],
+  timeRange: { field: { field: "created_at" }, from: "$start_date", to: "$end_date" },
+  limit: 100
+}
+\`\`\`
+
+## Chart types
+
+- \`time-series-line\`: config needs \`xField\` (time column) and \`yFields\` (numeric columns)
+- \`bar-chart\`: config needs \`xField\` (category) and \`yFields\` (numeric), optional \`mode\` (grouped/stacked)
+- \`stat-card\`: config needs \`valueField\`, optional \`label\` and \`sparklineField\`
+- \`data-table\`: config is optional, auto-detects columns
+
+## Important rules
+
+- Be concise in your explanations
+- Show your reasoning briefly, then create the view
+- Always set reasonable defaults for controls
+- Prefer aggregated views over raw data dumps
+- Include a title and description in every view`;

--- a/packages/agent/src/provider/claude.ts
+++ b/packages/agent/src/provider/claude.ts
@@ -1,0 +1,141 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { ChatOptions, LLMProvider, Message, StreamEvent, ToolDefinition } from './types';
+import { LLMError } from './types';
+
+/** Configuration for the Claude provider. */
+export interface ClaudeProviderConfig {
+  apiKey: string;
+  model?: string;
+  maxTokens?: number;
+}
+
+/**
+ * Claude LLM provider using the Anthropic SDK.
+ * Streams responses with native tool use support.
+ */
+export class ClaudeProvider implements LLMProvider {
+  readonly name = 'claude';
+  private client: Anthropic;
+  private defaultModel: string;
+  private defaultMaxTokens: number;
+
+  constructor(config: ClaudeProviderConfig) {
+    this.client = new Anthropic({ apiKey: config.apiKey });
+    this.defaultModel = config.model ?? 'claude-sonnet-4-20250514';
+    this.defaultMaxTokens = config.maxTokens ?? 4096;
+  }
+
+  /** Stream a chat response from Claude with tool use. */
+  async *chat(
+    messages: Message[],
+    tools: ToolDefinition[],
+    options?: ChatOptions,
+  ): AsyncIterable<StreamEvent> {
+    const anthropicMessages = this.convertMessages(messages);
+    const anthropicTools = tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      input_schema: t.inputSchema as Anthropic.Tool['input_schema'],
+    }));
+
+    try {
+      const stream = this.client.messages.stream({
+        model: options?.model ?? this.defaultModel,
+        max_tokens: options?.maxTokens ?? this.defaultMaxTokens,
+        temperature: options?.temperature,
+        system: options?.system,
+        messages: anthropicMessages,
+        tools: anthropicTools.length > 0 ? anthropicTools : undefined,
+      });
+
+      for await (const event of stream) {
+        yield* this.convertStreamEvent(event);
+      }
+    } catch (err) {
+      if (err instanceof Anthropic.APIError) {
+        throw new LLMError(
+          err.message,
+          'claude',
+          err.status,
+          err.status === 429 || err.status >= 500,
+        );
+      }
+      throw err;
+    }
+  }
+
+  /** Converts our Message format to Anthropic's format. */
+  private convertMessages(messages: Message[]): Anthropic.MessageParam[] {
+    const result: Anthropic.MessageParam[] = [];
+
+    for (const msg of messages) {
+      if (msg.role === 'system') continue; // System handled separately
+
+      if (msg.role === 'user') {
+        if (msg.toolResults && msg.toolResults.length > 0) {
+          // Tool results go as user messages with tool_result content blocks
+          result.push({
+            role: 'user',
+            content: msg.toolResults.map((r) => ({
+              type: 'tool_result' as const,
+              tool_use_id: r.toolCallId,
+              content: r.content,
+              is_error: r.isError,
+            })),
+          });
+        } else {
+          result.push({ role: 'user', content: msg.content });
+        }
+      } else if (msg.role === 'assistant') {
+        const content: Anthropic.ContentBlockParam[] = [];
+        if (msg.content) {
+          content.push({ type: 'text', text: msg.content });
+        }
+        if (msg.toolCalls) {
+          for (const tc of msg.toolCalls) {
+            content.push({
+              type: 'tool_use',
+              id: tc.id,
+              name: tc.name,
+              input: tc.input,
+            });
+          }
+        }
+        result.push({ role: 'assistant', content });
+      }
+    }
+
+    return result;
+  }
+
+  /** Converts Anthropic stream events to our StreamEvent format. */
+  private *convertStreamEvent(event: Anthropic.MessageStreamEvent): Iterable<StreamEvent> {
+    switch (event.type) {
+      case 'content_block_start':
+        if (event.content_block.type === 'tool_use') {
+          yield {
+            type: 'tool_call_start',
+            id: event.content_block.id,
+            name: event.content_block.name,
+          };
+        }
+        break;
+
+      case 'content_block_delta':
+        if (event.delta.type === 'text_delta') {
+          yield { type: 'text_delta', text: event.delta.text };
+        } else if (event.delta.type === 'input_json_delta') {
+          yield {
+            type: 'tool_call_delta',
+            id: '', // Anthropic doesn't include id in deltas
+            input: event.delta.partial_json,
+          };
+        }
+        break;
+
+      case 'message_stop':
+        yield { type: 'message_end', stopReason: 'end_turn' };
+        break;
+    }
+  }
+}

--- a/packages/agent/src/provider/index.ts
+++ b/packages/agent/src/provider/index.ts
@@ -1,0 +1,12 @@
+export { ClaudeProvider, type ClaudeProviderConfig } from './claude';
+export { OpenAICompatibleProvider, type OpenAICompatibleConfig } from './openai-compatible';
+export type {
+  ChatOptions,
+  LLMProvider,
+  Message,
+  StreamEvent,
+  ToolCallResult,
+  ToolDefinition,
+  ToolResult,
+} from './types';
+export { LLMError } from './types';

--- a/packages/agent/src/provider/openai-compatible.ts
+++ b/packages/agent/src/provider/openai-compatible.ts
@@ -1,0 +1,171 @@
+import type { ChatOptions, LLMProvider, Message, StreamEvent, ToolDefinition } from './types';
+import { LLMError } from './types';
+
+/** Configuration for OpenAI-compatible providers (Ollama, vLLM, etc.). */
+export interface OpenAICompatibleConfig {
+  baseUrl: string;
+  apiKey?: string;
+  model: string;
+  maxTokens?: number;
+}
+
+/**
+ * OpenAI-compatible LLM provider for on-prem and airgapped deployments.
+ * Works with Ollama, vLLM, LiteLLM, or any OpenAI-compatible API.
+ */
+export class OpenAICompatibleProvider implements LLMProvider {
+  readonly name = 'openai-compatible';
+  private baseUrl: string;
+  private apiKey: string;
+  private defaultModel: string;
+  private defaultMaxTokens: number;
+
+  constructor(config: OpenAICompatibleConfig) {
+    this.baseUrl = config.baseUrl.replace(/\/$/, '');
+    this.apiKey = config.apiKey ?? '';
+    this.defaultModel = config.model;
+    this.defaultMaxTokens = config.maxTokens ?? 4096;
+  }
+
+  /** Stream a chat response from an OpenAI-compatible endpoint. */
+  async *chat(
+    messages: Message[],
+    tools: ToolDefinition[],
+    options?: ChatOptions,
+  ): AsyncIterable<StreamEvent> {
+    const openaiMessages = this.convertMessages(messages, options?.system);
+    const openaiTools = tools.length > 0
+      ? tools.map((t) => ({
+          type: 'function' as const,
+          function: {
+            name: t.name,
+            description: t.description,
+            parameters: t.inputSchema,
+          },
+        }))
+      : undefined;
+
+    const body = {
+      model: options?.model ?? this.defaultModel,
+      messages: openaiMessages,
+      tools: openaiTools,
+      max_tokens: options?.maxTokens ?? this.defaultMaxTokens,
+      temperature: options?.temperature,
+      stream: true,
+    };
+
+    const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new LLMError(
+        `OpenAI-compatible API error: ${response.status} ${response.statusText}`,
+        'openai-compatible',
+        response.status,
+        response.status === 429 || response.status >= 500,
+      );
+    }
+
+    if (!response.body) {
+      throw new LLMError('No response body', 'openai-compatible');
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        const data = line.slice(6).trim();
+        if (data === '[DONE]') {
+          yield { type: 'message_end', stopReason: 'end_turn' };
+          return;
+        }
+
+        try {
+          const parsed = JSON.parse(data);
+          const delta = parsed.choices?.[0]?.delta;
+          if (!delta) continue;
+
+          if (delta.content) {
+            yield { type: 'text_delta', text: delta.content };
+          }
+
+          if (delta.tool_calls) {
+            for (const tc of delta.tool_calls) {
+              if (tc.function?.name) {
+                yield {
+                  type: 'tool_call_start',
+                  id: tc.id ?? `call_${tc.index}`,
+                  name: tc.function.name,
+                };
+              }
+              if (tc.function?.arguments) {
+                yield {
+                  type: 'tool_call_delta',
+                  id: tc.id ?? `call_${tc.index}`,
+                  input: tc.function.arguments,
+                };
+              }
+            }
+          }
+        } catch {
+          // Skip malformed SSE lines
+        }
+      }
+    }
+
+    yield { type: 'message_end', stopReason: 'end_turn' };
+  }
+
+  /** Converts our Message format to OpenAI's format. */
+  private convertMessages(messages: Message[], system?: string): Record<string, unknown>[] {
+    const result: Record<string, unknown>[] = [];
+
+    if (system) {
+      result.push({ role: 'system', content: system });
+    }
+
+    for (const msg of messages) {
+      if (msg.role === 'system') {
+        result.push({ role: 'system', content: msg.content });
+      } else if (msg.role === 'user' && msg.toolResults) {
+        for (const r of msg.toolResults) {
+          result.push({
+            role: 'tool',
+            tool_call_id: r.toolCallId,
+            content: r.content,
+          });
+        }
+      } else if (msg.role === 'assistant' && msg.toolCalls) {
+        result.push({
+          role: 'assistant',
+          content: msg.content || null,
+          tool_calls: msg.toolCalls.map((tc) => ({
+            id: tc.id,
+            type: 'function',
+            function: { name: tc.name, arguments: JSON.stringify(tc.input) },
+          })),
+        });
+      } else {
+        result.push({ role: msg.role, content: msg.content });
+      }
+    }
+
+    return result;
+  }
+}

--- a/packages/agent/src/provider/types.ts
+++ b/packages/agent/src/provider/types.ts
@@ -1,0 +1,73 @@
+/** A message in the conversation. */
+export interface Message {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  toolCalls?: ToolCallResult[];
+  toolResults?: ToolResult[];
+}
+
+/** A tool call made by the assistant. */
+export interface ToolCallResult {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+/** Result returned from executing a tool. */
+export interface ToolResult {
+  toolCallId: string;
+  content: string;
+  isError?: boolean;
+}
+
+/** Tool definition passed to the LLM. */
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+/** Streaming events emitted by the LLM provider. */
+export type StreamEvent =
+  | { type: 'text_delta'; text: string }
+  | { type: 'tool_call_start'; id: string; name: string }
+  | { type: 'tool_call_delta'; id: string; input: string }
+  | { type: 'tool_call_end'; id: string; name: string; input: Record<string, unknown> }
+  | { type: 'message_end'; stopReason: string };
+
+/** Options for LLM chat requests. */
+export interface ChatOptions {
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  system?: string;
+}
+
+/** Normalized error from any LLM provider. */
+export class LLMError extends Error {
+  constructor(
+    message: string,
+    public readonly provider: string,
+    public readonly statusCode?: number,
+    public readonly retryable: boolean = false,
+  ) {
+    super(message);
+    this.name = 'LLMError';
+  }
+}
+
+/**
+ * Abstract interface for LLM providers.
+ * Normalizes Claude and OpenAI-compatible APIs into a single streaming interface.
+ */
+export interface LLMProvider {
+  /** Provider name (e.g. 'claude', 'openai'). */
+  readonly name: string;
+
+  /** Send a chat request with tools and stream the response. */
+  chat(
+    messages: Message[],
+    tools: ToolDefinition[],
+    options?: ChatOptions,
+  ): AsyncIterable<StreamEvent>;
+}

--- a/packages/agent/src/tools/definitions.ts
+++ b/packages/agent/src/tools/definitions.ts
@@ -1,0 +1,126 @@
+import type { ToolDefinition } from '../provider/types';
+
+/** Tool definitions in a format compatible with Claude's tool use and OpenAI's function calling. */
+export const agentTools: ToolDefinition[] = [
+  {
+    name: 'get_schema',
+    description:
+      'Get the schema (tables, columns, types, relationships) of a connected data source. ' +
+      'Always call this before writing a query to understand what data is available.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source_id: {
+          type: 'string',
+          description: 'The ID of the data source to introspect',
+        },
+      },
+      required: ['source_id'],
+    },
+  },
+  {
+    name: 'execute_query',
+    description:
+      'Execute a query against a data source using QueryIR (not raw SQL). ' +
+      'Returns the query results. Use get_schema first to understand the available tables and columns.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source_id: {
+          type: 'string',
+          description: 'The data source to query',
+        },
+        query_ir: {
+          type: 'object',
+          description: 'The QueryIR document describing the query',
+          properties: {
+            source: { type: 'string' },
+            table: { type: 'string' },
+            select: { type: 'array', items: { type: 'object' } },
+            filter: { type: 'object' },
+            aggregations: { type: 'array', items: { type: 'object' } },
+            groupBy: { type: 'array', items: { type: 'object' } },
+            orderBy: { type: 'array', items: { type: 'object' } },
+            timeRange: { type: 'object' },
+            joins: { type: 'array', items: { type: 'object' } },
+            limit: { type: 'number' },
+            offset: { type: 'number' },
+          },
+          required: ['source', 'table'],
+        },
+      },
+      required: ['source_id', 'query_ir'],
+    },
+  },
+  {
+    name: 'create_view',
+    description:
+      'Create an interactive visualization view from query results. ' +
+      'Specify the chart type, configuration, and interactive controls. ' +
+      'Controls should include dropdowns for categorical columns and date range pickers for time columns.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        view_spec: {
+          type: 'object',
+          description: 'The ViewSpec document describing the view',
+          properties: {
+            title: { type: 'string', description: 'Title for the view' },
+            description: { type: 'string', description: 'Description of what the view shows' },
+            query: { type: 'object', description: 'QueryIR for the view data' },
+            chart: {
+              type: 'object',
+              properties: {
+                type: { type: 'string', description: 'Panel plugin ID (time-series-line, bar-chart, stat-card, data-table)' },
+                config: { type: 'object', description: 'Chart-specific configuration' },
+              },
+              required: ['type', 'config'],
+            },
+            controls: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  type: { type: 'string', enum: ['dropdown', 'multi_select', 'date_range', 'text_input', 'toggle'] },
+                  label: { type: 'string' },
+                  variable: { type: 'string', description: 'Template variable name (without $)' },
+                  defaultValue: {},
+                },
+                required: ['type', 'label', 'variable'],
+              },
+            },
+          },
+          required: ['query', 'chart'],
+        },
+      },
+      required: ['view_spec'],
+    },
+  },
+  {
+    name: 'modify_view',
+    description:
+      'Modify an existing view — change chart type, add/remove controls, update filters, adjust configuration. ' +
+      'Use this for follow-up requests like "show it as a bar chart" or "add a filter for region".',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        view_id: {
+          type: 'string',
+          description: 'The ID of the view to modify',
+        },
+        patch: {
+          type: 'object',
+          description: 'Partial ViewSpec with only the fields to change',
+          properties: {
+            title: { type: 'string' },
+            description: { type: 'string' },
+            query: { type: 'object' },
+            chart: { type: 'object' },
+            controls: { type: 'array' },
+          },
+        },
+      },
+      required: ['view_id', 'patch'],
+    },
+  },
+];

--- a/packages/agent/src/tools/index.ts
+++ b/packages/agent/src/tools/index.ts
@@ -1,0 +1,2 @@
+export { agentTools } from './definitions';
+export { ToolRouter, type ToolContext, type ToolExecutionResult } from './router';

--- a/packages/agent/src/tools/router.test.ts
+++ b/packages/agent/src/tools/router.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ToolRouter, type ToolContext } from './router';
+
+function createMockContext(): ToolContext {
+  return {
+    getSchema: vi.fn().mockResolvedValue({
+      tables: [{ name: 'events', columns: [{ name: 'id', type: 'integer' }] }],
+    }),
+    executeQuery: vi.fn().mockResolvedValue({
+      rows: [{ count: 42 }],
+      rowCount: 1,
+    }),
+  };
+}
+
+describe('ToolRouter', () => {
+  it('routes get_schema calls', async () => {
+    const ctx = createMockContext();
+    const router = new ToolRouter(ctx);
+
+    const result = await router.execute('get_schema', { source_id: 'pg-main' });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('events');
+    expect(ctx.getSchema).toHaveBeenCalledWith('pg-main');
+  });
+
+  it('routes execute_query calls', async () => {
+    const ctx = createMockContext();
+    const router = new ToolRouter(ctx);
+
+    const result = await router.execute('execute_query', {
+      source_id: 'pg-main',
+      query_ir: { source: 'pg-main', table: 'events' },
+    });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('42');
+  });
+
+  it('routes create_view calls', async () => {
+    const ctx = createMockContext();
+    const router = new ToolRouter(ctx);
+
+    const result = await router.execute('create_view', {
+      view_spec: {
+        query: { source: 'pg-main', table: 'events' },
+        chart: { type: 'bar-chart', config: { xField: 'category', yFields: ['count'] } },
+      },
+    });
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.viewId).toBeDefined();
+    expect(parsed.viewSpec.chart.type).toBe('bar-chart');
+  });
+
+  it('routes modify_view calls', async () => {
+    const ctx = createMockContext();
+    const router = new ToolRouter(ctx);
+
+    // First create a view
+    const createResult = await router.execute('create_view', {
+      view_spec: {
+        query: { source: 'pg-main', table: 'events' },
+        chart: { type: 'bar-chart', config: {} },
+        title: 'Original',
+      },
+    });
+    const { viewId } = JSON.parse(createResult.content);
+
+    // Then modify it
+    const modifyResult = await router.execute('modify_view', {
+      view_id: viewId,
+      patch: { title: 'Updated Title' },
+    });
+    expect(modifyResult.isError).toBe(false);
+    const parsed = JSON.parse(modifyResult.content);
+    expect(parsed.viewSpec.title).toBe('Updated Title');
+  });
+
+  it('returns error for modify_view with unknown view', async () => {
+    const ctx = createMockContext();
+    const router = new ToolRouter(ctx);
+
+    const result = await router.execute('modify_view', {
+      view_id: 'nonexistent',
+      patch: { title: 'x' },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found');
+  });
+
+  it('returns error for unknown tool', async () => {
+    const ctx = createMockContext();
+    const router = new ToolRouter(ctx);
+
+    const result = await router.execute('unknown_tool', {});
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Unknown tool');
+  });
+
+  it('returns error for invalid get_schema input', async () => {
+    const ctx = createMockContext();
+    const router = new ToolRouter(ctx);
+
+    const result = await router.execute('get_schema', {});
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input');
+  });
+
+  it('catches handler errors and returns them', async () => {
+    const ctx = createMockContext();
+    (ctx.getSchema as any).mockRejectedValue(new Error('Connection failed'));
+    const router = new ToolRouter(ctx);
+
+    const result = await router.execute('get_schema', { source_id: 'broken' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Connection failed');
+  });
+});

--- a/packages/agent/src/tools/router.ts
+++ b/packages/agent/src/tools/router.ts
@@ -1,0 +1,147 @@
+import { queryIRSchema } from '@lightboard/query-ir';
+import { z } from 'zod';
+
+/** Context provided to tool handlers for accessing services. */
+export interface ToolContext {
+  /** Get schema metadata for a data source. */
+  getSchema: (sourceId: string) => Promise<Record<string, unknown>>;
+  /** Execute a query against a data source. */
+  executeQuery: (sourceId: string, queryIR: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  /** Get the current view state. */
+  getCurrentView?: () => Record<string, unknown> | null;
+}
+
+/** Result of a tool execution. */
+export interface ToolExecutionResult {
+  content: string;
+  isError: boolean;
+}
+
+/** Input validation schemas for each tool. */
+const toolInputSchemas = {
+  get_schema: z.object({
+    source_id: z.string().min(1),
+  }),
+  execute_query: z.object({
+    source_id: z.string().min(1),
+    query_ir: z.record(z.unknown()),
+  }),
+  create_view: z.object({
+    view_spec: z.object({
+      title: z.string().optional(),
+      description: z.string().optional(),
+      query: z.record(z.unknown()),
+      chart: z.object({
+        type: z.string(),
+        config: z.record(z.unknown()),
+      }),
+      controls: z.array(z.record(z.unknown())).optional(),
+    }),
+  }),
+  modify_view: z.object({
+    view_id: z.string().min(1),
+    patch: z.record(z.unknown()),
+  }),
+};
+
+/**
+ * Routes tool calls from the LLM to the appropriate handler.
+ * Each handler validates inputs, delegates to services, and returns
+ * structured results (or errors for agent self-correction).
+ */
+export class ToolRouter {
+  private context: ToolContext;
+  private viewStore = new Map<string, Record<string, unknown>>();
+
+  constructor(context: ToolContext) {
+    this.context = context;
+  }
+
+  /** Execute a tool call and return the result. Errors are returned, not thrown. */
+  async execute(toolName: string, input: Record<string, unknown>): Promise<ToolExecutionResult> {
+    try {
+      switch (toolName) {
+        case 'get_schema':
+          return await this.handleGetSchema(input);
+        case 'execute_query':
+          return await this.handleExecuteQuery(input);
+        case 'create_view':
+          return await this.handleCreateView(input);
+        case 'modify_view':
+          return await this.handleModifyView(input);
+        default:
+          return { content: `Unknown tool: ${toolName}`, isError: true };
+      }
+    } catch (err) {
+      return {
+        content: `Tool "${toolName}" failed: ${err instanceof Error ? err.message : String(err)}`,
+        isError: true,
+      };
+    }
+  }
+
+  /** Handle get_schema tool call. */
+  private async handleGetSchema(input: Record<string, unknown>): Promise<ToolExecutionResult> {
+    const parsed = toolInputSchemas.get_schema.safeParse(input);
+    if (!parsed.success) {
+      return { content: `Invalid input: ${parsed.error.message}`, isError: true };
+    }
+
+    const schema = await this.context.getSchema(parsed.data.source_id);
+    return { content: JSON.stringify(schema, null, 2), isError: false };
+  }
+
+  /** Handle execute_query tool call. */
+  private async handleExecuteQuery(input: Record<string, unknown>): Promise<ToolExecutionResult> {
+    const parsed = toolInputSchemas.execute_query.safeParse(input);
+    if (!parsed.success) {
+      return { content: `Invalid input: ${parsed.error.message}`, isError: true };
+    }
+
+    const result = await this.context.executeQuery(parsed.data.source_id, parsed.data.query_ir);
+    return { content: JSON.stringify(result, null, 2), isError: false };
+  }
+
+  /** Handle create_view tool call. */
+  private async handleCreateView(input: Record<string, unknown>): Promise<ToolExecutionResult> {
+    const parsed = toolInputSchemas.create_view.safeParse(input);
+    if (!parsed.success) {
+      return { content: `Invalid input: ${parsed.error.message}`, isError: true };
+    }
+
+    const viewId = `view_${Date.now()}`;
+    const viewSpec = parsed.data.view_spec;
+    this.viewStore.set(viewId, viewSpec);
+
+    return {
+      content: JSON.stringify({ viewId, viewSpec }),
+      isError: false,
+    };
+  }
+
+  /** Handle modify_view tool call. */
+  private async handleModifyView(input: Record<string, unknown>): Promise<ToolExecutionResult> {
+    const parsed = toolInputSchemas.modify_view.safeParse(input);
+    if (!parsed.success) {
+      return { content: `Invalid input: ${parsed.error.message}`, isError: true };
+    }
+
+    const existing = this.viewStore.get(parsed.data.view_id);
+    if (!existing) {
+      return { content: `View "${parsed.data.view_id}" not found`, isError: true };
+    }
+
+    const updated = { ...existing, ...parsed.data.patch };
+    this.viewStore.set(parsed.data.view_id, updated);
+
+    return {
+      content: JSON.stringify({ viewId: parsed.data.view_id, viewSpec: updated }),
+      isError: false,
+    };
+  }
+
+  /** Get a stored view by ID (for testing). */
+  getView(viewId: string): Record<string, unknown> | undefined {
+    return this.viewStore.get(viewId);
+  }
+}

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,28 @@ importers:
         specifier: ^3.1.0
         version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)
 
+  packages/agent:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.52.0
+        version: 0.52.0
+      '@lightboard/connector-sdk':
+        specifier: workspace:*
+        version: link:../connector-sdk
+      '@lightboard/query-ir':
+        specifier: workspace:*
+        version: link:../query-ir
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)
+
   packages/compute:
     dependencies:
       '@duckdb/node-api':
@@ -356,6 +378,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/sdk@0.52.0':
+    resolution: {integrity: sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ==}
+    hasBin: true
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -4833,6 +4859,8 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.52.0': {}
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:


### PR DESCRIPTION
## Summary
- **Provider abstraction** (`provider/`): `LLMProvider` interface with `ClaudeProvider` (Anthropic SDK) and `OpenAICompatibleProvider` (Ollama/vLLM/LiteLLM). Streaming via `AsyncIterable<StreamEvent>`.
- **Tool definitions** (`tools/`): `get_schema`, `execute_query`, `create_view`, `modify_view` with rich input schemas. `ToolRouter` validates inputs (Zod) and dispatches to handlers. Errors returned as results for agent self-correction.
- **System prompt** (`prompt/`): Instructs agent to introspect schemas first, use QueryIR (never raw SQL), create views with thoughtful controls, handle follow-ups, and self-correct on errors. Dynamic context injection for data sources and current view.
- **Conversation management** (`conversation/`): Message history with sliding window truncation when exceeding context limits.
- **Agent class**: Multi-round tool calling loop, streams `AgentEvent` (text, tool_start, tool_end, done), configurable max tool rounds.

Closes #8, closes #22, closes #23, closes #24

## Test plan
- [x] `pnpm typecheck` — all 10 packages clean
- [x] `pnpm test` — 179 tests pass (28 agent + 24 telemetry + 27 viz-core + 37 postgres + 6 sdk + 40 query-ir + 6 compute + 8 db + 3 web)
- [x] CI passes

No UI changes — browser testing not needed. Agent gets wired into the Explore page in D10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)