### PR TITLE
fix: logout navigation + extension disable scripts for testing

### DIFF
--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { Link, useTransitionRouter } from 'next-view-transitions';
+import { Link } from 'next-view-transitions';
 import {
   Compass,
   Database,
@@ -37,13 +37,12 @@ const NAV_ITEMS: NavItem[] = [
  */
 export function Sidebar() {
   const pathname = usePathname();
-  const router = useTransitionRouter();
   const t = useTranslations('nav');
 
   async function handleLogout() {
     await fetch('/api/auth/logout', { method: 'POST' });
-    router.push('/login');
-    router.refresh();
+    // Use hard navigation to clear all client state and let middleware redirect
+    window.location.href = '/login';
   }
 
   return (

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "test:e2e": "turbo test:e2e",
     "typecheck": "turbo typecheck",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
-    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,md}\""
+    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
+    "infra:up": "docker compose up -d",
+    "infra:down": "docker compose down",
+    "infra:reset": "docker compose down -v && docker compose up -d",
+    "cleanup": "node scripts/cleanup.mjs"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/scripts/cleanup.mjs
+++ b/scripts/cleanup.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+/**
+ * Kills all running Lightboard dev servers and stops Docker infrastructure.
+ * Cross-platform: works on Windows, macOS, and Linux.
+ *
+ * Usage: pnpm cleanup
+ */
+
+import { execSync } from 'child_process';
+
+const PORTS = [3000, 3001];
+
+function log(msg) {
+  console.log(`[cleanup] ${msg}`);
+}
+
+// 1. Stop Docker containers
+try {
+  execSync('docker compose down', { stdio: 'pipe', cwd: process.cwd() });
+  log('Docker containers stopped.');
+} catch {
+  log('No Docker containers to stop (or docker not available).');
+}
+
+// 2. Kill processes on dev server ports
+const isWindows = process.platform === 'win32';
+
+for (const port of PORTS) {
+  try {
+    if (isWindows) {
+      const output = execSync(`netstat -ano | findstr :${port}.*LISTENING`, {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const pids = new Set(
+        output
+          .split('\n')
+          .filter((line) => line.includes('LISTENING'))
+          .map((line) => line.trim().split(/\s+/).pop())
+          .filter(Boolean),
+      );
+      for (const pid of pids) {
+        try {
+          execSync(`taskkill /F /PID ${pid}`, { stdio: 'pipe' });
+          log(`Killed process ${pid} on port ${port}.`);
+        } catch {}
+      }
+    } else {
+      execSync(`lsof -ti :${port} | xargs kill -9 2>/dev/null`, { stdio: 'pipe' });
+      log(`Killed process on port ${port}.`);
+    }
+  } catch {
+    // No process on this port — that's fine
+  }
+}
+
+log('All clean.');

--- a/scripts/disable-extensions-for-testing.ps1
+++ b/scripts/disable-extensions-for-testing.ps1
@@ -1,0 +1,88 @@
+<#
+.SYNOPSIS
+    Temporarily disables Chrome/Brave extensions that interfere with browser automation testing.
+
+.DESCRIPTION
+    Password managers, ad blockers, and autofill extensions intercept form interactions
+    and steal focus from the page, causing "Cannot access chrome-extension:// URL" errors
+    in browser automation tools like claude-in-chrome.
+
+    This script renames the Extensions directory so the browser launches clean,
+    then restores it when testing is complete.
+
+.PARAMETER Browser
+    Which browser to target: "chrome" or "brave" (default: chrome)
+
+.PARAMETER Action
+    "disable" to rename Extensions dir, "restore" to bring it back
+
+.EXAMPLE
+    # Before testing:
+    .\scripts\disable-extensions-for-testing.ps1 -Browser chrome -Action disable
+
+    # After testing:
+    .\scripts\disable-extensions-for-testing.ps1 -Browser chrome -Action restore
+#>
+
+param(
+    [ValidateSet("chrome", "brave")]
+    [string]$Browser = "chrome",
+
+    [ValidateSet("disable", "restore")]
+    [string]$Action = "disable"
+)
+
+$paths = @{
+    "chrome" = "$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Extensions"
+    "brave"  = "$env:LOCALAPPDATA\BraveSoftware\Brave-Browser\User Data\Default\Extensions"
+}
+
+$extPath = $paths[$Browser]
+$backupPath = "${extPath}_disabled_for_testing"
+
+if ($Action -eq "disable") {
+    if (Test-Path $extPath) {
+        if (Test-Path $backupPath) {
+            Write-Host "Extensions already disabled for $Browser (backup exists)." -ForegroundColor Yellow
+            return
+        }
+
+        # Check if browser is running
+        $processName = if ($Browser -eq "chrome") { "chrome" } else { "brave" }
+        $running = Get-Process -Name $processName -ErrorAction SilentlyContinue
+        if ($running) {
+            Write-Host "WARNING: Close $Browser before disabling extensions." -ForegroundColor Red
+            Write-Host "Run: taskkill /F /IM ${processName}.exe" -ForegroundColor Yellow
+            return
+        }
+
+        Rename-Item -Path $extPath -NewName "Extensions_disabled_for_testing"
+        New-Item -ItemType Directory -Path $extPath | Out-Null
+        Write-Host "Extensions disabled for $Browser." -ForegroundColor Green
+        Write-Host "Backup at: $backupPath" -ForegroundColor Gray
+        Write-Host "Run with -Action restore when done testing." -ForegroundColor Gray
+    } else {
+        Write-Host "Extensions directory not found: $extPath" -ForegroundColor Red
+    }
+}
+elseif ($Action -eq "restore") {
+    if (Test-Path $backupPath) {
+        # Check if browser is running
+        $processName = if ($Browser -eq "chrome") { "chrome" } else { "brave" }
+        $running = Get-Process -Name $processName -ErrorAction SilentlyContinue
+        if ($running) {
+            Write-Host "WARNING: Close $Browser before restoring extensions." -ForegroundColor Red
+            Write-Host "Run: taskkill /F /IM ${processName}.exe" -ForegroundColor Yellow
+            return
+        }
+
+        # Remove the empty placeholder
+        if (Test-Path $extPath) {
+            Remove-Item -Path $extPath -Recurse -Force
+        }
+        Rename-Item -Path $backupPath -NewName "Extensions"
+        Write-Host "Extensions restored for $Browser." -ForegroundColor Green
+    } else {
+        Write-Host "No backup found. Extensions were not disabled or already restored." -ForegroundColor Yellow
+    }
+}

--- a/scripts/disable-extensions-for-testing.sh
+++ b/scripts/disable-extensions-for-testing.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Temporarily disables Chrome/Brave extensions that interfere with browser automation.
+#
+# Password managers, ad blockers, and autofill extensions intercept form interactions
+# and steal focus, causing "Cannot access chrome-extension:// URL" errors in
+# browser automation tools like claude-in-chrome.
+#
+# Usage:
+#   ./scripts/disable-extensions-for-testing.sh disable [chrome|brave]
+#   ./scripts/disable-extensions-for-testing.sh restore [chrome|brave]
+
+set -euo pipefail
+
+ACTION="${1:-disable}"
+BROWSER="${2:-chrome}"
+
+# Resolve Extensions path based on OS and browser
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+    APPDATA_LOCAL="$LOCALAPPDATA"
+    case "$BROWSER" in
+        chrome) EXT_DIR="$APPDATA_LOCAL/Google/Chrome/User Data/Default/Extensions" ;;
+        brave)  EXT_DIR="$APPDATA_LOCAL/BraveSoftware/Brave-Browser/User Data/Default/Extensions" ;;
+        *) echo "Unknown browser: $BROWSER (use chrome or brave)"; exit 1 ;;
+    esac
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    case "$BROWSER" in
+        chrome) EXT_DIR="$HOME/Library/Application Support/Google/Chrome/Default/Extensions" ;;
+        brave)  EXT_DIR="$HOME/Library/Application Support/BraveSoftware/Brave-Browser/Default/Extensions" ;;
+        *) echo "Unknown browser: $BROWSER"; exit 1 ;;
+    esac
+else
+    case "$BROWSER" in
+        chrome) EXT_DIR="$HOME/.config/google-chrome/Default/Extensions" ;;
+        brave)  EXT_DIR="$HOME/.config/BraveSoftware/Brave-Browser/Default/Extensions" ;;
+        *) echo "Unknown browser: $BROWSER"; exit 1 ;;
+    esac
+fi
+
+BACKUP_DIR="${EXT_DIR}_disabled_for_testing"
+
+case "$ACTION" in
+    disable)
+        if [[ -d "$BACKUP_DIR" ]]; then
+            echo "Extensions already disabled for $BROWSER (backup exists)."
+            exit 0
+        fi
+        if [[ ! -d "$EXT_DIR" ]]; then
+            echo "Extensions directory not found: $EXT_DIR"
+            exit 1
+        fi
+        echo "⚠️  Close $BROWSER before running this script."
+        echo ""
+        mv "$EXT_DIR" "$BACKUP_DIR"
+        mkdir -p "$EXT_DIR"
+        echo "✓ Extensions disabled for $BROWSER."
+        echo "  Backup: $BACKUP_DIR"
+        echo "  Run '$0 restore $BROWSER' when done testing."
+        ;;
+
+    restore)
+        if [[ ! -d "$BACKUP_DIR" ]]; then
+            echo "No backup found. Extensions were not disabled or already restored."
+            exit 0
+        fi
+        echo "⚠️  Close $BROWSER before running this script."
+        echo ""
+        rm -rf "$EXT_DIR"
+        mv "$BACKUP_DIR" "$EXT_DIR"
+        echo "✓ Extensions restored for $BROWSER."
+        ;;
+
+    *)
+        echo "Usage: $0 [disable|restore] [chrome|brave]"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- **Bug #43 fix**: Logout now uses `window.location.href = '/login'` instead of `router.push('/login')` + `router.refresh()`. The transition router's `refresh()` was canceling the push navigation, leaving the user on the dashboard after logout.
- **Testing helper scripts**: PowerShell and Bash scripts to temporarily disable Chrome/Brave extensions during browser automation testing. Password managers and autofill extensions intercept form interactions, causing "Cannot access chrome-extension:// URL" errors.

Fixes #43

## Test plan
- [x] `pnpm typecheck` — all 11 packages clean
- [x] `pnpm lint` — no errors
- [x] E2E tests — 13 pass (including logout redirect test)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)