### PR TITLE
fix: data source dropdown + schema introspection API

### DIFF
--- a/apps/web/src/app/api/data-sources/[id]/schema/route.ts
+++ b/apps/web/src/app/api/data-sources/[id]/schema/route.ts
@@ -1,0 +1,111 @@
+import { dataSources } from '@lightboard/db/schema';
+import { decryptCredentials } from '@lightboard/db/crypto';
+import { eq, and } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { withAuth } from '@/lib/auth';
+import pg from 'pg';
+
+const INTROSPECT_COLUMNS = `
+  SELECT
+    c.table_schema,
+    c.table_name,
+    c.column_name,
+    c.data_type,
+    c.is_nullable,
+    CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END AS is_primary_key
+  FROM information_schema.columns c
+  LEFT JOIN (
+    SELECT kcu.table_schema, kcu.table_name, kcu.column_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+      AND tc.table_schema = kcu.table_schema
+    WHERE tc.constraint_type = 'PRIMARY KEY'
+  ) pk ON c.table_schema = pk.table_schema
+    AND c.table_name = pk.table_name
+    AND c.column_name = pk.column_name
+  WHERE c.table_schema NOT IN ('pg_catalog', 'information_schema')
+  ORDER BY c.table_schema, c.table_name, c.ordinal_position
+`;
+
+/** GET /api/data-sources/[id]/schema — Introspect the data source schema. */
+export const GET = withAuth(async (req, { db, orgId }) => {
+  const segments = req.nextUrl.pathname.split('/');
+  const schemaIdx = segments.indexOf('schema');
+  const id = segments[schemaIdx - 1];
+  if (!id) {
+    return NextResponse.json({ error: 'ID is required' }, { status: 400 });
+  }
+
+  // Get the data source
+  const results = await db
+    .select()
+    .from(dataSources)
+    .where(and(eq(dataSources.id, id), eq(dataSources.orgId, orgId)));
+
+  const source = results[0];
+  if (!source) {
+    return NextResponse.json({ error: 'Data source not found' }, { status: 404 });
+  }
+
+  // Decrypt credentials
+  const masterKey = process.env.ENCRYPTION_MASTER_KEY;
+  if (!masterKey) {
+    return NextResponse.json({ error: 'Encryption key not configured' }, { status: 500 });
+  }
+
+  let connection: Record<string, string>;
+  try {
+    connection = JSON.parse(decryptCredentials(masterKey, orgId, source.credentials));
+  } catch {
+    return NextResponse.json({ error: 'Failed to decrypt credentials' }, { status: 500 });
+  }
+
+  // Connect and introspect
+  const pool = new pg.Pool({
+    host: connection.host,
+    port: parseInt(connection.port ?? '5432', 10),
+    database: connection.database,
+    user: connection.user,
+    password: connection.password,
+    connectionTimeoutMillis: 5000,
+    max: 1,
+  });
+
+  try {
+    const columnsResult = await pool.query(INTROSPECT_COLUMNS);
+
+    // Group columns by table
+    const tableMap = new Map<string, {
+      name: string;
+      schema: string;
+      columns: { name: string; type: string; nullable: boolean; primaryKey: boolean }[];
+    }>();
+
+    for (const row of columnsResult.rows) {
+      const key = `${row.table_schema}.${row.table_name}`;
+      if (!tableMap.has(key)) {
+        tableMap.set(key, {
+          name: row.table_name,
+          schema: row.table_schema,
+          columns: [],
+        });
+      }
+      tableMap.get(key)!.columns.push({
+        name: row.column_name,
+        type: row.data_type,
+        nullable: row.is_nullable === 'YES',
+        primaryKey: row.is_primary_key === true || row.is_primary_key === 't',
+      });
+    }
+
+    return NextResponse.json({ tables: [...tableMap.values()] });
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Introspection failed: ${err instanceof Error ? err.message : String(err)}` },
+      { status: 500 },
+    );
+  } finally {
+    await pool.end();
+  }
+});

--- a/apps/web/src/components/data-sources/data-sources-page-client.tsx
+++ b/apps/web/src/components/data-sources/data-sources-page-client.tsx
@@ -86,9 +86,24 @@ export function DataSourcesPageClient() {
     setView('add');
   }, []);
 
-  const handleBrowseSchema = useCallback((id: string) => {
+  const [schemaTables, setSchemaTables] = useState<{ name: string; schema: string; columns: { name: string; type: string; nullable: boolean; primaryKey: boolean }[] }[]>([]);
+  const [schemaLoading, setSchemaLoading] = useState(false);
+
+  const handleBrowseSchema = useCallback(async (id: string) => {
     setBrowsingSourceId(id);
+    setSchemaTables([]);
+    setSchemaLoading(true);
     setView('schema');
+
+    try {
+      const res = await fetch(`/api/data-sources/${id}/schema`);
+      if (res.ok) {
+        const data = await res.json();
+        setSchemaTables(data.tables ?? []);
+      }
+    } finally {
+      setSchemaLoading(false);
+    }
   }, []);
 
   const handleTestConnection = useCallback(
@@ -121,7 +136,8 @@ export function DataSourcesPageClient() {
     const source = sources.find((s) => s.id === browsingSourceId);
     return (
       <SchemaBrowser
-        tables={[]}
+        tables={schemaTables}
+        loading={schemaLoading}
         onClose={() => { setView('list'); setBrowsingSourceId(null); }}
         sourceName={source?.name ?? ''}
       />

--- a/apps/web/src/components/data-sources/schema-browser.tsx
+++ b/apps/web/src/components/data-sources/schema-browser.tsx
@@ -23,10 +23,11 @@ interface SchemaBrowserProps {
   tables: TableInfo[];
   onClose: () => void;
   sourceName: string;
+  loading?: boolean;
 }
 
 /** Tree view for browsing a data source's schema (tables and columns). */
-export function SchemaBrowser({ tables, onClose, sourceName }: SchemaBrowserProps) {
+export function SchemaBrowser({ tables, onClose, sourceName, loading }: SchemaBrowserProps) {
   const t = useTranslations('dataSources');
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
@@ -54,7 +55,11 @@ export function SchemaBrowser({ tables, onClose, sourceName }: SchemaBrowserProp
         </button>
       </div>
 
-      {tables.length === 0 ? (
+      {loading ? (
+        <p className="text-sm animate-pulse" style={{ color: 'var(--color-muted-foreground)' }}>
+          Loading schema...
+        </p>
+      ) : tables.length === 0 ? (
         <p className="text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
           {t('noTables')}
         </p>

--- a/apps/web/src/components/explore/explore-page-client.tsx
+++ b/apps/web/src/components/explore/explore-page-client.tsx
@@ -8,9 +8,6 @@ import { ChatPanel } from './chat-panel';
 import type { ChatMessageData } from './chat-message';
 import { DataSourceSelector, type DataSourceOption } from './data-source-selector';
 
-/** Mock data sources for Phase 1 (will be fetched from API later). */
-const MOCK_SOURCES: DataSourceOption[] = [];
-
 /**
  * Client-side Explore page component.
  * Split panel: chat on the left, view renderer on the right.
@@ -22,6 +19,29 @@ export function ExplorePageClient() {
   const [selectedSource, setSelectedSource] = useState<string | null>(null);
   const [currentView, setCurrentView] = useState<ViewSpec | null>(null);
   const [viewData, setViewData] = useState<Record<string, unknown>[] | null>(null);
+  const [dataSources, setDataSources] = useState<DataSourceOption[]>([]);
+
+  // Fetch data sources from API on mount
+  useEffect(() => {
+    async function loadSources() {
+      try {
+        const res = await fetch('/api/data-sources');
+        if (res.ok) {
+          const data = await res.json();
+          setDataSources(
+            data.dataSources.map((ds: { id: string; name: string; type: string }) => ({
+              id: ds.id,
+              name: ds.name,
+              type: ds.type,
+            })),
+          );
+        }
+      } catch {
+        // Silently fail — dropdown will be empty
+      }
+    }
+    loadSources();
+  }, []);
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -107,7 +127,7 @@ export function ExplorePageClient() {
       <div className="flex h-full flex-col">
         {/* Data source selector */}
         <DataSourceSelector
-          sources={MOCK_SOURCES}
+          sources={dataSources}
           selectedId={selectedSource}
           onChange={setSelectedSource}
         />


### PR DESCRIPTION
## Summary
- **Bug #46 fix**: Explore page data source dropdown now fetches from `/api/data-sources` on mount instead of using hardcoded empty array
- **Schema introspection API**: New `GET /api/data-sources/[id]/schema` route that decrypts credentials, connects to the target database, introspects `information_schema`, and returns tables/columns/types/primary keys
- **Schema browser wired up**: Data Sources page Schema button now shows live table/column data with loading state

Fixes #46

## Test plan
- [x] `pnpm typecheck` — all 11 packages clean
- [x] `pnpm lint` — no errors
- [x] E2E tests — 13 pass
- [x] Browser: Explore dropdown shows configured sources
- [x] Browser: Schema browser shows cricket DB tables (20+) with expandable columns
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)