### PR TITLE
feat: user-configurable AI model endpoints via Settings page

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -63,7 +63,25 @@
     "createFirst": "Open Explore to create your first view."
   },
   "settings": {
-    "title": "Settings"
+    "title": "Settings",
+    "ai": {
+      "title": "AI Model Configuration",
+      "description": "Configure the AI model used for data exploration.",
+      "providerType": "Provider",
+      "providerClaude": "Claude (Anthropic)",
+      "providerOpenAI": "OpenAI-Compatible",
+      "apiKey": "API Key",
+      "apiKeyPlaceholder": "Enter your API key",
+      "baseUrl": "Base URL",
+      "baseUrlPlaceholder": "https://your-endpoint.com/v1",
+      "model": "Model Name",
+      "modelPlaceholder": "e.g. gpt-4o, claude-sonnet-4-20250514",
+      "save": "Save",
+      "saving": "Saving...",
+      "saved": "AI model configuration saved.",
+      "error": "Failed to save configuration.",
+      "noConfig": "No AI model configured. The agent will use the server default if available."
+    }
   },
   "auth": {
     "login": "Log in",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -4,7 +4,7 @@ import createNextIntlPlugin from 'next-intl/plugin';
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const nextConfig: NextConfig = {
-  transpilePackages: ['@lightboard/ui', '@lightboard/db', '@lightboard/query-ir', '@lightboard/viz-core'],
+  transpilePackages: ['@lightboard/agent', '@lightboard/ui', '@lightboard/db', '@lightboard/query-ir', '@lightboard/viz-core'],
   serverExternalPackages: ['pg', '@node-rs/argon2'],
   devIndicators: false,
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@lightboard/agent": "workspace:*",
     "@lightboard/db": "workspace:*",
     "@lightboard/query-ir": "workspace:*",
     "@lightboard/ui": "workspace:*",

--- a/apps/web/src/app/(dashboard)/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/page.tsx
@@ -1,15 +1,13 @@
-import { useTranslations } from 'next-intl';
+import { AIModelSettings } from '@/components/settings/ai-model-settings';
 
 /**
  * Settings page — application configuration.
- * Sub-pages (Data Sources, etc.) added in later deliverables.
+ * Includes AI model provider settings.
  */
 export default function SettingsPage() {
-  const t = useTranslations('settings');
-
   return (
-    <div className="flex flex-col items-center justify-center py-20">
-      <h2 className="text-2xl font-bold tracking-tight">{t('title')}</h2>
+    <div className="p-6 space-y-6">
+      <AIModelSettings />
     </div>
   );
 }

--- a/apps/web/src/app/api/agent/chat/route.ts
+++ b/apps/web/src/app/api/agent/chat/route.ts
@@ -1,14 +1,12 @@
-import { NextResponse, type NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { withAuth } from '@/lib/auth';
+import { resolveAIProvider } from '@/lib/ai-provider';
 
 /**
  * POST /api/agent/chat — Send a message to the AI agent.
- * Returns the agent's response, tool calls, and any generated ViewSpec.
- *
- * Phase 1 placeholder: returns a mock response explaining that the agent
- * requires a Claude API key to be configured. The full implementation
- * will be wired when the agent package is integrated with real connectors.
+ * Uses the org's configured AI provider, falling back to ANTHROPIC_API_KEY env var.
  */
-export async function POST(req: NextRequest) {
+export const POST = withAuth(async (req, { db, orgId }) => {
   const body = await req.json();
   const { message, sourceId } = body as { message?: string; sourceId?: string };
 
@@ -16,12 +14,12 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Message is required' }, { status: 400 });
   }
 
-  // Check if Claude API key is configured
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  // Resolve AI provider from org settings or env var fallback
+  const provider = await resolveAIProvider(db, orgId);
+  if (!provider) {
     return NextResponse.json({
-      text: 'The AI agent requires an Anthropic API key to be configured. ' +
-        'Set ANTHROPIC_API_KEY in your environment variables to enable the agent. ' +
+      text: 'No AI model configured. Go to Settings to set up your AI provider, ' +
+        'or set the ANTHROPIC_API_KEY environment variable.' +
         `\n\nYour message was: "${message}"` +
         (sourceId ? `\nSelected data source: ${sourceId}` : ''),
       toolCalls: [],
@@ -29,10 +27,12 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  // TODO: Wire up the real agent with ClaudeProvider when connectors are integrated
+  // TODO: Wire up the real Agent class with the resolved provider
+  // For now, acknowledge that a provider is configured
   return NextResponse.json({
-    text: `Agent processing is not yet fully wired. Your question: "${message}"`,
+    text: `AI provider "${provider.name}" is configured. Full agent wiring coming soon.` +
+      `\n\nYour question: "${message}"`,
     toolCalls: [],
     viewSpec: null,
   });
-}
+});

--- a/apps/web/src/app/api/settings/ai/route.ts
+++ b/apps/web/src/app/api/settings/ai/route.ts
@@ -1,0 +1,105 @@
+import { encryptCredentials } from '@lightboard/db/crypto';
+import { organizations } from '@lightboard/db/schema';
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { getAdminDb, withAuth } from '@/lib/auth';
+
+/**
+ * GET /api/settings/ai — Returns the org's AI model configuration.
+ * Never returns the actual API key — only a boolean `hasApiKey`.
+ */
+export const GET = withAuth(async (_req, { orgId }) => {
+  const adminDb = getAdminDb();
+  const [org] = await adminDb
+    .select({ settings: organizations.settings, aiCredentials: organizations.aiCredentials })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
+  if (!org) {
+    return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+  }
+
+  const settings = org.settings as Record<string, unknown> | null;
+  const aiConfig = (settings?.ai as Record<string, unknown>) ?? {};
+
+  return NextResponse.json({
+    providerType: aiConfig.providerType ?? null,
+    baseUrl: aiConfig.baseUrl ?? null,
+    model: aiConfig.model ?? null,
+    hasApiKey: !!org.aiCredentials,
+  });
+});
+
+/**
+ * PUT /api/settings/ai — Save AI model configuration.
+ * Encrypts the API key with per-org key derivation before storing.
+ * If apiKey is "********", skips key update (only updates non-sensitive fields).
+ */
+export const PUT = withAuth(async (req, { orgId }) => {
+  const body = await req.json();
+  const { providerType, apiKey, baseUrl, model } = body as {
+    providerType?: string;
+    apiKey?: string;
+    baseUrl?: string;
+    model?: string;
+  };
+
+  if (!providerType || !['claude', 'openai-compatible'].includes(providerType)) {
+    return NextResponse.json(
+      { error: 'providerType must be "claude" or "openai-compatible"' },
+      { status: 400 },
+    );
+  }
+
+  if (providerType === 'openai-compatible' && !baseUrl) {
+    return NextResponse.json(
+      { error: 'baseUrl is required for openai-compatible provider' },
+      { status: 400 },
+    );
+  }
+
+  const masterKey = process.env.ENCRYPTION_MASTER_KEY;
+  if (!masterKey) {
+    return NextResponse.json({ error: 'Encryption key not configured' }, { status: 500 });
+  }
+
+  const adminDb = getAdminDb();
+
+  // Build the settings.ai object
+  const aiSettings: Record<string, unknown> = { providerType };
+  if (baseUrl) aiSettings.baseUrl = baseUrl;
+  if (model) aiSettings.model = model;
+
+  // Fetch current org to merge settings
+  const [org] = await adminDb
+    .select({ settings: organizations.settings, aiCredentials: organizations.aiCredentials })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
+  if (!org) {
+    return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+  }
+
+  const currentSettings = (org.settings as Record<string, unknown>) ?? {};
+  const updatedSettings = { ...currentSettings, ai: aiSettings };
+
+  // Determine whether to update the encrypted API key
+  const masked = '********';
+  let encryptedKey = org.aiCredentials;
+
+  if (apiKey && apiKey !== masked) {
+    encryptedKey = encryptCredentials(masterKey, orgId, apiKey);
+  }
+
+  await adminDb
+    .update(organizations)
+    .set({
+      settings: updatedSettings,
+      aiCredentials: encryptedKey,
+    })
+    .where(eq(organizations.id, orgId));
+
+  return NextResponse.json({ saved: true });
+});

--- a/apps/web/src/components/settings/ai-model-settings.tsx
+++ b/apps/web/src/components/settings/ai-model-settings.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { Button, Card, CardContent, CardHeader, CardTitle, Input, Label } from '@lightboard/ui';
+import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
+
+/** AI model settings form — lets users configure their AI provider per-org. */
+export function AIModelSettings() {
+  const t = useTranslations('settings.ai');
+  const [providerType, setProviderType] = useState<'claude' | 'openai-compatible'>('openai-compatible');
+  const [apiKey, setApiKey] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
+  const [model, setModel] = useState('');
+  const [hasExistingKey, setHasExistingKey] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+
+  // Load existing config on mount
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/ai');
+        if (res.ok) {
+          const data = await res.json();
+          if (data.providerType) setProviderType(data.providerType);
+          if (data.baseUrl) setBaseUrl(data.baseUrl);
+          if (data.model) setModel(data.model);
+          if (data.hasApiKey) {
+            setHasExistingKey(true);
+            setApiKey('********');
+          }
+        }
+      } catch {
+        // Silently fail — form will show defaults
+      }
+    }
+    load();
+  }, []);
+
+  async function handleSave() {
+    setSaving(true);
+    setFeedback(null);
+    try {
+      const res = await fetch('/api/settings/ai', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ providerType, apiKey, baseUrl, model }),
+      });
+      if (res.ok) {
+        setFeedback({ type: 'success', message: t('saved') });
+        setHasExistingKey(true);
+      } else {
+        const data = await res.json();
+        setFeedback({ type: 'error', message: data.error ?? t('error') });
+      }
+    } catch {
+      setFeedback({ type: 'error', message: t('error') });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card className="max-w-lg">
+      <CardHeader>
+        <CardTitle>{t('title')}</CardTitle>
+        <p className="text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
+          {t('description')}
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Provider Type */}
+        <div className="space-y-2">
+          <Label htmlFor="ai-provider">{t('providerType')}</Label>
+          <select
+            id="ai-provider"
+            value={providerType}
+            onChange={(e) => setProviderType(e.target.value as 'claude' | 'openai-compatible')}
+            className="flex h-10 w-full rounded-md px-3 py-2 text-sm"
+            style={{
+              borderWidth: '1px',
+              borderStyle: 'solid',
+              borderColor: 'var(--color-input)',
+              backgroundColor: 'transparent',
+              color: 'var(--color-foreground)',
+            }}
+          >
+            <option value="openai-compatible">{t('providerOpenAI')}</option>
+            <option value="claude">{t('providerClaude')}</option>
+          </select>
+        </div>
+
+        {/* API Key */}
+        <div className="space-y-2">
+          <Label htmlFor="ai-api-key">{t('apiKey')}</Label>
+          <Input
+            id="ai-api-key"
+            type="password"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            placeholder={t('apiKeyPlaceholder')}
+            onFocus={() => {
+              if (apiKey === '********') setApiKey('');
+            }}
+            onBlur={() => {
+              if (!apiKey && hasExistingKey) setApiKey('********');
+            }}
+          />
+        </div>
+
+        {/* Base URL — only for openai-compatible */}
+        {providerType === 'openai-compatible' && (
+          <div className="space-y-2">
+            <Label htmlFor="ai-base-url">{t('baseUrl')}</Label>
+            <Input
+              id="ai-base-url"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder={t('baseUrlPlaceholder')}
+            />
+          </div>
+        )}
+
+        {/* Model Name */}
+        <div className="space-y-2">
+          <Label htmlFor="ai-model">{t('model')}</Label>
+          <Input
+            id="ai-model"
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            placeholder={t('modelPlaceholder')}
+          />
+        </div>
+
+        {/* Feedback */}
+        {feedback && (
+          <div
+            className="rounded-md p-3 text-sm"
+            style={{
+              backgroundColor: feedback.type === 'success' ? 'rgba(34,197,94,0.1)' : 'rgba(239,68,68,0.1)',
+              color: feedback.type === 'success' ? '#22c55e' : '#ef4444',
+            }}
+          >
+            {feedback.message}
+          </div>
+        )}
+
+        {/* Save */}
+        <Button onClick={handleSave} disabled={saving || !apiKey || apiKey === '********'}>
+          {saving ? t('saving') : t('save')}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/ai-provider.ts
+++ b/apps/web/src/lib/ai-provider.ts
@@ -1,0 +1,71 @@
+import { decryptCredentials } from '@lightboard/db/crypto';
+import { organizations } from '@lightboard/db/schema';
+import { eq } from 'drizzle-orm';
+import {
+  ClaudeProvider,
+  type LLMProvider,
+  OpenAICompatibleProvider,
+} from '@lightboard/agent';
+import type { Database } from '@lightboard/db';
+
+/** AI config stored in organizations.settings.ai */
+interface AIConfig {
+  providerType: 'claude' | 'openai-compatible';
+  baseUrl?: string;
+  model?: string;
+}
+
+/**
+ * Resolves the AI provider for an organization.
+ *
+ * 1. If the org has AI config + encrypted credentials in the DB → use those
+ * 2. Fallback: if ANTHROPIC_API_KEY env var exists → use ClaudeProvider
+ * 3. Neither → return null (caller should return 503)
+ */
+export async function resolveAIProvider(
+  db: Database,
+  orgId: string,
+): Promise<LLMProvider | null> {
+  // Query org settings and AI credentials
+  const [org] = await db
+    .select({ settings: organizations.settings, aiCredentials: organizations.aiCredentials })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
+  if (org?.aiCredentials) {
+    const masterKey = process.env.ENCRYPTION_MASTER_KEY;
+    if (!masterKey) return null;
+
+    try {
+      const apiKey = decryptCredentials(masterKey, orgId, org.aiCredentials);
+      const settings = org.settings as Record<string, unknown> | null;
+      const aiConfig = settings?.ai as AIConfig | undefined;
+      const providerType = aiConfig?.providerType ?? 'openai-compatible';
+
+      if (providerType === 'claude') {
+        return new ClaudeProvider({
+          apiKey,
+          model: aiConfig?.model,
+        });
+      }
+
+      // Default: openai-compatible
+      return new OpenAICompatibleProvider({
+        baseUrl: aiConfig?.baseUrl ?? 'https://api.openai.com',
+        apiKey,
+        model: aiConfig?.model ?? 'gpt-4o',
+      });
+    } catch {
+      // Decryption failed — fall through to env var fallback
+    }
+  }
+
+  // Fallback: environment variable
+  const envKey = process.env.ANTHROPIC_API_KEY;
+  if (envKey) {
+    return new ClaudeProvider({ apiKey: envKey });
+  }
+
+  return null;
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -11,6 +11,7 @@
     "plugins": [{ "name": "next" }],
     "paths": {
       "@/*": ["./src/*"],
+      "@lightboard/agent": ["../../packages/agent/src"],
       "@lightboard/db": ["../../packages/db/src"],
       "@lightboard/db/*": ["../../packages/db/src/*"],
       "@lightboard/query-ir": ["../../packages/query-ir/src"],

--- a/packages/db/src/schema/organizations.ts
+++ b/packages/db/src/schema/organizations.ts
@@ -6,6 +6,7 @@ export const organizations = pgTable('organizations', {
   name: text('name').notNull(),
   slug: text('slug').notNull().unique(),
   settings: jsonb('settings').default({}).notNull(),
+  aiCredentials: text('ai_credentials'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp('updated_at', { withTimezone: true })
     .defaultNow()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@lightboard/agent':
+        specifier: workspace:*
+        version: link:../../packages/agent
       '@lightboard/db':
         specifier: workspace:*
         version: link:../../packages/db


### PR DESCRIPTION
## Summary
Users can now configure their own AI provider via Settings instead of relying on `ANTHROPIC_API_KEY` env var.

- **DB schema**: `aiCredentials` column on `organizations` for encrypted API key (AES-256-GCM per-org)
- **Settings API**: GET/PUT `/api/settings/ai` — config stored in `organizations.settings.ai` JSONB
- **Provider resolution**: `resolveAIProvider(db, orgId)` — org config first, env var fallback, null if neither
- **Settings UI**: Provider dropdown (OpenAI-Compatible/Claude), API key, base URL, model name
- **Agent chat route**: Uses resolved provider instead of hardcoded env var

## Test plan
- [x] `pnpm typecheck` — 11 packages clean
- [x] `pnpm lint` — no errors
- [x] `pnpm test` — 203 tests pass
- [x] E2E tests — 13 pass
- [x] API: save config → GET returns it with hasApiKey=true → agent resolves provider
- [x] API: masked key update preserves existing key
- [x] API: validation rejects missing baseUrl for openai-compatible
- [x] Browser: Settings page renders, save works, persists across navigation
- [x] Browser: Explore confirms provider is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)