### PR TITLE
feat: sub-agent interfaces and query agent extraction (D-1.5.1)

### DIFF
--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -1,0 +1,8 @@
+export { QueryAgent, type QueryAgentConfig } from './query-agent';
+export type {
+  AgentTask,
+  SubAgent,
+  SubAgentResult,
+  SubAgentRole,
+  ToolCallRecord,
+} from './types';

--- a/packages/agent/src/agents/query-agent.test.ts
+++ b/packages/agent/src/agents/query-agent.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgentEvent } from '../agent';
+import type { LLMProvider, StreamEvent, ToolContext } from '../index';
+
+import { QueryAgent } from './query-agent';
+import type { AgentTask } from './types';
+
+/** Creates a mock provider that yields predefined event sequences. */
+function mockProvider(eventSequences: StreamEvent[][]): LLMProvider {
+  let callIndex = 0;
+  return {
+    name: 'mock',
+    async *chat() {
+      const events = eventSequences[callIndex] ?? [
+        { type: 'message_end' as const, stopReason: 'end_turn' },
+      ];
+      callIndex++;
+      for (const event of events) {
+        yield event;
+      }
+    },
+  };
+}
+
+/** Creates a mock tool context with schema and query capabilities. */
+function mockToolContext(): ToolContext {
+  return {
+    getSchema: vi.fn().mockResolvedValue({
+      tables: [
+        {
+          name: 'orders',
+          columns: [
+            { name: 'id', type: 'integer' },
+            { name: 'amount', type: 'numeric' },
+            { name: 'region', type: 'varchar' },
+          ],
+        },
+      ],
+    }),
+    executeQuery: vi.fn().mockResolvedValue({
+      rows: [
+        { region: 'North', total: 5000 },
+        { region: 'South', total: 3200 },
+      ],
+      rowCount: 2,
+    }),
+    runSQL: vi.fn().mockResolvedValue({
+      rows: [{ count: 42 }],
+      rowCount: 1,
+    }),
+  };
+}
+
+/** Collects all AgentEvents from the query agent's chat generator. */
+async function collectEvents(
+  agent: QueryAgent,
+  task: AgentTask,
+): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of agent.chat(task)) {
+    events.push(event);
+  }
+  return events;
+}
+
+/** Creates a standard AgentTask for testing. */
+function makeTask(instruction: string): AgentTask {
+  return {
+    instruction,
+    context: {
+      dataSources: [
+        {
+          id: 'pg-main',
+          name: 'Main DB',
+          type: 'postgres',
+          cachedSchema: {
+            tables: [
+              {
+                name: 'orders',
+                schema: 'public',
+                columns: [
+                  { name: 'id', type: 'integer', nullable: false, primaryKey: true },
+                  { name: 'amount', type: 'numeric', nullable: false, primaryKey: false },
+                  { name: 'region', type: 'varchar', nullable: true, primaryKey: false },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    },
+    conversationId: 'test-conv-1',
+  };
+}
+
+describe('QueryAgent', () => {
+  it('implements SubAgent interface with correct role', () => {
+    const agent = new QueryAgent({
+      provider: mockProvider([]),
+      toolContext: mockToolContext(),
+    });
+
+    expect(agent.role).toBe('query');
+    expect(agent.id).toMatch(/^query-agent-/);
+  });
+
+  it('streams text response without tool calls', async () => {
+    const agent = new QueryAgent({
+      provider: mockProvider([
+        [
+          { type: 'text_delta', text: 'The schema has an orders table.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+    });
+
+    const events = await collectEvents(agent, makeTask('Describe the schema'));
+
+    const textEvents = events.filter((e) => e.type === 'text');
+    expect(textEvents).toHaveLength(1);
+    expect(events.some((e) => e.type === 'done')).toBe(true);
+  });
+
+  it('executes execute_query tool and returns results', async () => {
+    const ctx = mockToolContext();
+    const agent = new QueryAgent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'execute_query' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'execute_query',
+            input: {
+              source_id: 'pg-main',
+              query_ir: {
+                source: 'pg-main',
+                table: 'orders',
+                select: [{ field: 'region' }],
+                aggregations: [{ function: 'sum', field: { field: 'amount' }, alias: 'total' }],
+                groupBy: [{ field: 'region' }],
+                orderBy: [],
+                joins: [],
+                limit: 100,
+              },
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'Query executed.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: ctx,
+    });
+
+    const events = await collectEvents(agent, makeTask('Sum amount by region'));
+
+    expect(events.some((e) => e.type === 'tool_start')).toBe(true);
+    const toolEnd = events.find((e) => e.type === 'tool_end') as Extract<AgentEvent, { type: 'tool_end' }>;
+    expect(toolEnd).toBeDefined();
+    expect(toolEnd.name).toBe('execute_query');
+    expect(toolEnd.isError).toBe(false);
+    expect(ctx.executeQuery).toHaveBeenCalled();
+  });
+
+  it('executes run_sql tool for complex queries', async () => {
+    const ctx = mockToolContext();
+    const agent = new QueryAgent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'run_sql' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'run_sql',
+            input: {
+              source_id: 'pg-main',
+              sql: 'SELECT COUNT(*) as count FROM orders',
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'Found 42 orders.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: ctx,
+    });
+
+    const events = await collectEvents(agent, makeTask('Count all orders'));
+
+    const toolEnd = events.find((e) => e.type === 'tool_end') as Extract<AgentEvent, { type: 'tool_end' }>;
+    expect(toolEnd.name).toBe('run_sql');
+    expect(toolEnd.isError).toBe(false);
+    expect(ctx.runSQL).toHaveBeenCalledWith('pg-main', 'SELECT COUNT(*) as count FROM orders');
+  });
+
+  it('rejects tools not in the query tool set', async () => {
+    const agent = new QueryAgent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'create_view' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'create_view',
+            input: { view_spec: { query: {}, chart: { type: 'bar', config: {} } } },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'Sorry, I cannot create views.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+    });
+
+    const events = await collectEvents(agent, makeTask('Create a chart'));
+
+    const toolEnd = events.find((e) => e.type === 'tool_end') as Extract<AgentEvent, { type: 'tool_end' }>;
+    expect(toolEnd.isError).toBe(true);
+    expect(toolEnd.result).toContain('not available');
+  });
+
+  it('handles tool errors and self-corrects', async () => {
+    const ctx = mockToolContext();
+    (ctx.executeQuery as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('column "foo" does not exist'))
+      .mockResolvedValueOnce({ rows: [{ count: 10 }], rowCount: 1 });
+
+    const agent = new QueryAgent({
+      provider: mockProvider([
+        // First attempt: query fails
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'execute_query' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'execute_query',
+            input: { source_id: 'pg-main', query_ir: { source: 'pg-main', table: 'orders', select: [{ field: 'foo' }], aggregations: [], groupBy: [], orderBy: [], joins: [] } },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Second attempt: agent fixes query
+        [
+          { type: 'tool_call_start', id: 'tc_2', name: 'execute_query' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_2',
+            name: 'execute_query',
+            input: { source_id: 'pg-main', query_ir: { source: 'pg-main', table: 'orders', select: [{ field: 'region' }], aggregations: [], groupBy: [], orderBy: [], joins: [] } },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Final response
+        [
+          { type: 'text_delta', text: 'Fixed and got results.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: ctx,
+    });
+
+    const events = await collectEvents(agent, makeTask('Get region data'));
+
+    const toolEnds = events.filter((e) => e.type === 'tool_end') as Array<Extract<AgentEvent, { type: 'tool_end' }>>;
+    expect(toolEnds).toHaveLength(2);
+    expect(toolEnds[0]!.isError).toBe(true);
+    expect(toolEnds[1]!.isError).toBe(false);
+  });
+
+  it('stops after maxRounds', async () => {
+    const infiniteProvider: LLMProvider = {
+      name: 'mock',
+      async *chat() {
+        yield { type: 'tool_call_start' as const, id: 'tc', name: 'get_schema' };
+        yield {
+          type: 'tool_call_end' as const,
+          id: 'tc',
+          name: 'get_schema',
+          input: { source_id: 'x' },
+        };
+        yield { type: 'message_end' as const, stopReason: 'tool_use' };
+      },
+    };
+
+    const agent = new QueryAgent({
+      provider: infiniteProvider,
+      toolContext: mockToolContext(),
+      maxRounds: 2,
+    });
+
+    const events = await collectEvents(agent, makeTask('loop forever'));
+
+    const done = events.find((e) => e.type === 'done') as Extract<AgentEvent, { type: 'done' }>;
+    expect(done).toBeDefined();
+  });
+
+  it('run() returns structured SubAgentResult', async () => {
+    const agent = new QueryAgent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'execute_query' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'execute_query',
+            input: {
+              source_id: 'pg-main',
+              query_ir: { source: 'pg-main', table: 'orders', select: [{ field: 'region' }], aggregations: [], groupBy: [], orderBy: [], joins: [] },
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'Done.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+    });
+
+    const result = await agent.run(makeTask('Get regions'));
+
+    expect(result.agentId).toMatch(/^query-agent-/);
+    expect(result.role).toBe('query');
+    expect(result.success).toBe(true);
+    expect(result.toolCalls.length).toBeGreaterThan(0);
+    expect(result.toolCalls[0]!.name).toBe('execute_query');
+  });
+
+  it('builds system prompt with schema context', async () => {
+    let capturedSystem: string | undefined;
+
+    const captureProvider: LLMProvider = {
+      name: 'mock',
+      async *chat(_messages, _tools, options) {
+        capturedSystem = options?.system;
+        yield { type: 'text_delta' as const, text: 'ok' };
+        yield { type: 'message_end' as const, stopReason: 'end_turn' };
+      },
+    };
+
+    const agent = new QueryAgent({
+      provider: captureProvider,
+      toolContext: mockToolContext(),
+    });
+
+    await collectEvents(agent, makeTask('test'));
+
+    expect(capturedSystem).toBeDefined();
+    expect(capturedSystem).toContain('Query Agent');
+    expect(capturedSystem).toContain('orders');
+    expect(capturedSystem).toContain('pg-main');
+  });
+
+  it('only passes query tools to the LLM', async () => {
+    let capturedTools: unknown;
+
+    const captureProvider: LLMProvider = {
+      name: 'mock',
+      async *chat(_messages, tools) {
+        capturedTools = tools;
+        yield { type: 'text_delta' as const, text: 'ok' };
+        yield { type: 'message_end' as const, stopReason: 'end_turn' };
+      },
+    };
+
+    const agent = new QueryAgent({
+      provider: captureProvider,
+      toolContext: mockToolContext(),
+    });
+
+    await collectEvents(agent, makeTask('test'));
+
+    const toolNames = (capturedTools as Array<{ name: string }>).map((t) => t.name);
+    expect(toolNames).toContain('get_schema');
+    expect(toolNames).toContain('execute_query');
+    expect(toolNames).toContain('run_sql');
+    expect(toolNames).not.toContain('create_view');
+    expect(toolNames).not.toContain('modify_view');
+  });
+});

--- a/packages/agent/src/agents/query-agent.ts
+++ b/packages/agent/src/agents/query-agent.ts
@@ -1,0 +1,235 @@
+import type { AgentEvent } from '../agent';
+import { buildQueryPrompt } from '../prompt/query-prompt';
+import type { LLMProvider, ToolCallResult } from '../provider/types';
+import { queryTools } from '../tools/query-tools';
+import { ToolRouter, type ToolContext } from '../tools/router';
+
+import type {
+  AgentTask,
+  SubAgent,
+  SubAgentResult,
+  ToolCallRecord,
+} from './types';
+
+/** Configuration for creating a QueryAgent. */
+export interface QueryAgentConfig {
+  /** LLM provider for the query agent's own conversation. */
+  provider: LLMProvider;
+  /** Tool context connecting to data source services. */
+  toolContext: ToolContext;
+  /** Maximum tool call rounds before stopping (default: 5). */
+  maxRounds?: number;
+}
+
+/**
+ * Query Agent specialist — handles schema exploration and data retrieval.
+ *
+ * Runs its own LLM conversation with a focused system prompt containing
+ * schema details and QueryIR specification. Has access to get_schema,
+ * execute_query, and run_sql tools only.
+ *
+ * Returns structured SubAgentResult with query results data.
+ */
+export class QueryAgent implements SubAgent {
+  readonly id: string;
+  readonly role = 'query' as const;
+
+  private provider: LLMProvider;
+  private toolRouter: ToolRouter;
+  private maxRounds: number;
+
+  constructor(config: QueryAgentConfig) {
+    this.id = `query-agent-${Date.now()}`;
+    this.provider = config.provider;
+    this.toolRouter = new ToolRouter(config.toolContext, queryTools);
+    this.maxRounds = config.maxRounds ?? 5;
+  }
+
+  /**
+   * Execute a query task. Yields AgentEvents for transparency logging,
+   * then returns a structured SubAgentResult via the final 'done' event.
+   *
+   * The leader collects tool_start/tool_end events but does NOT forward
+   * text events to the user — only the leader streams to the user.
+   */
+  async *chat(task: AgentTask): AsyncGenerator<AgentEvent> {
+    const toolCallLog: ToolCallRecord[] = [];
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let resultData: Record<string, unknown> = {};
+    let lastError: string | undefined;
+
+    // Build focused system prompt with schema context
+    const dataSources = (task.context.dataSources ?? []) as Array<{
+      id: string;
+      name: string;
+      type: string;
+      cachedSchema?: { tables: { name: string; schema: string; columns: { name: string; type: string; nullable: boolean; primaryKey: boolean }[] }[] } | null;
+    }>;
+
+    const systemPrompt = buildQueryPrompt({ dataSources });
+
+    // Start with the task instruction as a user message
+    const messages: Array<{ role: 'user' | 'assistant' | 'system'; content: string; toolCalls?: ToolCallResult[]; toolResults?: Array<{ toolCallId: string; content: string; isError?: boolean }> }> = [
+      { role: 'user', content: task.instruction },
+    ];
+
+    for (let round = 0; round < this.maxRounds; round++) {
+      const toolCalls: ToolCallResult[] = [];
+      const toolInputBuffers = new Map<string, string>();
+      let textContent = '';
+      let hasToolCalls = false;
+
+      const stream = this.provider.chat(messages, queryTools, {
+        system: systemPrompt,
+      });
+
+      for await (const event of stream) {
+        switch (event.type) {
+          case 'text_delta':
+            textContent += event.text;
+            yield { type: 'text', text: event.text };
+            break;
+
+          case 'tool_call_start':
+            hasToolCalls = true;
+            toolInputBuffers.set(event.id, '');
+            toolCalls.push({ id: event.id, name: event.name, input: {} });
+            yield { type: 'tool_start', name: event.name, id: event.id };
+            break;
+
+          case 'tool_call_delta': {
+            const existing = toolInputBuffers.get(event.id) ?? '';
+            toolInputBuffers.set(event.id, existing + event.input);
+            break;
+          }
+
+          case 'tool_call_end': {
+            const tc = toolCalls.find((t) => t.id === event.id);
+            if (tc) tc.input = event.input;
+            break;
+          }
+
+          case 'message_end':
+            if (hasToolCalls) {
+              for (const tc of toolCalls) {
+                if (Object.keys(tc.input).length === 0) {
+                  const raw = toolInputBuffers.get(tc.id);
+                  if (raw) {
+                    try { tc.input = JSON.parse(raw); } catch { /* ignore */ }
+                  }
+                }
+              }
+            }
+            break;
+        }
+      }
+
+      // Store assistant message
+      messages.push({
+        role: 'assistant',
+        content: textContent,
+        toolCalls: hasToolCalls ? toolCalls : undefined,
+      });
+
+      // If no tool calls, the agent is done reasoning
+      if (!hasToolCalls) {
+        resultData = { text: textContent };
+        break;
+      }
+
+      // Execute tool calls
+      const toolResults: Array<{ toolCallId: string; content: string; isError?: boolean }> = [];
+      for (const tc of toolCalls) {
+        const startTime = Date.now();
+        const result = await this.toolRouter.execute(tc.name, tc.input);
+        const durationMs = Date.now() - startTime;
+
+        toolCallLog.push({
+          name: tc.name,
+          input: tc.input,
+          result: result.content,
+          isError: result.isError,
+          durationMs,
+        });
+
+        toolResults.push({
+          toolCallId: tc.id,
+          content: result.content,
+          isError: result.isError,
+        });
+
+        if (result.isError) {
+          lastError = result.content;
+        } else {
+          lastError = undefined;
+          // Capture the last successful query result as the output
+          try {
+            resultData = JSON.parse(result.content) as Record<string, unknown>;
+          } catch {
+            resultData = { raw: result.content };
+          }
+        }
+
+        yield { type: 'tool_end', name: tc.name, result: result.content, isError: result.isError };
+      }
+
+      // Feed tool results back for next round
+      messages.push({
+        role: 'user',
+        content: '',
+        toolResults,
+      });
+    }
+
+    // Build the final SubAgentResult and attach it to the done event
+    const agentResult: SubAgentResult = {
+      agentId: this.id,
+      role: this.role,
+      success: !lastError,
+      data: resultData,
+      toolCalls: toolCallLog,
+      tokenUsage: { input: totalInputTokens, output: totalOutputTokens },
+      error: lastError,
+    };
+
+    yield {
+      type: 'done',
+      stopReason: lastError ? 'error' : 'end_turn',
+      ...(agentResult as unknown as Record<string, never>),
+    };
+  }
+
+  /**
+   * Run a query task and return the structured result directly.
+   * Convenience method that consumes the async generator internally.
+   */
+  async run(task: AgentTask): Promise<SubAgentResult> {
+    const toolCallLog: ToolCallRecord[] = [];
+    let resultData: Record<string, unknown> = {};
+    let lastError: string | undefined;
+
+    for await (const event of this.chat(task)) {
+      if (event.type === 'tool_end') {
+        // toolCallLog is already populated via chat()
+      }
+      if (event.type === 'done') {
+        // Extract the SubAgentResult we attached to the done event
+        const doneWithResult = event as unknown as Record<string, unknown>;
+        if (doneWithResult.agentId) {
+          return doneWithResult as unknown as SubAgentResult;
+        }
+      }
+    }
+
+    return {
+      agentId: this.id,
+      role: this.role,
+      success: !lastError,
+      data: resultData,
+      toolCalls: toolCallLog,
+      tokenUsage: { input: 0, output: 0 },
+      error: lastError,
+    };
+  }
+}

--- a/packages/agent/src/agents/types.ts
+++ b/packages/agent/src/agents/types.ts
@@ -1,0 +1,78 @@
+import type { AgentEvent } from '../agent';
+
+/**
+ * Roles a sub-agent can fulfill in the multi-agent orchestration.
+ * Each role has a focused context window and tool set.
+ */
+export type SubAgentRole = 'query' | 'view' | 'insights';
+
+/**
+ * Contract that every sub-agent must implement.
+ * Sub-agents are headless — they run their own LLM conversation internally
+ * and return structured results. Only the leader streams text to the user.
+ */
+export interface SubAgent {
+  /** Unique identifier for this agent instance. */
+  readonly id: string;
+  /** The specialist role this agent fulfills. */
+  readonly role: SubAgentRole;
+  /**
+   * Execute a task and yield AgentEvents as the sub-agent works.
+   * The leader collects tool_start/tool_end events for transparency
+   * but does NOT forward text events to the user.
+   */
+  chat(task: AgentTask): AsyncGenerator<AgentEvent>;
+}
+
+/**
+ * Task handed from the leader agent to a sub-agent.
+ * Contains the instruction and role-specific context payload.
+ */
+export interface AgentTask {
+  /** Natural language instruction describing what the sub-agent should do. */
+  instruction: string;
+  /** Role-specific context payload (e.g., schema for query agent, data summary for view agent). */
+  context: Record<string, unknown>;
+  /** Conversation ID for tracing and scratchpad association. */
+  conversationId: string;
+  /** Parent span ID for distributed tracing. */
+  parentSpanId?: string;
+}
+
+/**
+ * Record of a single tool call made by a sub-agent.
+ * Used for transparency logging in the leader's response.
+ */
+export interface ToolCallRecord {
+  /** Tool name that was called. */
+  name: string;
+  /** Input passed to the tool. */
+  input: Record<string, unknown>;
+  /** Result returned by the tool. */
+  result: string;
+  /** Whether the tool call errored. */
+  isError: boolean;
+  /** Duration of the tool call in milliseconds. */
+  durationMs: number;
+}
+
+/**
+ * Structured result returned by a sub-agent to the leader.
+ * Contains the role-specific output data, tool call log, and token usage.
+ */
+export interface SubAgentResult {
+  /** ID of the sub-agent that produced this result. */
+  agentId: string;
+  /** Role of the sub-agent. */
+  role: SubAgentRole;
+  /** Whether the sub-agent completed its task successfully. */
+  success: boolean;
+  /** Role-specific output data (e.g., query results, ViewSpec, insights). */
+  data: Record<string, unknown>;
+  /** Log of all tool calls made during execution. */
+  toolCalls: ToolCallRecord[];
+  /** Token usage for the sub-agent's LLM calls. */
+  tokenUsage: { input: number; output: number };
+  /** Error message if the sub-agent failed. */
+  error?: string;
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,13 @@
 export { Agent, type AgentConfig, type AgentDataSource, type AgentEvent } from './agent';
+export {
+  QueryAgent,
+  type QueryAgentConfig,
+  type AgentTask,
+  type SubAgent,
+  type SubAgentResult,
+  type SubAgentRole,
+  type ToolCallRecord,
+} from './agents';
 export { ConversationManager } from './conversation';
 export {
   ClaudeProvider,
@@ -11,5 +20,5 @@ export {
   type StreamEvent,
   type ToolDefinition,
 } from './provider';
-export { buildSystemPrompt } from './prompt';
-export { agentTools, ToolRouter, type ToolContext, type ToolExecutionResult } from './tools';
+export { buildSystemPrompt, buildQueryPrompt } from './prompt';
+export { agentTools, queryTools, viewTools, ToolRouter, type ToolContext, type ToolExecutionResult } from './tools';

--- a/packages/agent/src/prompt/index.ts
+++ b/packages/agent/src/prompt/index.ts
@@ -1,1 +1,2 @@
 export { buildSystemPrompt } from './system';
+export { buildQueryPrompt } from './query-prompt';

--- a/packages/agent/src/prompt/query-prompt.ts
+++ b/packages/agent/src/prompt/query-prompt.ts
@@ -1,0 +1,77 @@
+/**
+ * Data source context with schema for building the query agent's system prompt.
+ * Mirrors the shape used by the main system prompt builder.
+ */
+interface DataSourceContext {
+  id: string;
+  name: string;
+  type: string;
+  cachedSchema?: {
+    tables: {
+      name: string;
+      schema: string;
+      columns: { name: string; type: string; nullable: boolean; primaryKey: boolean }[];
+    }[];
+  } | null;
+}
+
+/**
+ * Builds a focused system prompt for the Query Agent specialist.
+ * Contains schema details and QueryIR specification — no chart or view knowledge.
+ * Designed to stay under ~2K tokens for efficient context usage.
+ */
+export function buildQueryPrompt(context: {
+  dataSources: DataSourceContext[];
+}): string {
+  const parts = [QUERY_AGENT_INSTRUCTIONS];
+
+  for (const ds of context.dataSources) {
+    parts.push(`\n### Data Source: "${ds.name}" (id: "${ds.id}", type: ${ds.type})`);
+
+    if (ds.cachedSchema && ds.cachedSchema.tables.length > 0) {
+      parts.push('Tables:');
+      for (const table of ds.cachedSchema.tables) {
+        const cols = table.columns
+          .map((c) => `  - ${c.name} (${c.type}${c.primaryKey ? ', PK' : ''}${c.nullable ? ', nullable' : ''})`)
+          .join('\n');
+        parts.push(`${table.name}:\n${cols}`);
+      }
+    } else {
+      parts.push('Schema not cached — use get_schema to discover tables.');
+    }
+  }
+
+  return parts.join('\n');
+}
+
+const QUERY_AGENT_INSTRUCTIONS = `You are Lightboard's Query Agent — a data retrieval specialist.
+Your job: given a data question, explore schemas and execute queries to retrieve the answer.
+
+## Rules
+
+1. Schema is provided below. Only call get_schema if it says "not cached".
+2. Use execute_query with QueryIR for single-table queries.
+3. Use run_sql for JOINs or complex SQL that QueryIR cannot express.
+4. Return data — do NOT create views or charts. That is another agent's job.
+5. If a query fails, read the error, fix the query, and retry once.
+6. Be efficient: 1-2 tool calls max.
+
+## QueryIR Specification
+
+\`\`\`
+{
+  source: string,           // Data source ID (REQUIRED)
+  table: string,            // Primary table name (REQUIRED)
+  select: FieldRef[],       // [{field: "col", alias?: "name"}]
+  filter?: FilterClause,    // {field: {field: "col"}, operator: "eq"|"neq"|"gt"|"gte"|"lt"|"lte"|"in"|"like"|"is_null", value: ...}
+  aggregations: Agg[],      // [{function: "sum"|"avg"|"count"|"count_distinct"|"min"|"max", field: {field: "col"}, alias: "name"}]
+  groupBy: FieldRef[],      // [{field: "col"}]
+  orderBy: OrderClause[],   // [{field: {field: "col"}, direction: "asc"|"desc"}]
+  joins: JoinClause[],      // [{type: "inner"|"left", table: "name", alias: "t", on: FilterClause}]
+  limit?: number
+}
+\`\`\`
+
+RULES:
+- aggregations, groupBy, orderBy, joins MUST be arrays (use [] if empty)
+- For COUNT(*): {function: "count", field: {field: "*"}, alias: "total"}`;

--- a/packages/agent/src/tools/index.ts
+++ b/packages/agent/src/tools/index.ts
@@ -1,2 +1,4 @@
 export { agentTools } from './definitions';
+export { queryTools } from './query-tools';
+export { viewTools } from './view-tools';
 export { ToolRouter, type ToolContext, type ToolExecutionResult } from './router';

--- a/packages/agent/src/tools/query-tools.ts
+++ b/packages/agent/src/tools/query-tools.ts
@@ -1,0 +1,79 @@
+import type { ToolDefinition } from '../provider/types';
+
+/**
+ * Tool definitions for the Query Agent specialist.
+ * These tools focus on schema exploration and data retrieval.
+ */
+export const queryTools: ToolDefinition[] = [
+  {
+    name: 'get_schema',
+    description:
+      'Get the schema (tables, columns, types, relationships) of a connected data source. ' +
+      'Always call this before writing a query to understand what data is available.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source_id: {
+          type: 'string',
+          description: 'The ID of the data source to introspect',
+        },
+      },
+      required: ['source_id'],
+    },
+  },
+  {
+    name: 'execute_query',
+    description:
+      'Execute a query against a data source using QueryIR (not raw SQL). ' +
+      'Returns the query results. Use get_schema first to understand the available tables and columns.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source_id: {
+          type: 'string',
+          description: 'The data source to query',
+        },
+        query_ir: {
+          type: 'object',
+          description: 'The QueryIR document describing the query',
+          properties: {
+            source: { type: 'string' },
+            table: { type: 'string' },
+            select: { type: 'array', items: { type: 'object' } },
+            filter: { type: 'object' },
+            aggregations: { type: 'array', items: { type: 'object' } },
+            groupBy: { type: 'array', items: { type: 'object' } },
+            orderBy: { type: 'array', items: { type: 'object' } },
+            timeRange: { type: 'object' },
+            joins: { type: 'array', items: { type: 'object' } },
+            limit: { type: 'number' },
+            offset: { type: 'number' },
+          },
+          required: ['source', 'table'],
+        },
+      },
+      required: ['source_id', 'query_ir'],
+    },
+  },
+  {
+    name: 'run_sql',
+    description:
+      'Execute a read-only SELECT SQL query directly against a data source. ' +
+      'Use this for complex queries involving JOINs that are hard to express in QueryIR. ' +
+      'Only SELECT queries are allowed. Results are limited to 1000 rows.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source_id: {
+          type: 'string',
+          description: 'The data source to query',
+        },
+        sql: {
+          type: 'string',
+          description: 'A read-only SELECT SQL query',
+        },
+      },
+      required: ['source_id', 'sql'],
+    },
+  },
+];

--- a/packages/agent/src/tools/router.test.ts
+++ b/packages/agent/src/tools/router.test.ts
@@ -94,7 +94,7 @@ describe('ToolRouter', () => {
 
     const result = await router.execute('unknown_tool', {});
     expect(result.isError).toBe(true);
-    expect(result.content).toContain('Unknown tool');
+    expect(result.content).toContain('not available');
   });
 
   it('returns error for invalid get_schema input', async () => {

--- a/packages/agent/src/tools/router.ts
+++ b/packages/agent/src/tools/router.ts
@@ -1,5 +1,6 @@
-import { queryIRSchema } from '@lightboard/query-ir';
 import { z } from 'zod';
+
+import type { ToolDefinition } from '../provider/types';
 
 /** Context provided to tool handlers for accessing services. */
 export interface ToolContext {
@@ -52,19 +53,27 @@ const toolInputSchemas = {
 
 /**
  * Routes tool calls from the LLM to the appropriate handler.
- * Each handler validates inputs, delegates to services, and returns
- * structured results (or errors for agent self-correction).
+ * Accepts a dynamic set of tool definitions at construction time,
+ * allowing different agents to use different tool subsets.
  */
 export class ToolRouter {
   private context: ToolContext;
   private viewStore = new Map<string, Record<string, unknown>>();
+  private allowedTools: Set<string>;
 
-  constructor(context: ToolContext) {
+  constructor(context: ToolContext, toolDefinitions?: ToolDefinition[]) {
     this.context = context;
+    this.allowedTools = toolDefinitions
+      ? new Set(toolDefinitions.map((t) => t.name))
+      : new Set(['get_schema', 'execute_query', 'run_sql', 'create_view', 'modify_view']);
   }
 
   /** Execute a tool call and return the result. Errors are returned, not thrown. */
   async execute(toolName: string, input: Record<string, unknown>): Promise<ToolExecutionResult> {
+    if (!this.allowedTools.has(toolName)) {
+      return { content: `Tool "${toolName}" is not available for this agent`, isError: true };
+    }
+
     // Auto-parse stringified JSON values — local models often send nested objects as strings
     const normalizedInput = this.normalizeInput(input);
     // Debug: log normalization for troubleshooting local model issues

--- a/packages/agent/src/tools/view-tools.ts
+++ b/packages/agent/src/tools/view-tools.ts
@@ -1,0 +1,79 @@
+import type { ToolDefinition } from '../provider/types';
+
+/**
+ * Tool definitions for the View Agent specialist.
+ * These tools focus on creating and modifying visualizations.
+ */
+export const viewTools: ToolDefinition[] = [
+  {
+    name: 'create_view',
+    description:
+      'Create an interactive visualization view from query results. ' +
+      'Specify the chart type, configuration, and interactive controls. ' +
+      'Controls should include dropdowns for categorical columns and date range pickers for time columns.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        view_spec: {
+          type: 'object',
+          description: 'The ViewSpec document describing the view',
+          properties: {
+            title: { type: 'string', description: 'Title for the view' },
+            description: { type: 'string', description: 'Description of what the view shows' },
+            query: { type: 'object', description: 'QueryIR for the view data' },
+            chart: {
+              type: 'object',
+              properties: {
+                type: { type: 'string', description: 'Panel plugin ID (time-series-line, bar-chart, stat-card, data-table)' },
+                config: { type: 'object', description: 'Chart-specific configuration' },
+              },
+              required: ['type', 'config'],
+            },
+            controls: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  type: { type: 'string', enum: ['dropdown', 'multi_select', 'date_range', 'text_input', 'toggle'] },
+                  label: { type: 'string' },
+                  variable: { type: 'string', description: 'Template variable name (without $)' },
+                  defaultValue: {},
+                },
+                required: ['type', 'label', 'variable'],
+              },
+            },
+          },
+          required: ['query', 'chart'],
+        },
+      },
+      required: ['view_spec'],
+    },
+  },
+  {
+    name: 'modify_view',
+    description:
+      'Modify an existing view — change chart type, add/remove controls, update filters, adjust configuration. ' +
+      'Use this for follow-up requests like "show it as a bar chart" or "add a filter for region".',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        view_id: {
+          type: 'string',
+          description: 'The ID of the view to modify',
+        },
+        patch: {
+          type: 'object',
+          description: 'Partial ViewSpec with only the fields to change',
+          properties: {
+            title: { type: 'string' },
+            description: { type: 'string' },
+            query: { type: 'object' },
+            chart: { type: 'object' },
+            controls: { type: 'array' },
+          },
+        },
+      },
+      required: ['view_id', 'patch'],
+    },
+  },
+];


### PR DESCRIPTION
## Summary

- Introduces `SubAgent`, `AgentTask`, `SubAgentResult` interfaces as the foundation for multi-agent orchestration
- Extracts `QueryAgent` specialist with focused system prompt (<2K tokens) and query-only tools (`get_schema`, `execute_query`, `run_sql`)
- Splits tool definitions into `query-tools.ts` and `view-tools.ts` for per-agent tool sets
- Refactors `ToolRouter` to accept dynamic tool definitions at construction time, gating execution to allowed tools only

## Test plan

- [x] 10 new QueryAgent unit tests (mock LLM provider)
- [x] Existing 28 tests continue to pass (38 total)
- [x] TypeScript strict mode typecheck passes
- [x] `create_view`/`modify_view` rejected by QueryAgent's ToolRouter

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)