### PR TITLE
feat: view agent and insights agent specialists (D-1.5.2)

### DIFF
--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -1,8 +1,10 @@
-export { QueryAgent, type QueryAgentConfig } from './query-agent';
+export { QueryAgent } from './query-agent';
+export { ViewAgent } from './view-agent';
+export { InsightsAgent } from './insights-agent';
 export type {
-  AgentTask,
   SubAgent,
-  SubAgentResult,
+  SubAgentConfig,
   SubAgentRole,
-  ToolCallRecord,
+  AgentTask,
+  SubAgentResult,
 } from './types';

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -1,0 +1,8 @@
+export { QueryAgent, type QueryAgentConfig } from './query-agent';
+export type {
+  AgentTask,
+  SubAgent,
+  SubAgentResult,
+  SubAgentRole,
+  ToolCallRecord,
+} from './types';

--- a/packages/agent/src/agents/insights-agent.test.ts
+++ b/packages/agent/src/agents/insights-agent.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { LLMProvider, StreamEvent } from '../provider/types';
+import type { ToolContext } from '../tools/router';
+import { ToolRouter } from '../tools/router';
+import { insightsTools } from '../tools/insights-tools';
+import { InsightsAgent } from './insights-agent';
+import type { AgentTask, SubAgentResult } from './types';
+
+/** Creates a mock provider that yields predefined event sequences. */
+function mockProvider(eventSequences: StreamEvent[][]): LLMProvider {
+  let callIndex = 0;
+  return {
+    name: 'mock',
+    async *chat() {
+      const events = eventSequences[callIndex] ?? [{ type: 'message_end', stopReason: 'end_turn' }];
+      callIndex++;
+      for (const event of events) {
+        yield event;
+      }
+    },
+  };
+}
+
+/** Creates a mock tool context with analyzeData support. */
+function mockToolContext(analyzeResult?: Record<string, unknown>): ToolContext {
+  return {
+    getSchema: vi.fn().mockResolvedValue({ tables: [] }),
+    executeQuery: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    analyzeData: vi.fn().mockResolvedValue(
+      analyzeResult ?? {
+        rows: [
+          { region: 'North', avg_sales: 5000, stddev: 1200 },
+          { region: 'South', avg_sales: 3200, stddev: 800 },
+        ],
+        rowCount: 2,
+      },
+    ),
+  };
+}
+
+/** Creates a standard insights task for testing. */
+function createInsightsTask(overrides?: Partial<AgentTask>): AgentTask {
+  return {
+    id: 'task_1',
+    instruction: 'What are the average sales by region and are there any outliers?',
+    context: {
+      dataSummary: {
+        columns: [
+          { name: 'region', type: 'varchar' },
+          { name: 'sales', type: 'numeric' },
+          { name: 'date', type: 'timestamp' },
+        ],
+        rowCount: 1000,
+      },
+      tableName: 'sales_data',
+    },
+    ...overrides,
+  };
+}
+
+describe('InsightsAgent', () => {
+  it('has role set to insights and correct tools', () => {
+    const agent = new InsightsAgent({
+      provider: mockProvider([]),
+      toolRouter: new ToolRouter(mockToolContext(), insightsTools),
+    });
+
+    expect(agent.role).toBe('insights');
+    const toolNames = agent.tools.map((t) => t.name);
+    expect(toolNames).toEqual(['analyze_data']);
+  });
+
+  it('executes analyze_data tool and returns analysis result', async () => {
+    const ctx = mockToolContext();
+    const router = new ToolRouter(ctx, insightsTools);
+
+    const agent = new InsightsAgent({
+      provider: mockProvider([
+        // Round 1: LLM calls analyze_data
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'analyze_data' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'analyze_data',
+            input: {
+              sql: 'SELECT region, AVG(sales) AS avg_sales, STDDEV(sales) AS stddev FROM sales_data GROUP BY region',
+              description: 'Average sales and standard deviation by region',
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Round 2: LLM responds with analysis
+        [
+          { type: 'text_delta', text: 'The North region has the highest average sales at 5000.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolRouter: router,
+    });
+
+    const result = await agent.run(createInsightsTask());
+
+    expect(result.role).toBe('insights');
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveProperty('rows');
+    expect(result.explanation).toContain('North region');
+    expect(ctx.analyzeData).toHaveBeenCalledWith(
+      'SELECT region, AVG(sales) AS avg_sales, STDDEV(sales) AS stddev FROM sales_data GROUP BY region',
+    );
+  });
+
+  it('returns text-only analysis when no tool calls are made', async () => {
+    const agent = new InsightsAgent({
+      provider: mockProvider([
+        [
+          { type: 'text_delta', text: 'Based on the data summary, the sales appear normally distributed.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolRouter: new ToolRouter(mockToolContext(), insightsTools),
+    });
+
+    const result = await agent.run(createInsightsTask());
+
+    expect(result.success).toBe(true);
+    expect(result.explanation).toContain('normally distributed');
+    expect(result.data).toHaveProperty('analysis');
+  });
+
+  it('handles analyze_data unavailable gracefully', async () => {
+    // Context without analyzeData
+    const ctx: ToolContext = {
+      getSchema: vi.fn().mockResolvedValue({ tables: [] }),
+      executeQuery: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+      // No analyzeData
+    };
+    const router = new ToolRouter(ctx, insightsTools);
+
+    const agent = new InsightsAgent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'analyze_data' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'analyze_data',
+            input: { sql: 'SELECT 1' },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // LLM recovers after tool error
+        [
+          { type: 'text_delta', text: 'Analysis tool is not available.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolRouter: router,
+    });
+
+    const result = await agent.run(createInsightsTask());
+
+    expect(result.success).toBe(true);
+    expect(result.role).toBe('insights');
+  });
+
+  it('yields result via execute async iterable', async () => {
+    const agent = new InsightsAgent({
+      provider: mockProvider([
+        [
+          { type: 'text_delta', text: 'Insights ready.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolRouter: new ToolRouter(mockToolContext(), insightsTools),
+    });
+
+    const results: SubAgentResult[] = [];
+    for await (const result of agent.execute(createInsightsTask())) {
+      results.push(result);
+    }
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.role).toBe('insights');
+    expect(results[0]!.success).toBe(true);
+  });
+
+  it('returns failure when max rounds exceeded without final text', async () => {
+    // Provider always makes tool calls, never returns text
+    const infiniteToolProvider: LLMProvider = {
+      name: 'mock',
+      async *chat() {
+        yield { type: 'tool_call_start' as const, id: 'tc', name: 'analyze_data' };
+        yield {
+          type: 'tool_call_end' as const,
+          id: 'tc',
+          name: 'analyze_data',
+          input: { sql: 'SELECT COUNT(*) FROM data' },
+        };
+        yield { type: 'message_end' as const, stopReason: 'tool_use' };
+      },
+    };
+
+    const agent = new InsightsAgent({
+      provider: infiniteToolProvider,
+      toolRouter: new ToolRouter(mockToolContext(), insightsTools),
+      maxToolRounds: 2,
+    });
+
+    const result = await agent.run(createInsightsTask());
+
+    expect(result.role).toBe('insights');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('max_tool_rounds');
+    // Should still capture the last analysis result
+    expect(result.data).toHaveProperty('rows');
+  });
+});

--- a/packages/agent/src/agents/insights-agent.ts
+++ b/packages/agent/src/agents/insights-agent.ts
@@ -1,44 +1,38 @@
 import type { Message, ToolCallResult } from '../provider/types';
-import { buildQueryPrompt } from '../prompt/query-prompt';
-import { queryTools } from '../tools/query-tools';
+import { buildInsightsPrompt } from '../prompt/insights-prompt';
+import { insightsTools } from '../tools/insights-tools';
 import type { AgentTask, SubAgent, SubAgentConfig, SubAgentResult } from './types';
 
 /**
- * Query specialist sub-agent.
- * Handles schema exploration and data retrieval via get_schema, execute_query, and run_sql.
- * Receives full schema in task context. Does NOT create views — that is the ViewAgent's job.
+ * Insights specialist sub-agent.
+ * Handles statistical analysis via DuckDB analytics on the session scratchpad.
+ * Has access to the analyze_data tool only.
+ * Receives data summary and user question in task context.
  */
-export class QueryAgent implements SubAgent {
-  readonly role = 'query' as const;
-  readonly tools = queryTools;
+export class InsightsAgent implements SubAgent {
+  readonly role = 'insights' as const;
+  readonly tools = insightsTools;
   private config: SubAgentConfig;
 
   constructor(config: SubAgentConfig) {
     this.config = config;
   }
 
-  /** Execute a query task and yield the result. */
+  /** Execute an insights task and yield the result. */
   async *execute(task: AgentTask): AsyncIterable<SubAgentResult> {
     const result = await this.run(task);
     yield result;
   }
 
-  /** Run a query task and return the structured result. */
+  /** Run an insights task and return the structured result. */
   async run(task: AgentTask): Promise<SubAgentResult> {
-    const dataSources = (task.context.dataSources ?? []) as Array<{
-      id: string;
-      name: string;
-      type: string;
-      cachedSchema?: { tables: { name: string; schema: string; columns: { name: string; type: string; nullable: boolean; primaryKey: boolean }[] }[] } | null;
-    }>;
-
-    const systemPrompt = buildQueryPrompt({ dataSources });
+    const systemPrompt = buildInsightsPrompt(task.context);
     const messages: Message[] = [
       { role: 'user', content: task.instruction },
     ];
 
     const maxRounds = this.config.maxToolRounds ?? 5;
-    let lastQueryResult: Record<string, unknown> | undefined;
+    let lastAnalysisResult: Record<string, unknown> | undefined;
 
     for (let round = 0; round < maxRounds; round++) {
       const toolCalls: ToolCallResult[] = [];
@@ -46,9 +40,11 @@ export class QueryAgent implements SubAgent {
       let textContent = '';
       let hasToolCalls = false;
 
-      const stream = this.config.provider.chat(messages, this.tools, {
-        system: systemPrompt,
-      });
+      const stream = this.config.provider.chat(
+        messages,
+        this.tools,
+        { system: systemPrompt },
+      );
 
       for await (const event of stream) {
         switch (event.type) {
@@ -90,10 +86,11 @@ export class QueryAgent implements SubAgent {
       });
 
       if (!hasToolCalls) {
+        // Agent finished with a text response containing its analysis
         return {
-          role: 'query',
+          role: 'insights',
           success: true,
-          data: lastQueryResult ?? { text: textContent },
+          data: lastAnalysisResult ?? this.extractInsightsData(textContent),
           explanation: textContent,
         };
       }
@@ -108,11 +105,12 @@ export class QueryAgent implements SubAgent {
           isError: result.isError,
         });
 
-        if (!result.isError) {
+        // Capture analysis results
+        if (!result.isError && tc.name === 'analyze_data') {
           try {
-            lastQueryResult = JSON.parse(result.content) as Record<string, unknown>;
+            lastAnalysisResult = JSON.parse(result.content) as Record<string, unknown>;
           } catch {
-            lastQueryResult = { raw: result.content };
+            lastAnalysisResult = { rawResult: result.content };
           }
         }
       }
@@ -125,11 +123,24 @@ export class QueryAgent implements SubAgent {
     }
 
     return {
-      role: 'query',
+      role: 'insights',
       success: false,
-      data: lastQueryResult ?? {},
+      data: lastAnalysisResult ?? {},
       explanation: 'Exceeded maximum tool rounds',
       error: 'max_tool_rounds',
     };
+  }
+
+  /** Extract structured insights data from the agent's text response. */
+  private extractInsightsData(text: string): Record<string, unknown> {
+    const jsonMatch = text.match(/```json\s*([\s\S]*?)```/);
+    if (jsonMatch?.[1]) {
+      try {
+        return JSON.parse(jsonMatch[1]) as Record<string, unknown>;
+      } catch {
+        // fall through
+      }
+    }
+    return { analysis: text };
   }
 }

--- a/packages/agent/src/agents/query-agent.test.ts
+++ b/packages/agent/src/agents/query-agent.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { AgentEvent } from '../agent';
-import type { LLMProvider, StreamEvent, ToolContext } from '../index';
+import type { LLMProvider, StreamEvent } from '../provider/types';
+import type { ToolContext } from '../tools/router';
+import { ToolRouter } from '../tools/router';
 
 import { QueryAgent } from './query-agent';
-import type { AgentTask } from './types';
+import type { AgentTask, SubAgentResult } from './types';
 
 /** Creates a mock provider that yields predefined event sequences. */
 function mockProvider(eventSequences: StreamEvent[][]): LLMProvider {
@@ -23,7 +24,7 @@ function mockProvider(eventSequences: StreamEvent[][]): LLMProvider {
   };
 }
 
-/** Creates a mock tool context with schema and query capabilities. */
+/** Creates a mock tool context. */
 function mockToolContext(): ToolContext {
   return {
     getSchema: vi.fn().mockResolvedValue({
@@ -52,21 +53,10 @@ function mockToolContext(): ToolContext {
   };
 }
 
-/** Collects all AgentEvents from the query agent's chat generator. */
-async function collectEvents(
-  agent: QueryAgent,
-  task: AgentTask,
-): Promise<AgentEvent[]> {
-  const events: AgentEvent[] = [];
-  for await (const event of agent.chat(task)) {
-    events.push(event);
-  }
-  return events;
-}
-
 /** Creates a standard AgentTask for testing. */
 function makeTask(instruction: string): AgentTask {
   return {
+    id: 'task_1',
     instruction,
     context: {
       dataSources: [
@@ -90,22 +80,25 @@ function makeTask(instruction: string): AgentTask {
         },
       ],
     },
-    conversationId: 'test-conv-1',
   };
 }
 
 describe('QueryAgent', () => {
-  it('implements SubAgent interface with correct role', () => {
+  it('has role set to query and correct tools', () => {
     const agent = new QueryAgent({
       provider: mockProvider([]),
-      toolContext: mockToolContext(),
+      toolRouter: new ToolRouter(mockToolContext()),
     });
 
     expect(agent.role).toBe('query');
-    expect(agent.id).toMatch(/^query-agent-/);
+    const toolNames = agent.tools.map((t) => t.name);
+    expect(toolNames).toContain('get_schema');
+    expect(toolNames).toContain('execute_query');
+    expect(toolNames).toContain('run_sql');
+    expect(toolNames).not.toContain('create_view');
   });
 
-  it('streams text response without tool calls', async () => {
+  it('returns success on text-only response', async () => {
     const agent = new QueryAgent({
       provider: mockProvider([
         [
@@ -113,14 +106,14 @@ describe('QueryAgent', () => {
           { type: 'message_end', stopReason: 'end_turn' },
         ],
       ]),
-      toolContext: mockToolContext(),
+      toolRouter: new ToolRouter(mockToolContext()),
     });
 
-    const events = await collectEvents(agent, makeTask('Describe the schema'));
+    const result = await agent.run(makeTask('Describe the schema'));
 
-    const textEvents = events.filter((e) => e.type === 'text');
-    expect(textEvents).toHaveLength(1);
-    expect(events.some((e) => e.type === 'done')).toBe(true);
+    expect(result.role).toBe('query');
+    expect(result.success).toBe(true);
+    expect(result.explanation).toContain('orders table');
   });
 
   it('executes execute_query tool and returns results', async () => {
@@ -150,24 +143,21 @@ describe('QueryAgent', () => {
           { type: 'message_end', stopReason: 'tool_use' },
         ],
         [
-          { type: 'text_delta', text: 'Query executed.' },
+          { type: 'text_delta', text: 'Query executed successfully.' },
           { type: 'message_end', stopReason: 'end_turn' },
         ],
       ]),
-      toolContext: ctx,
+      toolRouter: new ToolRouter(ctx),
     });
 
-    const events = await collectEvents(agent, makeTask('Sum amount by region'));
+    const result = await agent.run(makeTask('Sum amount by region'));
 
-    expect(events.some((e) => e.type === 'tool_start')).toBe(true);
-    const toolEnd = events.find((e) => e.type === 'tool_end') as Extract<AgentEvent, { type: 'tool_end' }>;
-    expect(toolEnd).toBeDefined();
-    expect(toolEnd.name).toBe('execute_query');
-    expect(toolEnd.isError).toBe(false);
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveProperty('rows');
     expect(ctx.executeQuery).toHaveBeenCalled();
   });
 
-  it('executes run_sql tool for complex queries', async () => {
+  it('executes run_sql tool', async () => {
     const ctx = mockToolContext();
     const agent = new QueryAgent({
       provider: mockProvider([
@@ -177,10 +167,7 @@ describe('QueryAgent', () => {
             type: 'tool_call_end',
             id: 'tc_1',
             name: 'run_sql',
-            input: {
-              source_id: 'pg-main',
-              sql: 'SELECT COUNT(*) as count FROM orders',
-            },
+            input: { source_id: 'pg-main', sql: 'SELECT COUNT(*) as count FROM orders' },
           },
           { type: 'message_end', stopReason: 'tool_use' },
         ],
@@ -189,43 +176,13 @@ describe('QueryAgent', () => {
           { type: 'message_end', stopReason: 'end_turn' },
         ],
       ]),
-      toolContext: ctx,
+      toolRouter: new ToolRouter(ctx),
     });
 
-    const events = await collectEvents(agent, makeTask('Count all orders'));
+    const result = await agent.run(makeTask('Count all orders'));
 
-    const toolEnd = events.find((e) => e.type === 'tool_end') as Extract<AgentEvent, { type: 'tool_end' }>;
-    expect(toolEnd.name).toBe('run_sql');
-    expect(toolEnd.isError).toBe(false);
+    expect(result.success).toBe(true);
     expect(ctx.runSQL).toHaveBeenCalledWith('pg-main', 'SELECT COUNT(*) as count FROM orders');
-  });
-
-  it('rejects tools not in the query tool set', async () => {
-    const agent = new QueryAgent({
-      provider: mockProvider([
-        [
-          { type: 'tool_call_start', id: 'tc_1', name: 'create_view' },
-          {
-            type: 'tool_call_end',
-            id: 'tc_1',
-            name: 'create_view',
-            input: { view_spec: { query: {}, chart: { type: 'bar', config: {} } } },
-          },
-          { type: 'message_end', stopReason: 'tool_use' },
-        ],
-        [
-          { type: 'text_delta', text: 'Sorry, I cannot create views.' },
-          { type: 'message_end', stopReason: 'end_turn' },
-        ],
-      ]),
-      toolContext: mockToolContext(),
-    });
-
-    const events = await collectEvents(agent, makeTask('Create a chart'));
-
-    const toolEnd = events.find((e) => e.type === 'tool_end') as Extract<AgentEvent, { type: 'tool_end' }>;
-    expect(toolEnd.isError).toBe(true);
-    expect(toolEnd.result).toContain('not available');
   });
 
   it('handles tool errors and self-corrects', async () => {
@@ -236,7 +193,6 @@ describe('QueryAgent', () => {
 
     const agent = new QueryAgent({
       provider: mockProvider([
-        // First attempt: query fails
         [
           { type: 'tool_call_start', id: 'tc_1', name: 'execute_query' },
           {
@@ -247,7 +203,6 @@ describe('QueryAgent', () => {
           },
           { type: 'message_end', stopReason: 'tool_use' },
         ],
-        // Second attempt: agent fixes query
         [
           { type: 'tool_call_start', id: 'tc_2', name: 'execute_query' },
           {
@@ -258,81 +213,62 @@ describe('QueryAgent', () => {
           },
           { type: 'message_end', stopReason: 'tool_use' },
         ],
-        // Final response
         [
           { type: 'text_delta', text: 'Fixed and got results.' },
           { type: 'message_end', stopReason: 'end_turn' },
         ],
       ]),
-      toolContext: ctx,
+      toolRouter: new ToolRouter(ctx),
     });
 
-    const events = await collectEvents(agent, makeTask('Get region data'));
+    const result = await agent.run(makeTask('Get region data'));
 
-    const toolEnds = events.filter((e) => e.type === 'tool_end') as Array<Extract<AgentEvent, { type: 'tool_end' }>>;
-    expect(toolEnds).toHaveLength(2);
-    expect(toolEnds[0]!.isError).toBe(true);
-    expect(toolEnds[1]!.isError).toBe(false);
+    expect(result.success).toBe(true);
+    expect(ctx.executeQuery).toHaveBeenCalledTimes(2);
   });
 
-  it('stops after maxRounds', async () => {
+  it('returns failure when max rounds exceeded', async () => {
     const infiniteProvider: LLMProvider = {
       name: 'mock',
       async *chat() {
         yield { type: 'tool_call_start' as const, id: 'tc', name: 'get_schema' };
-        yield {
-          type: 'tool_call_end' as const,
-          id: 'tc',
-          name: 'get_schema',
-          input: { source_id: 'x' },
-        };
+        yield { type: 'tool_call_end' as const, id: 'tc', name: 'get_schema', input: { source_id: 'x' } };
         yield { type: 'message_end' as const, stopReason: 'tool_use' };
       },
     };
 
     const agent = new QueryAgent({
       provider: infiniteProvider,
-      toolContext: mockToolContext(),
-      maxRounds: 2,
+      toolRouter: new ToolRouter(mockToolContext()),
+      maxToolRounds: 2,
     });
 
-    const events = await collectEvents(agent, makeTask('loop forever'));
+    const result = await agent.run(makeTask('loop forever'));
 
-    const done = events.find((e) => e.type === 'done') as Extract<AgentEvent, { type: 'done' }>;
-    expect(done).toBeDefined();
+    expect(result.role).toBe('query');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('max_tool_rounds');
   });
 
-  it('run() returns structured SubAgentResult', async () => {
+  it('yields result via execute async iterable', async () => {
     const agent = new QueryAgent({
       provider: mockProvider([
         [
-          { type: 'tool_call_start', id: 'tc_1', name: 'execute_query' },
-          {
-            type: 'tool_call_end',
-            id: 'tc_1',
-            name: 'execute_query',
-            input: {
-              source_id: 'pg-main',
-              query_ir: { source: 'pg-main', table: 'orders', select: [{ field: 'region' }], aggregations: [], groupBy: [], orderBy: [], joins: [] },
-            },
-          },
-          { type: 'message_end', stopReason: 'tool_use' },
-        ],
-        [
-          { type: 'text_delta', text: 'Done.' },
+          { type: 'text_delta', text: 'Schema info.' },
           { type: 'message_end', stopReason: 'end_turn' },
         ],
       ]),
-      toolContext: mockToolContext(),
+      toolRouter: new ToolRouter(mockToolContext()),
     });
 
-    const result = await agent.run(makeTask('Get regions'));
+    const results: SubAgentResult[] = [];
+    for await (const result of agent.execute(makeTask('test'))) {
+      results.push(result);
+    }
 
-    expect(result.agentId).toMatch(/^query-agent-/);
-    expect(result.role).toBe('query');
-    expect(result.success).toBe(true);
-    expect(result.toolCalls.length).toBeGreaterThan(0);
-    expect(result.toolCalls[0]!.name).toBe('execute_query');
+    expect(results).toHaveLength(1);
+    expect(results[0]!.role).toBe('query');
+    expect(results[0]!.success).toBe(true);
   });
 
   it('builds system prompt with schema context', async () => {
@@ -349,10 +285,10 @@ describe('QueryAgent', () => {
 
     const agent = new QueryAgent({
       provider: captureProvider,
-      toolContext: mockToolContext(),
+      toolRouter: new ToolRouter(mockToolContext()),
     });
 
-    await collectEvents(agent, makeTask('test'));
+    await agent.run(makeTask('test'));
 
     expect(capturedSystem).toBeDefined();
     expect(capturedSystem).toContain('Query Agent');
@@ -374,10 +310,10 @@ describe('QueryAgent', () => {
 
     const agent = new QueryAgent({
       provider: captureProvider,
-      toolContext: mockToolContext(),
+      toolRouter: new ToolRouter(mockToolContext()),
     });
 
-    await collectEvents(agent, makeTask('test'));
+    await agent.run(makeTask('test'));
 
     const toolNames = (capturedTools as Array<{ name: string }>).map((t) => t.name);
     expect(toolNames).toContain('get_schema');

--- a/packages/agent/src/agents/query-agent.test.ts
+++ b/packages/agent/src/agents/query-agent.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgentEvent } from '../agent';
+import type { LLMProvider, StreamEvent, ToolContext } from '../index';
+
+import { QueryAgent } from './query-agent';
+import type { AgentTask } from './types';
+
+/** Creates a mock provider that yields predefined event sequences. */
+function mockProvider(eventSequences: StreamEvent[][]): LLMProvider {
+  let callIndex = 0;
+  return {
+    name: 'mock',
+    async *chat() {
+      const events = eventSequences[callIndex] ?? [
+        { type: 'message_end' as const, stopReason: 'end_turn' },
+      ];
+      callIndex++;
+      for (const event of events) {
+        yield event;
+      }
+    },
+  };
+}
+
+/** Creates a mock tool context with schema and query capabilities. */
+function mockToolContext(): ToolContext {
+  return {
+    getSchema: vi.fn().mockResolvedValue({
+      tables: [
+        {
+          name: 'orders',
+          columns: [
+            { name: 'id', type: 'integer' },
+            { name: 'amount', type: 'numeric' },
+            { name: 'region', type: 'varchar' },
+          ],
+        },
+      ],
+    }),
+    executeQuery: vi.fn().mockResolvedValue({
+      rows: [
+        { region: 'North', total: 5000 },
+        { region: 'South', total: 3200 },
+      ],
+      rowCount: 2,
+    }),
+    runSQL: vi.fn().mockResolvedValue({
+      rows: [{ count: 42 }],
+      rowCount: 1,
+    }),
+  };
+}
+
+/** Collects all AgentEvents from the query agent's chat generator. */
+async function collectEvents(
+  agent: QueryAgent,
+  task: AgentTask,
+): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of agent.chat(task)) {
+    events.push(event);
+  }
+  return events;
+}
+
+/** Creates a standard AgentTask for testing. */
+function makeTask(instruction: string): AgentTask {
+  return {
+    instruction,
+    context: {
+      dataSources: [
+        {
+          id: 'pg-main',
+          name: 'Main DB',
+          type: 'postgres',
+          cachedSchema: {
+            tables: [
+              {
+                name: 'orders',
+                schema: 'public',
+                columns: [
+                  { name: 'id', type: 'integer', nullable: false, primaryKey: true },
+                  { name: 'amount', type: 'numeric', nullable: false, primaryKey: false },
+                  { name: 'region', type: 'varchar', nullable: true, primaryKey: false },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    },
+    conversationId: 'test-conv-1',
+  };
+}
+
+describe('QueryAgent', () => {
+  it('implements SubAgent interface with correct role', () => {
+    const agent = new QueryAgent({
+      provider: mockProvider([]),
+      toolContext: mockToolContext(),
+    });
+
+    expect(agent.role).toBe('query');
+    expect(agent.id).toMatch(/^query-agent-/);
+  });
+
+  it('streams text response without tool calls', async () => {
+    const agent = new QueryAgent({
+      provider: mockProvider([
+        [
+          { type: 'text_delta', text: 'The schema has an orders table.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+    });
+
+    const events = await collectEvents(agent, makeTask('Describe the schema'));
+
+    const textEvents = events.filter((e) => e.type === 'text');
+    expect(textEvents).toHaveLength(1);
+    expect(events.some((e) => e.type === 'done')).toBe(true);
+  });
+
+  it('executes execute_query tool and returns results', async () => {
+    const ctx = mockToolContext();
+    const agent = new QueryAgent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'execute_query' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'execute_query',
+            input: {
+              source_id: 'pg-main',
+              query_ir: {
+                source: 'pg-main',
+                table: 'orders',
+                select: [{ field: 'region' }],
+                aggregations: [{ function: 'sum', field: { field: 'amount' }, alias: 'total' }],
+                groupBy: [{ field: 'region' }],
+                orderBy: [],
+                joins: [],
+                limit: 100,
+              },
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'Query executed.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: ctx,
+    });
+
+    const events = await collectEvents(agent, makeTask('Sum amount by region'));
+
+    expect(events.some((e) => e.type === 'tool_start')).toBe(true);
+    const toolEnd = events.find((e) => e.type === 'tool_end') as Extract<AgentEvent, { type: 'tool_end' }>;
+    expect(toolEnd).toBeDefined();
+    expect(toolEnd.name).toBe('execute_query');
+    expect(toolEnd.isError).toBe(false);
+    expect(ctx.executeQuery).toHaveBeenCalled();
+  });
+
+  it('executes run_sql tool for complex queries', async () => {
+    const ctx = mockToolContext();
+    const agent = new QueryAgent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'run_sql' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'run_sql',
+            input: {
+              source_id: 'pg-main',
+              sql: 'SELECT COUNT(*) as count FROM orders',
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'Found 42 orders.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: ctx,
+    });
+
+    const events = await collectEvents(agent, makeTask('Count all orders'));
+
+    const toolEnd = events.find((e) => e.type === 'tool_end') as Extract<AgentEvent, { type: 'tool_end' }>;
+    expect(toolEnd.name).toBe('run_sql');
+    expect(toolEnd.isError).toBe(false);
+    expect(ctx.runSQL).toHaveBeenCalledWith('pg-main', 'SELECT COUNT(*) as count FROM orders');
+  });
+
+  it('rejects tools not in the query tool set', async () => {
+    const agent = new QueryAgent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'create_view' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'create_view',
+            input: { view_spec: { query: {}, chart: { type: 'bar', config: {} } } },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'Sorry, I cannot create views.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+    });
+
+    const events = await collectEvents(agent, makeTask('Create a chart'));
+
+    const toolEnd = events.find((e) => e.type === 'tool_end') as Extract<AgentEvent, { type: 'tool_end' }>;
+    expect(toolEnd.isError).toBe(true);
+    expect(toolEnd.result).toContain('not available');
+  });
+
+  it('handles tool errors and self-corrects', async () => {
+    const ctx = mockToolContext();
+    (ctx.executeQuery as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('column "foo" does not exist'))
+      .mockResolvedValueOnce({ rows: [{ count: 10 }], rowCount: 1 });
+
+    const agent = new QueryAgent({
+      provider: mockProvider([
+        // First attempt: query fails
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'execute_query' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'execute_query',
+            input: { source_id: 'pg-main', query_ir: { source: 'pg-main', table: 'orders', select: [{ field: 'foo' }], aggregations: [], groupBy: [], orderBy: [], joins: [] } },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Second attempt: agent fixes query
+        [
+          { type: 'tool_call_start', id: 'tc_2', name: 'execute_query' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_2',
+            name: 'execute_query',
+            input: { source_id: 'pg-main', query_ir: { source: 'pg-main', table: 'orders', select: [{ field: 'region' }], aggregations: [], groupBy: [], orderBy: [], joins: [] } },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Final response
+        [
+          { type: 'text_delta', text: 'Fixed and got results.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: ctx,
+    });
+
+    const events = await collectEvents(agent, makeTask('Get region data'));
+
+    const toolEnds = events.filter((e) => e.type === 'tool_end') as Array<Extract<AgentEvent, { type: 'tool_end' }>>;
+    expect(toolEnds).toHaveLength(2);
+    expect(toolEnds[0]!.isError).toBe(true);
+    expect(toolEnds[1]!.isError).toBe(false);
+  });
+
+  it('stops after maxRounds', async () => {
+    const infiniteProvider: LLMProvider = {
+      name: 'mock',
+      async *chat() {
+        yield { type: 'tool_call_start' as const, id: 'tc', name: 'get_schema' };
+        yield {
+          type: 'tool_call_end' as const,
+          id: 'tc',
+          name: 'get_schema',
+          input: { source_id: 'x' },
+        };
+        yield { type: 'message_end' as const, stopReason: 'tool_use' };
+      },
+    };
+
+    const agent = new QueryAgent({
+      provider: infiniteProvider,
+      toolContext: mockToolContext(),
+      maxRounds: 2,
+    });
+
+    const events = await collectEvents(agent, makeTask('loop forever'));
+
+    const done = events.find((e) => e.type === 'done') as Extract<AgentEvent, { type: 'done' }>;
+    expect(done).toBeDefined();
+  });
+
+  it('run() returns structured SubAgentResult', async () => {
+    const agent = new QueryAgent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'execute_query' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'execute_query',
+            input: {
+              source_id: 'pg-main',
+              query_ir: { source: 'pg-main', table: 'orders', select: [{ field: 'region' }], aggregations: [], groupBy: [], orderBy: [], joins: [] },
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'Done.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+    });
+
+    const result = await agent.run(makeTask('Get regions'));
+
+    expect(result.agentId).toMatch(/^query-agent-/);
+    expect(result.role).toBe('query');
+    expect(result.success).toBe(true);
+    expect(result.toolCalls.length).toBeGreaterThan(0);
+    expect(result.toolCalls[0]!.name).toBe('execute_query');
+  });
+
+  it('builds system prompt with schema context', async () => {
+    let capturedSystem: string | undefined;
+
+    const captureProvider: LLMProvider = {
+      name: 'mock',
+      async *chat(_messages, _tools, options) {
+        capturedSystem = options?.system;
+        yield { type: 'text_delta' as const, text: 'ok' };
+        yield { type: 'message_end' as const, stopReason: 'end_turn' };
+      },
+    };
+
+    const agent = new QueryAgent({
+      provider: captureProvider,
+      toolContext: mockToolContext(),
+    });
+
+    await collectEvents(agent, makeTask('test'));
+
+    expect(capturedSystem).toBeDefined();
+    expect(capturedSystem).toContain('Query Agent');
+    expect(capturedSystem).toContain('orders');
+    expect(capturedSystem).toContain('pg-main');
+  });
+
+  it('only passes query tools to the LLM', async () => {
+    let capturedTools: unknown;
+
+    const captureProvider: LLMProvider = {
+      name: 'mock',
+      async *chat(_messages, tools) {
+        capturedTools = tools;
+        yield { type: 'text_delta' as const, text: 'ok' };
+        yield { type: 'message_end' as const, stopReason: 'end_turn' };
+      },
+    };
+
+    const agent = new QueryAgent({
+      provider: captureProvider,
+      toolContext: mockToolContext(),
+    });
+
+    await collectEvents(agent, makeTask('test'));
+
+    const toolNames = (capturedTools as Array<{ name: string }>).map((t) => t.name);
+    expect(toolNames).toContain('get_schema');
+    expect(toolNames).toContain('execute_query');
+    expect(toolNames).toContain('run_sql');
+    expect(toolNames).not.toContain('create_view');
+    expect(toolNames).not.toContain('modify_view');
+  });
+});

--- a/packages/agent/src/agents/query-agent.ts
+++ b/packages/agent/src/agents/query-agent.ts
@@ -1,0 +1,235 @@
+import type { AgentEvent } from '../agent';
+import { buildQueryPrompt } from '../prompt/query-prompt';
+import type { LLMProvider, ToolCallResult } from '../provider/types';
+import { queryTools } from '../tools/query-tools';
+import { ToolRouter, type ToolContext } from '../tools/router';
+
+import type {
+  AgentTask,
+  SubAgent,
+  SubAgentResult,
+  ToolCallRecord,
+} from './types';
+
+/** Configuration for creating a QueryAgent. */
+export interface QueryAgentConfig {
+  /** LLM provider for the query agent's own conversation. */
+  provider: LLMProvider;
+  /** Tool context connecting to data source services. */
+  toolContext: ToolContext;
+  /** Maximum tool call rounds before stopping (default: 5). */
+  maxRounds?: number;
+}
+
+/**
+ * Query Agent specialist — handles schema exploration and data retrieval.
+ *
+ * Runs its own LLM conversation with a focused system prompt containing
+ * schema details and QueryIR specification. Has access to get_schema,
+ * execute_query, and run_sql tools only.
+ *
+ * Returns structured SubAgentResult with query results data.
+ */
+export class QueryAgent implements SubAgent {
+  readonly id: string;
+  readonly role = 'query' as const;
+
+  private provider: LLMProvider;
+  private toolRouter: ToolRouter;
+  private maxRounds: number;
+
+  constructor(config: QueryAgentConfig) {
+    this.id = `query-agent-${Date.now()}`;
+    this.provider = config.provider;
+    this.toolRouter = new ToolRouter(config.toolContext, queryTools);
+    this.maxRounds = config.maxRounds ?? 5;
+  }
+
+  /**
+   * Execute a query task. Yields AgentEvents for transparency logging,
+   * then returns a structured SubAgentResult via the final 'done' event.
+   *
+   * The leader collects tool_start/tool_end events but does NOT forward
+   * text events to the user — only the leader streams to the user.
+   */
+  async *chat(task: AgentTask): AsyncGenerator<AgentEvent> {
+    const toolCallLog: ToolCallRecord[] = [];
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let resultData: Record<string, unknown> = {};
+    let lastError: string | undefined;
+
+    // Build focused system prompt with schema context
+    const dataSources = (task.context.dataSources ?? []) as Array<{
+      id: string;
+      name: string;
+      type: string;
+      cachedSchema?: { tables: { name: string; schema: string; columns: { name: string; type: string; nullable: boolean; primaryKey: boolean }[] }[] } | null;
+    }>;
+
+    const systemPrompt = buildQueryPrompt({ dataSources });
+
+    // Start with the task instruction as a user message
+    const messages: Array<{ role: 'user' | 'assistant' | 'system'; content: string; toolCalls?: ToolCallResult[]; toolResults?: Array<{ toolCallId: string; content: string; isError?: boolean }> }> = [
+      { role: 'user', content: task.instruction },
+    ];
+
+    for (let round = 0; round < this.maxRounds; round++) {
+      const toolCalls: ToolCallResult[] = [];
+      const toolInputBuffers = new Map<string, string>();
+      let textContent = '';
+      let hasToolCalls = false;
+
+      const stream = this.provider.chat(messages, queryTools, {
+        system: systemPrompt,
+      });
+
+      for await (const event of stream) {
+        switch (event.type) {
+          case 'text_delta':
+            textContent += event.text;
+            yield { type: 'text', text: event.text };
+            break;
+
+          case 'tool_call_start':
+            hasToolCalls = true;
+            toolInputBuffers.set(event.id, '');
+            toolCalls.push({ id: event.id, name: event.name, input: {} });
+            yield { type: 'tool_start', name: event.name, id: event.id };
+            break;
+
+          case 'tool_call_delta': {
+            const existing = toolInputBuffers.get(event.id) ?? '';
+            toolInputBuffers.set(event.id, existing + event.input);
+            break;
+          }
+
+          case 'tool_call_end': {
+            const tc = toolCalls.find((t) => t.id === event.id);
+            if (tc) tc.input = event.input;
+            break;
+          }
+
+          case 'message_end':
+            if (hasToolCalls) {
+              for (const tc of toolCalls) {
+                if (Object.keys(tc.input).length === 0) {
+                  const raw = toolInputBuffers.get(tc.id);
+                  if (raw) {
+                    try { tc.input = JSON.parse(raw); } catch { /* ignore */ }
+                  }
+                }
+              }
+            }
+            break;
+        }
+      }
+
+      // Store assistant message
+      messages.push({
+        role: 'assistant',
+        content: textContent,
+        toolCalls: hasToolCalls ? toolCalls : undefined,
+      });
+
+      // If no tool calls, the agent is done reasoning
+      if (!hasToolCalls) {
+        resultData = { text: textContent };
+        break;
+      }
+
+      // Execute tool calls
+      const toolResults: Array<{ toolCallId: string; content: string; isError?: boolean }> = [];
+      for (const tc of toolCalls) {
+        const startTime = Date.now();
+        const result = await this.toolRouter.execute(tc.name, tc.input);
+        const durationMs = Date.now() - startTime;
+
+        toolCallLog.push({
+          name: tc.name,
+          input: tc.input,
+          result: result.content,
+          isError: result.isError,
+          durationMs,
+        });
+
+        toolResults.push({
+          toolCallId: tc.id,
+          content: result.content,
+          isError: result.isError,
+        });
+
+        if (result.isError) {
+          lastError = result.content;
+        } else {
+          lastError = undefined;
+          // Capture the last successful query result as the output
+          try {
+            resultData = JSON.parse(result.content) as Record<string, unknown>;
+          } catch {
+            resultData = { raw: result.content };
+          }
+        }
+
+        yield { type: 'tool_end', name: tc.name, result: result.content, isError: result.isError };
+      }
+
+      // Feed tool results back for next round
+      messages.push({
+        role: 'user',
+        content: '',
+        toolResults,
+      });
+    }
+
+    // Build the final SubAgentResult and attach it to the done event
+    const agentResult: SubAgentResult = {
+      agentId: this.id,
+      role: this.role,
+      success: !lastError,
+      data: resultData,
+      toolCalls: toolCallLog,
+      tokenUsage: { input: totalInputTokens, output: totalOutputTokens },
+      error: lastError,
+    };
+
+    yield {
+      type: 'done',
+      stopReason: lastError ? 'error' : 'end_turn',
+      ...(agentResult as unknown as Record<string, never>),
+    };
+  }
+
+  /**
+   * Run a query task and return the structured result directly.
+   * Convenience method that consumes the async generator internally.
+   */
+  async run(task: AgentTask): Promise<SubAgentResult> {
+    const toolCallLog: ToolCallRecord[] = [];
+    let resultData: Record<string, unknown> = {};
+    let lastError: string | undefined;
+
+    for await (const event of this.chat(task)) {
+      if (event.type === 'tool_end') {
+        // toolCallLog is already populated via chat()
+      }
+      if (event.type === 'done') {
+        // Extract the SubAgentResult we attached to the done event
+        const doneWithResult = event as unknown as Record<string, unknown>;
+        if (doneWithResult.agentId) {
+          return doneWithResult as unknown as SubAgentResult;
+        }
+      }
+    }
+
+    return {
+      agentId: this.id,
+      role: this.role,
+      success: !lastError,
+      data: resultData,
+      toolCalls: toolCallLog,
+      tokenUsage: { input: 0, output: 0 },
+      error: lastError,
+    };
+  }
+}

--- a/packages/agent/src/agents/types.ts
+++ b/packages/agent/src/agents/types.ts
@@ -1,0 +1,78 @@
+import type { AgentEvent } from '../agent';
+
+/**
+ * Roles a sub-agent can fulfill in the multi-agent orchestration.
+ * Each role has a focused context window and tool set.
+ */
+export type SubAgentRole = 'query' | 'view' | 'insights';
+
+/**
+ * Contract that every sub-agent must implement.
+ * Sub-agents are headless — they run their own LLM conversation internally
+ * and return structured results. Only the leader streams text to the user.
+ */
+export interface SubAgent {
+  /** Unique identifier for this agent instance. */
+  readonly id: string;
+  /** The specialist role this agent fulfills. */
+  readonly role: SubAgentRole;
+  /**
+   * Execute a task and yield AgentEvents as the sub-agent works.
+   * The leader collects tool_start/tool_end events for transparency
+   * but does NOT forward text events to the user.
+   */
+  chat(task: AgentTask): AsyncGenerator<AgentEvent>;
+}
+
+/**
+ * Task handed from the leader agent to a sub-agent.
+ * Contains the instruction and role-specific context payload.
+ */
+export interface AgentTask {
+  /** Natural language instruction describing what the sub-agent should do. */
+  instruction: string;
+  /** Role-specific context payload (e.g., schema for query agent, data summary for view agent). */
+  context: Record<string, unknown>;
+  /** Conversation ID for tracing and scratchpad association. */
+  conversationId: string;
+  /** Parent span ID for distributed tracing. */
+  parentSpanId?: string;
+}
+
+/**
+ * Record of a single tool call made by a sub-agent.
+ * Used for transparency logging in the leader's response.
+ */
+export interface ToolCallRecord {
+  /** Tool name that was called. */
+  name: string;
+  /** Input passed to the tool. */
+  input: Record<string, unknown>;
+  /** Result returned by the tool. */
+  result: string;
+  /** Whether the tool call errored. */
+  isError: boolean;
+  /** Duration of the tool call in milliseconds. */
+  durationMs: number;
+}
+
+/**
+ * Structured result returned by a sub-agent to the leader.
+ * Contains the role-specific output data, tool call log, and token usage.
+ */
+export interface SubAgentResult {
+  /** ID of the sub-agent that produced this result. */
+  agentId: string;
+  /** Role of the sub-agent. */
+  role: SubAgentRole;
+  /** Whether the sub-agent completed its task successfully. */
+  success: boolean;
+  /** Role-specific output data (e.g., query results, ViewSpec, insights). */
+  data: Record<string, unknown>;
+  /** Log of all tool calls made during execution. */
+  toolCalls: ToolCallRecord[];
+  /** Token usage for the sub-agent's LLM calls. */
+  tokenUsage: { input: number; output: number };
+  /** Error message if the sub-agent failed. */
+  error?: string;
+}

--- a/packages/agent/src/agents/types.ts
+++ b/packages/agent/src/agents/types.ts
@@ -1,78 +1,62 @@
-import type { AgentEvent } from '../agent';
+import type { LLMProvider, ToolDefinition } from '../provider/types';
+import type { ToolRouter } from '../tools/router';
 
-/**
- * Roles a sub-agent can fulfill in the multi-agent orchestration.
- * Each role has a focused context window and tool set.
- */
+/** Roles that sub-agents can take in the multi-agent orchestration. */
 export type SubAgentRole = 'query' | 'view' | 'insights';
 
 /**
- * Contract that every sub-agent must implement.
- * Sub-agents are headless — they run their own LLM conversation internally
- * and return structured results. Only the leader streams text to the user.
- */
-export interface SubAgent {
-  /** Unique identifier for this agent instance. */
-  readonly id: string;
-  /** The specialist role this agent fulfills. */
-  readonly role: SubAgentRole;
-  /**
-   * Execute a task and yield AgentEvents as the sub-agent works.
-   * The leader collects tool_start/tool_end events for transparency
-   * but does NOT forward text events to the user.
-   */
-  chat(task: AgentTask): AsyncGenerator<AgentEvent>;
-}
-
-/**
- * Task handed from the leader agent to a sub-agent.
+ * A task assigned by the leader to a sub-agent.
  * Contains the instruction and role-specific context payload.
  */
 export interface AgentTask {
-  /** Natural language instruction describing what the sub-agent should do. */
+  /** Unique task identifier. */
+  id: string;
+  /** Natural language instruction from the leader. */
   instruction: string;
-  /** Role-specific context payload (e.g., schema for query agent, data summary for view agent). */
+  /** Role-specific context (e.g., schema for query agent, data summary for view agent). */
   context: Record<string, unknown>;
-  /** Conversation ID for tracing and scratchpad association. */
-  conversationId: string;
-  /** Parent span ID for distributed tracing. */
-  parentSpanId?: string;
-}
-
-/**
- * Record of a single tool call made by a sub-agent.
- * Used for transparency logging in the leader's response.
- */
-export interface ToolCallRecord {
-  /** Tool name that was called. */
-  name: string;
-  /** Input passed to the tool. */
-  input: Record<string, unknown>;
-  /** Result returned by the tool. */
-  result: string;
-  /** Whether the tool call errored. */
-  isError: boolean;
-  /** Duration of the tool call in milliseconds. */
-  durationMs: number;
 }
 
 /**
  * Structured result returned by a sub-agent to the leader.
- * Contains the role-specific output data, tool call log, and token usage.
+ * Contains the role-specific output data and human-readable explanation.
  */
 export interface SubAgentResult {
-  /** ID of the sub-agent that produced this result. */
-  agentId: string;
-  /** Role of the sub-agent. */
+  /** The role of the agent that produced this result. */
   role: SubAgentRole;
-  /** Whether the sub-agent completed its task successfully. */
+  /** Whether the task succeeded. */
   success: boolean;
-  /** Role-specific output data (e.g., query results, ViewSpec, insights). */
+  /** The structured output (ViewSpec, query result, analysis). */
   data: Record<string, unknown>;
-  /** Log of all tool calls made during execution. */
-  toolCalls: ToolCallRecord[];
-  /** Token usage for the sub-agent's LLM calls. */
-  tokenUsage: { input: number; output: number };
-  /** Error message if the sub-agent failed. */
+  /** Human-readable explanation of what was done. */
+  explanation: string;
+  /** Error message if success is false. */
   error?: string;
+}
+
+/**
+ * Contract that all sub-agents implement.
+ * Sub-agents are headless specialists that receive tasks from the leader
+ * and return structured results. They do NOT stream to the user.
+ */
+export interface SubAgent {
+  /** The role this agent specializes in. */
+  readonly role: SubAgentRole;
+  /** Tool definitions this agent has access to. */
+  readonly tools: ToolDefinition[];
+  /** Execute a task and yield structured results. */
+  execute(task: AgentTask): AsyncIterable<SubAgentResult>;
+}
+
+/**
+ * Configuration for creating a sub-agent.
+ * Shared across all specialist agent types.
+ */
+export interface SubAgentConfig {
+  /** LLM provider for the sub-agent's own conversation. */
+  provider: LLMProvider;
+  /** Tool router for executing tool calls (scoped to allowed tools). */
+  toolRouter: ToolRouter;
+  /** Maximum tool call rounds before giving up (default varies by agent). */
+  maxToolRounds?: number;
 }

--- a/packages/agent/src/agents/view-agent.test.ts
+++ b/packages/agent/src/agents/view-agent.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { LLMProvider, StreamEvent } from '../provider/types';
+import type { ToolContext } from '../tools/router';
+import { ToolRouter } from '../tools/router';
+import { ViewAgent } from './view-agent';
+import type { AgentTask, SubAgentConfig } from './types';
+
+/** Creates a mock provider that yields predefined event sequences. */
+function mockProvider(eventSequences: StreamEvent[][]): LLMProvider {
+  let callIndex = 0;
+  return {
+    name: 'mock',
+    async *chat() {
+      const events = eventSequences[callIndex] ?? [{ type: 'message_end', stopReason: 'end_turn' }];
+      callIndex++;
+      for (const event of events) {
+        yield event;
+      }
+    },
+  };
+}
+
+/** Creates a mock tool context with standard stubs. */
+function mockToolContext(): ToolContext {
+  return {
+    getSchema: vi.fn().mockResolvedValue({ tables: [] }),
+    executeQuery: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+  };
+}
+
+/** Creates a standard view task for testing. */
+function createViewTask(overrides?: Partial<AgentTask>): AgentTask {
+  return {
+    id: 'task_1',
+    instruction: 'Create a bar chart showing sales by region',
+    context: {
+      dataSummary: {
+        columns: [
+          { name: 'region', type: 'varchar' },
+          { name: 'total_sales', type: 'numeric' },
+        ],
+        rowCount: 5,
+        sampleRows: [
+          { region: 'North', total_sales: 5000 },
+          { region: 'South', total_sales: 3200 },
+        ],
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('ViewAgent', () => {
+  it('has role set to view', () => {
+    const agent = new ViewAgent({
+      provider: mockProvider([]),
+      toolRouter: new ToolRouter(mockToolContext()),
+    });
+
+    expect(agent.role).toBe('view');
+  });
+
+  it('has create_view and modify_view tools', () => {
+    const agent = new ViewAgent({
+      provider: mockProvider([]),
+      toolRouter: new ToolRouter(mockToolContext()),
+    });
+
+    const toolNames = agent.tools.map((t) => t.name);
+    expect(toolNames).toContain('create_view');
+    expect(toolNames).toContain('modify_view');
+    expect(toolNames).toHaveLength(2);
+  });
+
+  it('returns success when LLM responds with text only', async () => {
+    const agent = new ViewAgent({
+      provider: mockProvider([
+        [
+          { type: 'text_delta', text: 'Here is the recommended chart configuration.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolRouter: new ToolRouter(mockToolContext()),
+    });
+
+    const result = await agent.run(createViewTask());
+
+    expect(result.role).toBe('view');
+    expect(result.success).toBe(true);
+    expect(result.explanation).toContain('recommended chart');
+  });
+
+  it('executes create_view tool and returns view data', async () => {
+    const ctx = mockToolContext();
+    const router = new ToolRouter(ctx);
+
+    const agent = new ViewAgent({
+      provider: mockProvider([
+        // Round 1: LLM calls create_view
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'create_view' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'create_view',
+            input: {
+              view_spec: {
+                title: 'Sales by Region',
+                description: 'Bar chart of total sales per region',
+                query: { source: 'pg-main', table: 'sales' },
+                chart: {
+                  type: 'bar-chart',
+                  config: { xField: 'region', yFields: ['total_sales'] },
+                },
+                controls: [],
+              },
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Round 2: LLM responds with explanation
+        [
+          { type: 'text_delta', text: 'I created a bar chart showing sales by region.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolRouter: router,
+    });
+
+    const result = await agent.run(createViewTask());
+
+    expect(result.role).toBe('view');
+    expect(result.success).toBe(true);
+    expect(result.explanation).toContain('bar chart');
+  });
+
+  it('handles modify_view tool call', async () => {
+    const ctx = mockToolContext();
+    const router = new ToolRouter(ctx);
+
+    // Pre-create a view in the router's store
+    await router.execute('create_view', {
+      view_spec: {
+        title: 'Original',
+        query: { source: 'pg-main', table: 'sales' },
+        chart: { type: 'bar-chart', config: {} },
+      },
+    });
+
+    const agent = new ViewAgent({
+      provider: mockProvider([
+        // LLM calls modify_view
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'modify_view' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'modify_view',
+            input: {
+              view_id: 'nonexistent_view',
+              patch: { chart: { type: 'time-series-line', config: { xField: 'date', yFields: ['total'] } } },
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // LLM responds after error
+        [
+          { type: 'text_delta', text: 'The view was not found, but here is my analysis.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolRouter: router,
+    });
+
+    const task = createViewTask({
+      instruction: 'Change the chart to a time series',
+      context: { currentView: { viewId: 'nonexistent_view' } },
+    });
+
+    const result = await agent.run(task);
+    expect(result.success).toBe(true);
+    expect(result.role).toBe('view');
+  });
+
+  it('returns failure when max tool rounds exceeded', async () => {
+    // Provider that always returns tool calls
+    const infiniteToolProvider: LLMProvider = {
+      name: 'mock',
+      async *chat() {
+        yield { type: 'tool_call_start' as const, id: 'tc', name: 'create_view' };
+        yield {
+          type: 'tool_call_end' as const,
+          id: 'tc',
+          name: 'create_view',
+          input: {
+            view_spec: {
+              query: { source: 'x', table: 'y' },
+              chart: { type: 'bar-chart', config: {} },
+            },
+          },
+        };
+        yield { type: 'message_end' as const, stopReason: 'tool_use' };
+      },
+    };
+
+    const agent = new ViewAgent({
+      provider: infiniteToolProvider,
+      toolRouter: new ToolRouter(mockToolContext()),
+      maxToolRounds: 2,
+    });
+
+    const result = await agent.run(createViewTask());
+
+    // Should succeed because last round captured the view result
+    expect(result.role).toBe('view');
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+  });
+
+  it('yields result via execute async iterable', async () => {
+    const agent = new ViewAgent({
+      provider: mockProvider([
+        [
+          { type: 'text_delta', text: 'Analysis complete.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolRouter: new ToolRouter(mockToolContext()),
+    });
+
+    const results: import('./types').SubAgentResult[] = [];
+    for await (const result of agent.execute(createViewTask())) {
+      results.push(result);
+    }
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.role).toBe('view');
+    expect(results[0]!.success).toBe(true);
+  });
+
+  it('extracts JSON from code blocks in text response', async () => {
+    const agent = new ViewAgent({
+      provider: mockProvider([
+        [
+          { type: 'text_delta', text: 'Here is the config:\n```json\n{"chartType": "bar-chart"}\n```' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolRouter: new ToolRouter(mockToolContext()),
+    });
+
+    const result = await agent.run(createViewTask());
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ chartType: 'bar-chart' });
+  });
+});

--- a/packages/agent/src/agents/view-agent.ts
+++ b/packages/agent/src/agents/view-agent.ts
@@ -1,44 +1,37 @@
 import type { Message, ToolCallResult } from '../provider/types';
-import { buildQueryPrompt } from '../prompt/query-prompt';
-import { queryTools } from '../tools/query-tools';
+import { buildViewPrompt } from '../prompt/view-prompt';
+import { viewTools } from '../tools/view-tools';
 import type { AgentTask, SubAgent, SubAgentConfig, SubAgentResult } from './types';
 
 /**
- * Query specialist sub-agent.
- * Handles schema exploration and data retrieval via get_schema, execute_query, and run_sql.
- * Receives full schema in task context. Does NOT create views — that is the ViewAgent's job.
+ * View specialist sub-agent.
+ * Handles chart type selection and ViewSpec generation.
+ * Has access to create_view and modify_view tools only.
+ * Receives data summary (columns, types, row count, sample rows) in task context.
  */
-export class QueryAgent implements SubAgent {
-  readonly role = 'query' as const;
-  readonly tools = queryTools;
+export class ViewAgent implements SubAgent {
+  readonly role = 'view' as const;
+  readonly tools = viewTools;
   private config: SubAgentConfig;
 
   constructor(config: SubAgentConfig) {
     this.config = config;
   }
 
-  /** Execute a query task and yield the result. */
+  /** Execute a view task and yield the result. */
   async *execute(task: AgentTask): AsyncIterable<SubAgentResult> {
     const result = await this.run(task);
     yield result;
   }
 
-  /** Run a query task and return the structured result. */
+  /** Run a view task and return the structured result. */
   async run(task: AgentTask): Promise<SubAgentResult> {
-    const dataSources = (task.context.dataSources ?? []) as Array<{
-      id: string;
-      name: string;
-      type: string;
-      cachedSchema?: { tables: { name: string; schema: string; columns: { name: string; type: string; nullable: boolean; primaryKey: boolean }[] }[] } | null;
-    }>;
-
-    const systemPrompt = buildQueryPrompt({ dataSources });
+    const systemPrompt = buildViewPrompt(task.context);
     const messages: Message[] = [
       { role: 'user', content: task.instruction },
     ];
 
-    const maxRounds = this.config.maxToolRounds ?? 5;
-    let lastQueryResult: Record<string, unknown> | undefined;
+    const maxRounds = this.config.maxToolRounds ?? 3;
 
     for (let round = 0; round < maxRounds; round++) {
       const toolCalls: ToolCallResult[] = [];
@@ -46,9 +39,11 @@ export class QueryAgent implements SubAgent {
       let textContent = '';
       let hasToolCalls = false;
 
-      const stream = this.config.provider.chat(messages, this.tools, {
-        system: systemPrompt,
-      });
+      const stream = this.config.provider.chat(
+        messages,
+        this.tools,
+        { system: systemPrompt },
+      );
 
       for await (const event of stream) {
         switch (event.type) {
@@ -91,15 +86,17 @@ export class QueryAgent implements SubAgent {
 
       if (!hasToolCalls) {
         return {
-          role: 'query',
+          role: 'view',
           success: true,
-          data: lastQueryResult ?? { text: textContent },
+          data: this.extractViewData(textContent),
           explanation: textContent,
         };
       }
 
-      // Execute tool calls
+      // Execute tool calls and collect results
       const toolResults = [];
+      let lastViewResult: Record<string, unknown> | undefined;
+
       for (const tc of toolCalls) {
         const result = await this.config.toolRouter.execute(tc.name, tc.input);
         toolResults.push({
@@ -108,11 +105,12 @@ export class QueryAgent implements SubAgent {
           isError: result.isError,
         });
 
-        if (!result.isError) {
+        // Capture the view data from create_view or modify_view results
+        if (!result.isError && (tc.name === 'create_view' || tc.name === 'modify_view')) {
           try {
-            lastQueryResult = JSON.parse(result.content) as Record<string, unknown>;
+            lastViewResult = JSON.parse(result.content) as Record<string, unknown>;
           } catch {
-            lastQueryResult = { raw: result.content };
+            // ignore parse failures
           }
         }
       }
@@ -122,14 +120,37 @@ export class QueryAgent implements SubAgent {
         content: '',
         toolResults,
       });
+
+      // If this is the last round and we have a view result, return it
+      if (round === maxRounds - 1 && lastViewResult) {
+        return {
+          role: 'view',
+          success: true,
+          data: lastViewResult,
+          explanation: textContent || 'View created successfully',
+        };
+      }
     }
 
     return {
-      role: 'query',
+      role: 'view',
       success: false,
-      data: lastQueryResult ?? {},
-      explanation: 'Exceeded maximum tool rounds',
+      data: {},
+      explanation: 'Exceeded maximum tool rounds without producing a view',
       error: 'max_tool_rounds',
     };
+  }
+
+  /** Extract structured view data from the agent's text response. */
+  private extractViewData(text: string): Record<string, unknown> {
+    const jsonMatch = text.match(/```json\s*([\s\S]*?)```/);
+    if (jsonMatch?.[1]) {
+      try {
+        return JSON.parse(jsonMatch[1]) as Record<string, unknown>;
+      } catch {
+        // fall through
+      }
+    }
+    return { rawText: text };
   }
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,13 @@
 export { Agent, type AgentConfig, type AgentDataSource, type AgentEvent } from './agent';
+export {
+  QueryAgent,
+  type QueryAgentConfig,
+  type AgentTask,
+  type SubAgent,
+  type SubAgentResult,
+  type SubAgentRole,
+  type ToolCallRecord,
+} from './agents';
 export { ConversationManager } from './conversation';
 export {
   ClaudeProvider,
@@ -11,5 +20,5 @@ export {
   type StreamEvent,
   type ToolDefinition,
 } from './provider';
-export { buildSystemPrompt } from './prompt';
-export { agentTools, ToolRouter, type ToolContext, type ToolExecutionResult } from './tools';
+export { buildSystemPrompt, buildQueryPrompt } from './prompt';
+export { agentTools, queryTools, viewTools, ToolRouter, type ToolContext, type ToolExecutionResult } from './tools';

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,12 +1,13 @@
 export { Agent, type AgentConfig, type AgentDataSource, type AgentEvent } from './agent';
 export {
   QueryAgent,
-  type QueryAgentConfig,
-  type AgentTask,
+  ViewAgent,
+  InsightsAgent,
   type SubAgent,
-  type SubAgentResult,
+  type SubAgentConfig,
   type SubAgentRole,
-  type ToolCallRecord,
+  type AgentTask,
+  type SubAgentResult,
 } from './agents';
 export { ConversationManager } from './conversation';
 export {
@@ -20,5 +21,13 @@ export {
   type StreamEvent,
   type ToolDefinition,
 } from './provider';
-export { buildSystemPrompt, buildQueryPrompt } from './prompt';
-export { agentTools, queryTools, viewTools, ToolRouter, type ToolContext, type ToolExecutionResult } from './tools';
+export { buildSystemPrompt, buildQueryPrompt, buildViewPrompt, buildInsightsPrompt } from './prompt';
+export {
+  agentTools,
+  queryTools,
+  viewTools,
+  insightsTools,
+  ToolRouter,
+  type ToolContext,
+  type ToolExecutionResult,
+} from './tools';

--- a/packages/agent/src/prompt/index.ts
+++ b/packages/agent/src/prompt/index.ts
@@ -1,1 +1,2 @@
 export { buildSystemPrompt } from './system';
+export { buildQueryPrompt } from './query-prompt';

--- a/packages/agent/src/prompt/index.ts
+++ b/packages/agent/src/prompt/index.ts
@@ -1,2 +1,4 @@
 export { buildSystemPrompt } from './system';
 export { buildQueryPrompt } from './query-prompt';
+export { buildViewPrompt } from './view-prompt';
+export { buildInsightsPrompt } from './insights-prompt';

--- a/packages/agent/src/prompt/insights-prompt.ts
+++ b/packages/agent/src/prompt/insights-prompt.ts
@@ -1,0 +1,53 @@
+/**
+ * Builds the system prompt for the Insights Agent specialist.
+ * Contains statistical analysis patterns for DuckDB analytics.
+ * Kept under 1K tokens for focused context.
+ */
+export function buildInsightsPrompt(context: Record<string, unknown>): string {
+  const parts = [INSIGHTS_SYSTEM_PROMPT];
+
+  if (context.dataSummary) {
+    parts.push(`\n## Data Summary\n${JSON.stringify(context.dataSummary, null, 2)}`);
+  }
+
+  if (context.tableName) {
+    parts.push(`\nTarget table: "${context.tableName}"`);
+  }
+
+  return parts.join('\n');
+}
+
+const INSIGHTS_SYSTEM_PROMPT = `You are a statistical analysis specialist. Your job is to find patterns and insights in data using DuckDB SQL.
+
+## Tool
+- analyze_data: Execute DuckDB SQL on the scratchpad to compute statistics
+
+## Analysis Patterns
+
+Descriptive stats:
+  SELECT column, COUNT(*), AVG(val), STDDEV(val), MIN(val), MAX(val),
+         PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY val) AS median
+  FROM table GROUP BY column
+
+Distribution:
+  SELECT HISTOGRAM(column) FROM table
+
+Correlation:
+  SELECT CORR(col_a, col_b) FROM table
+
+Top-N:
+  SELECT column, SUM(metric) AS total FROM table GROUP BY column ORDER BY total DESC LIMIT 10
+
+Time trends:
+  SELECT DATE_TRUNC('month', date_col) AS period, AVG(metric) FROM table GROUP BY period ORDER BY period
+
+Outliers (IQR method):
+  WITH stats AS (SELECT PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY val) AS q1,
+                        PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY val) AS q3 FROM table)
+  SELECT * FROM table, stats WHERE val < q1 - 1.5*(q3-q1) OR val > q3 + 1.5*(q3-q1)
+
+## Rules
+- Write read-only SELECT queries only
+- Return clear explanations of findings
+- Highlight anomalies, trends, and notable patterns
+- Use DuckDB SQL syntax (supports PERCENTILE_CONT, HISTOGRAM, etc.)`;

--- a/packages/agent/src/prompt/query-prompt.ts
+++ b/packages/agent/src/prompt/query-prompt.ts
@@ -1,0 +1,77 @@
+/**
+ * Data source context with schema for building the query agent's system prompt.
+ * Mirrors the shape used by the main system prompt builder.
+ */
+interface DataSourceContext {
+  id: string;
+  name: string;
+  type: string;
+  cachedSchema?: {
+    tables: {
+      name: string;
+      schema: string;
+      columns: { name: string; type: string; nullable: boolean; primaryKey: boolean }[];
+    }[];
+  } | null;
+}
+
+/**
+ * Builds a focused system prompt for the Query Agent specialist.
+ * Contains schema details and QueryIR specification — no chart or view knowledge.
+ * Designed to stay under ~2K tokens for efficient context usage.
+ */
+export function buildQueryPrompt(context: {
+  dataSources: DataSourceContext[];
+}): string {
+  const parts = [QUERY_AGENT_INSTRUCTIONS];
+
+  for (const ds of context.dataSources) {
+    parts.push(`\n### Data Source: "${ds.name}" (id: "${ds.id}", type: ${ds.type})`);
+
+    if (ds.cachedSchema && ds.cachedSchema.tables.length > 0) {
+      parts.push('Tables:');
+      for (const table of ds.cachedSchema.tables) {
+        const cols = table.columns
+          .map((c) => `  - ${c.name} (${c.type}${c.primaryKey ? ', PK' : ''}${c.nullable ? ', nullable' : ''})`)
+          .join('\n');
+        parts.push(`${table.name}:\n${cols}`);
+      }
+    } else {
+      parts.push('Schema not cached — use get_schema to discover tables.');
+    }
+  }
+
+  return parts.join('\n');
+}
+
+const QUERY_AGENT_INSTRUCTIONS = `You are Lightboard's Query Agent — a data retrieval specialist.
+Your job: given a data question, explore schemas and execute queries to retrieve the answer.
+
+## Rules
+
+1. Schema is provided below. Only call get_schema if it says "not cached".
+2. Use execute_query with QueryIR for single-table queries.
+3. Use run_sql for JOINs or complex SQL that QueryIR cannot express.
+4. Return data — do NOT create views or charts. That is another agent's job.
+5. If a query fails, read the error, fix the query, and retry once.
+6. Be efficient: 1-2 tool calls max.
+
+## QueryIR Specification
+
+\`\`\`
+{
+  source: string,           // Data source ID (REQUIRED)
+  table: string,            // Primary table name (REQUIRED)
+  select: FieldRef[],       // [{field: "col", alias?: "name"}]
+  filter?: FilterClause,    // {field: {field: "col"}, operator: "eq"|"neq"|"gt"|"gte"|"lt"|"lte"|"in"|"like"|"is_null", value: ...}
+  aggregations: Agg[],      // [{function: "sum"|"avg"|"count"|"count_distinct"|"min"|"max", field: {field: "col"}, alias: "name"}]
+  groupBy: FieldRef[],      // [{field: "col"}]
+  orderBy: OrderClause[],   // [{field: {field: "col"}, direction: "asc"|"desc"}]
+  joins: JoinClause[],      // [{type: "inner"|"left", table: "name", alias: "t", on: FilterClause}]
+  limit?: number
+}
+\`\`\`
+
+RULES:
+- aggregations, groupBy, orderBy, joins MUST be arrays (use [] if empty)
+- For COUNT(*): {function: "count", field: {field: "*"}, alias: "total"}`;

--- a/packages/agent/src/prompt/view-prompt.ts
+++ b/packages/agent/src/prompt/view-prompt.ts
@@ -1,0 +1,64 @@
+/**
+ * Builds the system prompt for the View Agent specialist.
+ * Contains chart type catalog, ViewSpec format, and control patterns.
+ * Kept under 1.5K tokens for focused context.
+ */
+export function buildViewPrompt(context: Record<string, unknown>): string {
+  const parts = [VIEW_SYSTEM_PROMPT];
+
+  if (context.dataSummary) {
+    parts.push(`\n## Data Summary\n${JSON.stringify(context.dataSummary, null, 2)}`);
+  }
+
+  if (context.currentView) {
+    parts.push(`\n## Current View\n${JSON.stringify(context.currentView, null, 2)}`);
+  }
+
+  return parts.join('\n');
+}
+
+const VIEW_SYSTEM_PROMPT = `You are a visualization specialist. Your job is to choose the best chart type and produce a ViewSpec.
+
+## Chart Type Catalog
+
+| Type | ID | Best for | Required config |
+|------|----|----------|-----------------|
+| Bar Chart | bar-chart | Categorical comparisons | xField, yFields[] |
+| Time Series | time-series-line | Trends over time | xField (date/time), yFields[] |
+| Stat Card | stat-card | Single KPI values | valueField, label? |
+| Data Table | data-table | Raw/detailed data | columns[] |
+
+## ViewSpec Format
+
+{
+  title: string,
+  description: string,
+  query: QueryIR,         // The query that feeds data to the chart
+  chart: {
+    type: string,         // One of: bar-chart, time-series-line, stat-card, data-table
+    config: { ... }       // Type-specific config (see catalog above)
+  },
+  controls: Control[]     // Interactive filters
+}
+
+## Control Types
+
+- dropdown: Single-select categorical filter. Config: { type, label, variable, defaultValue }
+- multi_select: Multi-select filter. Same shape as dropdown.
+- date_range: Date range picker. Config: { type, label, variable, defaultValue: { from, to } }
+- text_input: Free-text search filter. Config: { type, label, variable }
+- toggle: Boolean toggle. Config: { type, label, variable, defaultValue: boolean }
+
+## Chart Selection Rules
+
+1. Categorical column + numeric column -> bar-chart (xField=categorical, yFields=[numeric])
+2. Date/time column + numeric column -> time-series-line (xField=date, yFields=[numeric])
+3. Single aggregate value -> stat-card (valueField=the aggregate alias)
+4. Multiple columns, no clear viz pattern -> data-table
+5. Add dropdown controls for categorical columns with < 20 distinct values
+6. Add date_range controls for date columns
+
+## Rules
+- Always include title and description
+- Use create_view for new visualizations, modify_view for changes
+- Match chart config fields exactly to query output column names/aliases`;

--- a/packages/agent/src/tools/index.ts
+++ b/packages/agent/src/tools/index.ts
@@ -1,2 +1,4 @@
 export { agentTools } from './definitions';
+export { queryTools } from './query-tools';
+export { viewTools } from './view-tools';
 export { ToolRouter, type ToolContext, type ToolExecutionResult } from './router';

--- a/packages/agent/src/tools/index.ts
+++ b/packages/agent/src/tools/index.ts
@@ -1,4 +1,5 @@
 export { agentTools } from './definitions';
 export { queryTools } from './query-tools';
 export { viewTools } from './view-tools';
+export { insightsTools } from './insights-tools';
 export { ToolRouter, type ToolContext, type ToolExecutionResult } from './router';

--- a/packages/agent/src/tools/insights-tools.ts
+++ b/packages/agent/src/tools/insights-tools.ts
@@ -1,0 +1,32 @@
+import type { ToolDefinition } from '../provider/types';
+
+/**
+ * Tool definitions available to the Insights Agent specialist.
+ * Single tool for running DuckDB analytics on the scratchpad.
+ */
+export const insightsTools: ToolDefinition[] = [
+  {
+    name: 'analyze_data',
+    description:
+      'Execute a DuckDB SQL query on the session scratchpad for statistical analysis. ' +
+      'Use this for computing aggregations, distributions, correlations, and other analytics. ' +
+      'Only read-only SELECT queries are allowed. The scratchpad contains intermediate data ' +
+      'saved by previous query steps.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        sql: {
+          type: 'string',
+          description:
+            'A read-only DuckDB SELECT query for statistical analysis. ' +
+            'DuckDB supports PERCENTILE_CONT, HISTOGRAM, CORR, and other advanced analytics functions.',
+        },
+        description: {
+          type: 'string',
+          description: 'Brief description of what this analysis computes',
+        },
+      },
+      required: ['sql'],
+    },
+  },
+];

--- a/packages/agent/src/tools/query-tools.ts
+++ b/packages/agent/src/tools/query-tools.ts
@@ -1,0 +1,79 @@
+import type { ToolDefinition } from '../provider/types';
+
+/**
+ * Tool definitions for the Query Agent specialist.
+ * These tools focus on schema exploration and data retrieval.
+ */
+export const queryTools: ToolDefinition[] = [
+  {
+    name: 'get_schema',
+    description:
+      'Get the schema (tables, columns, types, relationships) of a connected data source. ' +
+      'Always call this before writing a query to understand what data is available.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source_id: {
+          type: 'string',
+          description: 'The ID of the data source to introspect',
+        },
+      },
+      required: ['source_id'],
+    },
+  },
+  {
+    name: 'execute_query',
+    description:
+      'Execute a query against a data source using QueryIR (not raw SQL). ' +
+      'Returns the query results. Use get_schema first to understand the available tables and columns.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source_id: {
+          type: 'string',
+          description: 'The data source to query',
+        },
+        query_ir: {
+          type: 'object',
+          description: 'The QueryIR document describing the query',
+          properties: {
+            source: { type: 'string' },
+            table: { type: 'string' },
+            select: { type: 'array', items: { type: 'object' } },
+            filter: { type: 'object' },
+            aggregations: { type: 'array', items: { type: 'object' } },
+            groupBy: { type: 'array', items: { type: 'object' } },
+            orderBy: { type: 'array', items: { type: 'object' } },
+            timeRange: { type: 'object' },
+            joins: { type: 'array', items: { type: 'object' } },
+            limit: { type: 'number' },
+            offset: { type: 'number' },
+          },
+          required: ['source', 'table'],
+        },
+      },
+      required: ['source_id', 'query_ir'],
+    },
+  },
+  {
+    name: 'run_sql',
+    description:
+      'Execute a read-only SELECT SQL query directly against a data source. ' +
+      'Use this for complex queries involving JOINs that are hard to express in QueryIR. ' +
+      'Only SELECT queries are allowed. Results are limited to 1000 rows.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source_id: {
+          type: 'string',
+          description: 'The data source to query',
+        },
+        sql: {
+          type: 'string',
+          description: 'A read-only SELECT SQL query',
+        },
+      },
+      required: ['source_id', 'sql'],
+    },
+  },
+];

--- a/packages/agent/src/tools/router.test.ts
+++ b/packages/agent/src/tools/router.test.ts
@@ -94,7 +94,7 @@ describe('ToolRouter', () => {
 
     const result = await router.execute('unknown_tool', {});
     expect(result.isError).toBe(true);
-    expect(result.content).toContain('Unknown tool');
+    expect(result.content).toContain('not available');
   });
 
   it('returns error for invalid get_schema input', async () => {

--- a/packages/agent/src/tools/router.ts
+++ b/packages/agent/src/tools/router.ts
@@ -1,5 +1,6 @@
-import { queryIRSchema } from '@lightboard/query-ir';
 import { z } from 'zod';
+
+import type { ToolDefinition } from '../provider/types';
 
 /** Context provided to tool handlers for accessing services. */
 export interface ToolContext {
@@ -52,19 +53,27 @@ const toolInputSchemas = {
 
 /**
  * Routes tool calls from the LLM to the appropriate handler.
- * Each handler validates inputs, delegates to services, and returns
- * structured results (or errors for agent self-correction).
+ * Accepts a dynamic set of tool definitions at construction time,
+ * allowing different agents to use different tool subsets.
  */
 export class ToolRouter {
   private context: ToolContext;
   private viewStore = new Map<string, Record<string, unknown>>();
+  private allowedTools: Set<string>;
 
-  constructor(context: ToolContext) {
+  constructor(context: ToolContext, toolDefinitions?: ToolDefinition[]) {
     this.context = context;
+    this.allowedTools = toolDefinitions
+      ? new Set(toolDefinitions.map((t) => t.name))
+      : new Set(['get_schema', 'execute_query', 'run_sql', 'create_view', 'modify_view']);
   }
 
   /** Execute a tool call and return the result. Errors are returned, not thrown. */
   async execute(toolName: string, input: Record<string, unknown>): Promise<ToolExecutionResult> {
+    if (!this.allowedTools.has(toolName)) {
+      return { content: `Tool "${toolName}" is not available for this agent`, isError: true };
+    }
+
     // Auto-parse stringified JSON values — local models often send nested objects as strings
     const normalizedInput = this.normalizeInput(input);
     // Debug: log normalization for troubleshooting local model issues

--- a/packages/agent/src/tools/router.ts
+++ b/packages/agent/src/tools/router.ts
@@ -12,6 +12,8 @@ export interface ToolContext {
   runSQL?: (sourceId: string, sql: string) => Promise<Record<string, unknown>>;
   /** Get the current view state. */
   getCurrentView?: () => Record<string, unknown> | null;
+  /** Execute DuckDB SQL on the session scratchpad for statistical analysis. */
+  analyzeData?: (sql: string) => Promise<Record<string, unknown>>;
 }
 
 /** Result of a tool execution. */
@@ -48,6 +50,10 @@ const toolInputSchemas = {
   run_sql: z.object({
     source_id: z.string().min(1),
     sql: z.string().min(1),
+  }),
+  analyze_data: z.object({
+    sql: z.string().min(1),
+    description: z.string().optional(),
   }),
 };
 
@@ -97,6 +103,8 @@ export class ToolRouter {
           return await this.handleCreateView(normalizedInput);
         case 'modify_view':
           return await this.handleModifyView(normalizedInput);
+        case 'analyze_data':
+          return await this.handleAnalyzeData(normalizedInput);
         default:
           return { content: `Unknown tool: ${toolName}`, isError: true };
       }
@@ -186,6 +194,21 @@ export class ToolRouter {
     }
 
     const result = await this.context.runSQL(parsed.data.source_id, parsed.data.sql);
+    return { content: JSON.stringify(result, null, 2), isError: false };
+  }
+
+  /** Handle analyze_data tool call — DuckDB analytics on the scratchpad. */
+  private async handleAnalyzeData(input: Record<string, unknown>): Promise<ToolExecutionResult> {
+    const parsed = toolInputSchemas.analyze_data.safeParse(input);
+    if (!parsed.success) {
+      return { content: `Invalid input for analyze_data: ${parsed.error.message}`, isError: true };
+    }
+
+    if (!this.context.analyzeData) {
+      return { content: 'analyze_data is not available — no scratchpad configured', isError: true };
+    }
+
+    const result = await this.context.analyzeData(parsed.data.sql);
     return { content: JSON.stringify(result, null, 2), isError: false };
   }
 

--- a/packages/agent/src/tools/view-tools.ts
+++ b/packages/agent/src/tools/view-tools.ts
@@ -1,0 +1,79 @@
+import type { ToolDefinition } from '../provider/types';
+
+/**
+ * Tool definitions for the View Agent specialist.
+ * These tools focus on creating and modifying visualizations.
+ */
+export const viewTools: ToolDefinition[] = [
+  {
+    name: 'create_view',
+    description:
+      'Create an interactive visualization view from query results. ' +
+      'Specify the chart type, configuration, and interactive controls. ' +
+      'Controls should include dropdowns for categorical columns and date range pickers for time columns.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        view_spec: {
+          type: 'object',
+          description: 'The ViewSpec document describing the view',
+          properties: {
+            title: { type: 'string', description: 'Title for the view' },
+            description: { type: 'string', description: 'Description of what the view shows' },
+            query: { type: 'object', description: 'QueryIR for the view data' },
+            chart: {
+              type: 'object',
+              properties: {
+                type: { type: 'string', description: 'Panel plugin ID (time-series-line, bar-chart, stat-card, data-table)' },
+                config: { type: 'object', description: 'Chart-specific configuration' },
+              },
+              required: ['type', 'config'],
+            },
+            controls: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  type: { type: 'string', enum: ['dropdown', 'multi_select', 'date_range', 'text_input', 'toggle'] },
+                  label: { type: 'string' },
+                  variable: { type: 'string', description: 'Template variable name (without $)' },
+                  defaultValue: {},
+                },
+                required: ['type', 'label', 'variable'],
+              },
+            },
+          },
+          required: ['query', 'chart'],
+        },
+      },
+      required: ['view_spec'],
+    },
+  },
+  {
+    name: 'modify_view',
+    description:
+      'Modify an existing view — change chart type, add/remove controls, update filters, adjust configuration. ' +
+      'Use this for follow-up requests like "show it as a bar chart" or "add a filter for region".',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        view_id: {
+          type: 'string',
+          description: 'The ID of the view to modify',
+        },
+        patch: {
+          type: 'object',
+          description: 'Partial ViewSpec with only the fields to change',
+          properties: {
+            title: { type: 'string' },
+            description: { type: 'string' },
+            query: { type: 'object' },
+            chart: { type: 'object' },
+            controls: { type: 'array' },
+          },
+        },
+      },
+      required: ['view_id', 'patch'],
+    },
+  },
+];


### PR DESCRIPTION
## Summary

- **ViewAgent**: Chart type selection and ViewSpec generation specialist with `create_view` and `modify_view` tools
- **InsightsAgent**: Statistical analysis specialist with `analyze_data` tool for DuckDB scratchpad analytics
- Refined `SubAgent` interface: `SubAgentConfig` (provider + toolRouter), `execute()` -> `AsyncIterable<SubAgentResult>`
- QueryAgent updated to match new interface (cleaner for headless sub-agents)
- Focused system prompts: view prompt with chart catalog (<1.5K tokens), insights prompt with SQL patterns (<1K tokens)
- `analyze_data` handler added to `ToolRouter` with `ToolContext.analyzeData`

## Test plan

- [x] 14 new tests (8 ViewAgent + 6 InsightsAgent)
- [x] 51 total tests passing
- [x] TypeScript strict mode clean

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)