### PR TITLE
feat: session scratchpad for intermediate data storage (D-1.5.3)

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -21,4 +21,5 @@ export {
   type ToolDefinition,
 } from './provider';
 export { buildSystemPrompt, buildQueryPrompt } from './prompt';
-export { agentTools, queryTools, viewTools, ToolRouter, type ToolContext, type ToolExecutionResult } from './tools';
+export { agentTools, queryTools, viewTools, scratchpadTools, ToolRouter, type ToolContext, type ToolExecutionResult } from './tools';
+export { SessionScratchpad, ScratchpadManager, type ScratchpadTable, type ScratchpadLimits, type ScratchpadManagerOptions } from './scratchpad';

--- a/packages/agent/src/scratchpad/index.ts
+++ b/packages/agent/src/scratchpad/index.ts
@@ -1,0 +1,2 @@
+export { SessionScratchpad, type ScratchpadTable, type ScratchpadLimits } from './scratchpad';
+export { ScratchpadManager, type ScratchpadManagerOptions } from './manager';

--- a/packages/agent/src/scratchpad/manager.test.ts
+++ b/packages/agent/src/scratchpad/manager.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ScratchpadManager } from './manager';
+
+describe('ScratchpadManager', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates and retrieves a scratchpad for a session', async () => {
+    const mgr = new ScratchpadManager({ cleanupIntervalMs: 0 });
+    const sp = mgr.getOrCreate('s1');
+
+    expect(sp.sessionId).toBe('s1');
+    expect(mgr.has('s1')).toBe(true);
+    expect(mgr.sessionCount).toBe(1);
+
+    // Same session returns the same instance
+    const sp2 = mgr.getOrCreate('s1');
+    expect(sp2).toBe(sp);
+
+    await mgr.destroyAll();
+  });
+
+  it('reports correct session count across multiple sessions', async () => {
+    const mgr = new ScratchpadManager({ cleanupIntervalMs: 0 });
+    mgr.getOrCreate('a');
+    mgr.getOrCreate('b');
+    mgr.getOrCreate('c');
+
+    expect(mgr.sessionCount).toBe(3);
+
+    await mgr.destroy('b');
+    expect(mgr.sessionCount).toBe(2);
+    expect(mgr.has('b')).toBe(false);
+
+    await mgr.destroyAll();
+  });
+
+  it('destroys a specific session', async () => {
+    const mgr = new ScratchpadManager({ cleanupIntervalMs: 0 });
+    const sp = mgr.getOrCreate('target');
+    await sp.saveTable('data', [{ x: 1 }]);
+
+    await mgr.destroy('target');
+    expect(mgr.has('target')).toBe(false);
+    expect(sp.isDestroyed).toBe(true);
+
+    // Destroying a non-existent session is a no-op
+    await mgr.destroy('nonexistent');
+
+    await mgr.destroyAll();
+  });
+
+  it('cleans up stale sessions based on maxSessionAgeMs', async () => {
+    const mgr = new ScratchpadManager({
+      cleanupIntervalMs: 0,
+      maxSessionAgeMs: 1000,
+    });
+
+    const sp = mgr.getOrCreate('old');
+    await sp.saveTable('data', [{ v: 1 }]);
+
+    // Manually backdate the lastAccess by mocking Date.now
+    const originalNow = Date.now;
+    vi.spyOn(Date, 'now').mockReturnValue(originalNow() + 2000);
+
+    const cleaned = await mgr.cleanup();
+    expect(cleaned).toBe(1);
+    expect(mgr.has('old')).toBe(false);
+
+    vi.spyOn(Date, 'now').mockRestore();
+    await mgr.destroyAll();
+  });
+
+  it('destroyAll cleans up all sessions', async () => {
+    const mgr = new ScratchpadManager({ cleanupIntervalMs: 0 });
+    mgr.getOrCreate('x');
+    mgr.getOrCreate('y');
+    mgr.getOrCreate('z');
+
+    expect(mgr.sessionCount).toBe(3);
+
+    await mgr.destroyAll();
+    expect(mgr.sessionCount).toBe(0);
+  });
+
+  it('creates a new scratchpad if the previous one was destroyed', async () => {
+    const mgr = new ScratchpadManager({ cleanupIntervalMs: 0 });
+    const sp1 = mgr.getOrCreate('s1');
+    await sp1.destroy();
+
+    // getOrCreate should detect the destroyed scratchpad and create a new one
+    const sp2 = mgr.getOrCreate('s1');
+    expect(sp2).not.toBe(sp1);
+    expect(sp2.isDestroyed).toBe(false);
+
+    await mgr.destroyAll();
+  });
+
+  it('passes scratchpad limits to new scratchpads', async () => {
+    const mgr = new ScratchpadManager({
+      cleanupIntervalMs: 0,
+      scratchpadLimits: { maxTables: 1 },
+    });
+
+    const sp = mgr.getOrCreate('limited');
+    await sp.saveTable('t1', [{ a: 1 }]);
+    await expect(sp.saveTable('t2', [{ b: 2 }])).rejects.toThrow('limit');
+
+    await mgr.destroyAll();
+  });
+});

--- a/packages/agent/src/scratchpad/manager.ts
+++ b/packages/agent/src/scratchpad/manager.ts
@@ -1,0 +1,137 @@
+import { SessionScratchpad, type ScratchpadLimits } from './scratchpad';
+
+/** Configuration options for the ScratchpadManager. */
+export interface ScratchpadManagerOptions {
+  /** Interval in ms between automatic cleanup sweeps (default: 5 minutes). */
+  cleanupIntervalMs?: number;
+  /** Maximum age in ms before a session is considered stale (default: 30 minutes). */
+  maxSessionAgeMs?: number;
+  /** Limits to apply to each new scratchpad. */
+  scratchpadLimits?: Partial<ScratchpadLimits>;
+}
+
+/** Default manager configuration. */
+const DEFAULTS = {
+  cleanupIntervalMs: 5 * 60 * 1000,
+  maxSessionAgeMs: 30 * 60 * 1000,
+};
+
+/**
+ * Manages the lifecycle of per-session scratchpads.
+ *
+ * Provides get-or-create semantics, automatic cleanup of stale sessions,
+ * and bulk teardown for graceful shutdown.
+ */
+export class ScratchpadManager {
+  private sessions = new Map<string, SessionScratchpad>();
+  private readonly maxSessionAgeMs: number;
+  private readonly scratchpadLimits: Partial<ScratchpadLimits> | undefined;
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(options?: ScratchpadManagerOptions) {
+    this.maxSessionAgeMs = options?.maxSessionAgeMs ?? DEFAULTS.maxSessionAgeMs;
+    this.scratchpadLimits = options?.scratchpadLimits;
+
+    const intervalMs = options?.cleanupIntervalMs ?? DEFAULTS.cleanupIntervalMs;
+    if (intervalMs > 0) {
+      this.cleanupTimer = setInterval(() => {
+        void this.cleanup();
+      }, intervalMs);
+      // Allow Node to exit even if the timer is still running
+      if (typeof this.cleanupTimer === 'object' && 'unref' in this.cleanupTimer) {
+        this.cleanupTimer.unref();
+      }
+    }
+  }
+
+  /**
+   * Get or create a scratchpad for the given session.
+   *
+   * If a scratchpad already exists for the session it is returned.
+   * Otherwise a new one is created with the manager's default limits.
+   *
+   * @param sessionId - Unique session identifier.
+   * @returns The session's scratchpad.
+   */
+  getOrCreate(sessionId: string): SessionScratchpad {
+    const existing = this.sessions.get(sessionId);
+    if (existing && !existing.isDestroyed) {
+      return existing;
+    }
+
+    const scratchpad = new SessionScratchpad(sessionId, this.scratchpadLimits);
+    this.sessions.set(sessionId, scratchpad);
+    return scratchpad;
+  }
+
+  /**
+   * Check whether a scratchpad exists for the given session.
+   *
+   * @param sessionId - Unique session identifier.
+   * @returns True if an active scratchpad exists.
+   */
+  has(sessionId: string): boolean {
+    const s = this.sessions.get(sessionId);
+    return s !== undefined && !s.isDestroyed;
+  }
+
+  /**
+   * Destroy a specific session's scratchpad and remove it from the manager.
+   *
+   * @param sessionId - Unique session identifier.
+   */
+  async destroy(sessionId: string): Promise<void> {
+    const scratchpad = this.sessions.get(sessionId);
+    if (scratchpad) {
+      await scratchpad.destroy();
+      this.sessions.delete(sessionId);
+    }
+  }
+
+  /**
+   * Clean up stale sessions that have not been accessed within the
+   * configured `maxSessionAgeMs`.
+   *
+   * @returns Number of sessions destroyed.
+   */
+  async cleanup(): Promise<number> {
+    const now = Date.now();
+    let count = 0;
+
+    for (const [id, scratchpad] of this.sessions.entries()) {
+      const age = now - scratchpad.lastAccess.getTime();
+      if (age > this.maxSessionAgeMs || scratchpad.isDestroyed) {
+        await scratchpad.destroy();
+        this.sessions.delete(id);
+        count++;
+      }
+    }
+
+    return count;
+  }
+
+  /**
+   * Destroy all active scratchpads and stop the cleanup timer.
+   * Call this during graceful shutdown.
+   */
+  async destroyAll(): Promise<void> {
+    if (this.cleanupTimer !== null) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+
+    for (const [id, scratchpad] of this.sessions.entries()) {
+      await scratchpad.destroy();
+      this.sessions.delete(id);
+    }
+  }
+
+  /** Number of active (non-destroyed) sessions. */
+  get sessionCount(): number {
+    let count = 0;
+    for (const s of this.sessions.values()) {
+      if (!s.isDestroyed) count++;
+    }
+    return count;
+  }
+}

--- a/packages/agent/src/scratchpad/scratchpad.test.ts
+++ b/packages/agent/src/scratchpad/scratchpad.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+import { SessionScratchpad } from './scratchpad';
+
+const sampleRows = [
+  { id: 1, name: 'Alice', score: 95.5 },
+  { id: 2, name: 'Bob', score: 87.0 },
+  { id: 3, name: 'Charlie', score: 92.3 },
+];
+
+describe('SessionScratchpad', () => {
+  it('saves and loads a table', async () => {
+    const sp = new SessionScratchpad('session-1');
+    const meta = await sp.saveTable('results', sampleRows, 'Test results');
+
+    expect(meta.name).toBe('results');
+    expect(meta.description).toBe('Test results');
+    expect(meta.rowCount).toBe(3);
+    expect(meta.columns).toEqual([
+      { name: 'id', type: 'integer' },
+      { name: 'name', type: 'string' },
+      { name: 'score', type: 'float' },
+    ]);
+
+    const loaded = await sp.loadTable('results');
+    expect(loaded).toEqual(sampleRows);
+
+    await sp.destroy();
+  });
+
+  it('returns a copy of rows (no mutation leakage)', async () => {
+    const sp = new SessionScratchpad('session-2');
+    await sp.saveTable('data', sampleRows);
+
+    const loaded = await sp.loadTable('data');
+    loaded.push({ id: 4, name: 'Diana', score: 88 });
+
+    const reloaded = await sp.loadTable('data');
+    expect(reloaded).toHaveLength(3);
+
+    await sp.destroy();
+  });
+
+  it('lists tables with metadata', async () => {
+    const sp = new SessionScratchpad('session-3');
+    await sp.saveTable('table_a', [{ x: 1 }], 'First table');
+    await sp.saveTable('table_b', [{ y: 2 }], 'Second table');
+
+    const tables = sp.listTables();
+    expect(tables).toHaveLength(2);
+    expect(tables.map((t) => t.name).sort()).toEqual(['table_a', 'table_b']);
+
+    await sp.destroy();
+  });
+
+  it('checks table existence with hasTable', async () => {
+    const sp = new SessionScratchpad('session-4');
+    expect(sp.hasTable('missing')).toBe(false);
+
+    await sp.saveTable('present', [{ a: 1 }]);
+    expect(sp.hasTable('present')).toBe(true);
+    expect(sp.hasTable('missing')).toBe(false);
+
+    await sp.destroy();
+  });
+
+  it('drops a table', async () => {
+    const sp = new SessionScratchpad('session-5');
+    await sp.saveTable('temp', [{ val: 42 }]);
+    expect(sp.hasTable('temp')).toBe(true);
+
+    await sp.dropTable('temp');
+    expect(sp.hasTable('temp')).toBe(false);
+    expect(sp.listTables()).toHaveLength(0);
+
+    await sp.destroy();
+  });
+
+  it('throws when dropping a non-existent table', async () => {
+    const sp = new SessionScratchpad('session-6');
+    await expect(sp.dropTable('ghost')).rejects.toThrow('not found');
+    await sp.destroy();
+  });
+
+  it('throws when loading a non-existent table', async () => {
+    const sp = new SessionScratchpad('session-7');
+    await expect(sp.loadTable('ghost')).rejects.toThrow('not found');
+    await sp.destroy();
+  });
+
+  it('enforces maxTables limit', async () => {
+    const sp = new SessionScratchpad('session-8', { maxTables: 2 });
+    await sp.saveTable('t1', [{ a: 1 }]);
+    await sp.saveTable('t2', [{ b: 2 }]);
+
+    await expect(sp.saveTable('t3', [{ c: 3 }])).rejects.toThrow('limit');
+
+    await sp.destroy();
+  });
+
+  it('enforces maxRowsPerTable limit', async () => {
+    const sp = new SessionScratchpad('session-9', { maxRowsPerTable: 5 });
+    const bigRows = Array.from({ length: 6 }, (_, i) => ({ i }));
+
+    await expect(sp.saveTable('big', bigRows)).rejects.toThrow('limit');
+
+    await sp.destroy();
+  });
+
+  it('enforces maxSizeBytes limit', async () => {
+    const sp = new SessionScratchpad('session-10', { maxSizeBytes: 50 });
+    // Each row serialized is well over 50 bytes total
+    const rows = Array.from({ length: 10 }, (_, i) => ({ key: `value_${i}_padding` }));
+
+    await expect(sp.saveTable('fat', rows)).rejects.toThrow('limit');
+
+    await sp.destroy();
+  });
+
+  it('allows overwriting an existing table without hitting maxTables', async () => {
+    const sp = new SessionScratchpad('session-11', { maxTables: 1 });
+    await sp.saveTable('only', [{ v: 1 }]);
+
+    // Overwriting the same table should succeed even though maxTables is 1
+    const meta = await sp.saveTable('only', [{ v: 2 }, { v: 3 }]);
+    expect(meta.rowCount).toBe(2);
+
+    await sp.destroy();
+  });
+
+  it('rejects invalid table names', async () => {
+    const sp = new SessionScratchpad('session-12');
+    await expect(sp.saveTable('123bad', [{ a: 1 }])).rejects.toThrow('Invalid table name');
+    await expect(sp.saveTable('has space', [{ a: 1 }])).rejects.toThrow('Invalid table name');
+    await expect(sp.saveTable('', [{ a: 1 }])).rejects.toThrow('Invalid table name');
+    await sp.destroy();
+  });
+
+  it('throws on query (DuckDB not integrated)', async () => {
+    const sp = new SessionScratchpad('session-13');
+    await expect(sp.query('SELECT 1')).rejects.toThrow('DuckDB');
+    await sp.destroy();
+  });
+
+  it('reports size estimate', async () => {
+    const sp = new SessionScratchpad('session-14');
+    expect(sp.getSizeEstimate()).toBe(0);
+
+    await sp.saveTable('data', sampleRows);
+    expect(sp.getSizeEstimate()).toBeGreaterThan(0);
+
+    await sp.destroy();
+  });
+
+  it('throws after destroy', async () => {
+    const sp = new SessionScratchpad('session-15');
+    await sp.saveTable('data', [{ a: 1 }]);
+    await sp.destroy();
+
+    expect(sp.isDestroyed).toBe(true);
+    expect(() => sp.hasTable('data')).toThrow('destroyed');
+    await expect(sp.loadTable('data')).rejects.toThrow('destroyed');
+    await expect(sp.saveTable('x', [])).rejects.toThrow('destroyed');
+  });
+
+  it('handles empty rows gracefully', async () => {
+    const sp = new SessionScratchpad('session-16');
+    const meta = await sp.saveTable('empty', []);
+    expect(meta.rowCount).toBe(0);
+    expect(meta.columns).toEqual([]);
+
+    const loaded = await sp.loadTable('empty');
+    expect(loaded).toEqual([]);
+
+    await sp.destroy();
+  });
+});

--- a/packages/agent/src/scratchpad/scratchpad.ts
+++ b/packages/agent/src/scratchpad/scratchpad.ts
@@ -1,0 +1,268 @@
+/** Metadata for a table stored in the session scratchpad. */
+export interface ScratchpadTable {
+  /** Table name (used as identifier). */
+  name: string;
+  /** Human-readable description of what this table contains. */
+  description: string;
+  /** Column definitions inferred from the data. */
+  columns: { name: string; type: string }[];
+  /** Number of rows in the table. */
+  rowCount: number;
+  /** When the table was created. */
+  createdAt: Date;
+}
+
+/** Resource limits for a session scratchpad. */
+export interface ScratchpadLimits {
+  /** Maximum number of tables allowed (default: 10). */
+  maxTables: number;
+  /** Maximum rows per table (default: 100,000). */
+  maxRowsPerTable: number;
+  /** Maximum total size in bytes (default: 100MB). */
+  maxSizeBytes: number;
+}
+
+/** Default limits for a session scratchpad. */
+const DEFAULT_LIMITS: ScratchpadLimits = {
+  maxTables: 10,
+  maxRowsPerTable: 100_000,
+  maxSizeBytes: 100 * 1024 * 1024,
+};
+
+/** Internal storage entry for a scratchpad table. */
+interface TableEntry {
+  rows: Record<string, unknown>[];
+  metadata: ScratchpadTable;
+}
+
+/**
+ * Per-session in-memory scratchpad for storing intermediate query results.
+ *
+ * Agents save named tables during multi-step analysis so that later steps
+ * can reference earlier results. This implementation uses an in-memory
+ * Map-based store; DuckDB-backed SQL queries will be added later.
+ */
+export class SessionScratchpad {
+  /** Unique session identifier. */
+  readonly sessionId: string;
+  /** Resource limits. */
+  private readonly limits: ScratchpadLimits;
+  /** Table storage. */
+  private tables = new Map<string, TableEntry>();
+  /** Timestamp of the last write operation (used for staleness checks). */
+  private _lastAccess: Date;
+  /** Whether this scratchpad has been destroyed. */
+  private destroyed = false;
+
+  constructor(sessionId: string, limits?: Partial<ScratchpadLimits>) {
+    this.sessionId = sessionId;
+    this.limits = { ...DEFAULT_LIMITS, ...limits };
+    this._lastAccess = new Date();
+  }
+
+  /** Timestamp of the last write operation. */
+  get lastAccess(): Date {
+    return this._lastAccess;
+  }
+
+  /**
+   * Save an array of row objects as a named table.
+   *
+   * @param name - Table name (must be a valid identifier).
+   * @param rows - Array of row objects to store.
+   * @param description - Optional human-readable description.
+   * @returns Metadata about the saved table.
+   * @throws If limits are exceeded or scratchpad is destroyed.
+   */
+  async saveTable(
+    name: string,
+    rows: Record<string, unknown>[],
+    description?: string,
+  ): Promise<ScratchpadTable> {
+    this.ensureAlive();
+
+    if (!name || !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+      throw new Error(
+        `Invalid table name "${name}". Must start with a letter or underscore and contain only alphanumeric characters and underscores.`,
+      );
+    }
+
+    // Check row limit
+    if (rows.length > this.limits.maxRowsPerTable) {
+      throw new Error(
+        `Row count ${rows.length} exceeds limit of ${this.limits.maxRowsPerTable} rows per table.`,
+      );
+    }
+
+    // Check table count (only if this is a new table)
+    if (!this.tables.has(name) && this.tables.size >= this.limits.maxTables) {
+      throw new Error(
+        `Table count would exceed limit of ${this.limits.maxTables}. Drop a table first.`,
+      );
+    }
+
+    // Estimate size and check limit
+    const serialized = JSON.stringify(rows);
+    const newSize = this.getSizeEstimateExcluding(name) + serialized.length;
+    if (newSize > this.limits.maxSizeBytes) {
+      throw new Error(
+        `Total size would exceed limit of ${this.limits.maxSizeBytes} bytes. Drop a table first.`,
+      );
+    }
+
+    // Infer columns from the first row (or empty array if no rows)
+    const columns = rows.length > 0 ? this.inferColumns(rows[0]!) : [];
+
+    const metadata: ScratchpadTable = {
+      name,
+      description: description ?? '',
+      columns,
+      rowCount: rows.length,
+      createdAt: new Date(),
+    };
+
+    this.tables.set(name, { rows: [...rows], metadata });
+    this._lastAccess = new Date();
+
+    return metadata;
+  }
+
+  /**
+   * Load all rows from a named table.
+   *
+   * @param name - The table name to load.
+   * @returns Array of row objects.
+   * @throws If the table does not exist or scratchpad is destroyed.
+   */
+  async loadTable(name: string): Promise<Record<string, unknown>[]> {
+    this.ensureAlive();
+
+    const entry = this.tables.get(name);
+    if (!entry) {
+      throw new Error(`Table "${name}" not found in scratchpad.`);
+    }
+    this._lastAccess = new Date();
+    return [...entry.rows];
+  }
+
+  /**
+   * List all tables with their metadata.
+   *
+   * @returns Array of table metadata objects.
+   */
+  listTables(): ScratchpadTable[] {
+    this.ensureAlive();
+    return [...this.tables.values()].map((e) => ({ ...e.metadata }));
+  }
+
+  /**
+   * Run a SQL query across scratchpad tables.
+   *
+   * Note: SQL queries require a DuckDB backend which is not yet integrated.
+   * This method currently throws an error indicating that SQL is unavailable.
+   *
+   * @param _sql - The SQL query string.
+   * @throws Always throws — DuckDB integration pending.
+   */
+  async query(_sql: string): Promise<Record<string, unknown>[]> {
+    this.ensureAlive();
+    throw new Error(
+      'SQL queries on the scratchpad require DuckDB, which is not yet integrated. ' +
+        'Use loadTable() to access data by table name.',
+    );
+  }
+
+  /**
+   * Check whether a table with the given name exists.
+   *
+   * @param name - The table name to check.
+   * @returns True if the table exists.
+   */
+  hasTable(name: string): boolean {
+    this.ensureAlive();
+    return this.tables.has(name);
+  }
+
+  /**
+   * Drop a table from the scratchpad.
+   *
+   * @param name - The table name to drop.
+   * @throws If the table does not exist or scratchpad is destroyed.
+   */
+  async dropTable(name: string): Promise<void> {
+    this.ensureAlive();
+
+    if (!this.tables.has(name)) {
+      throw new Error(`Table "${name}" not found in scratchpad.`);
+    }
+
+    this.tables.delete(name);
+    this._lastAccess = new Date();
+  }
+
+  /**
+   * Estimate the total size of all tables in bytes.
+   *
+   * Uses JSON serialization length as a rough proxy for memory consumption.
+   *
+   * @returns Estimated size in bytes.
+   */
+  getSizeEstimate(): number {
+    let total = 0;
+    for (const entry of this.tables.values()) {
+      total += JSON.stringify(entry.rows).length;
+    }
+    return total;
+  }
+
+  /**
+   * Destroy the scratchpad, releasing all stored data.
+   * After destruction, all methods will throw.
+   */
+  async destroy(): Promise<void> {
+    this.tables.clear();
+    this.destroyed = true;
+  }
+
+  /** Whether this scratchpad has been destroyed. */
+  get isDestroyed(): boolean {
+    return this.destroyed;
+  }
+
+  /** Throw if the scratchpad has been destroyed. */
+  private ensureAlive(): void {
+    if (this.destroyed) {
+      throw new Error(`Scratchpad for session "${this.sessionId}" has been destroyed.`);
+    }
+  }
+
+  /** Estimate total size excluding a specific table. */
+  private getSizeEstimateExcluding(tableName: string): number {
+    let total = 0;
+    for (const [name, entry] of this.tables.entries()) {
+      if (name !== tableName) {
+        total += JSON.stringify(entry.rows).length;
+      }
+    }
+    return total;
+  }
+
+  /** Infer column names and types from a sample row. */
+  private inferColumns(row: Record<string, unknown>): { name: string; type: string }[] {
+    return Object.entries(row).map(([name, value]) => ({
+      name,
+      type: this.inferType(value),
+    }));
+  }
+
+  /** Infer a simple type string from a JS value. */
+  private inferType(value: unknown): string {
+    if (value === null || value === undefined) return 'null';
+    if (typeof value === 'number') return Number.isInteger(value) ? 'integer' : 'float';
+    if (typeof value === 'boolean') return 'boolean';
+    if (typeof value === 'string') return 'string';
+    if (value instanceof Date) return 'date';
+    if (Array.isArray(value)) return 'array';
+    return 'object';
+  }
+}

--- a/packages/agent/src/tools/index.ts
+++ b/packages/agent/src/tools/index.ts
@@ -1,4 +1,5 @@
 export { agentTools } from './definitions';
 export { queryTools } from './query-tools';
 export { viewTools } from './view-tools';
+export { scratchpadTools } from './scratchpad-tools';
 export { ToolRouter, type ToolContext, type ToolExecutionResult } from './router';

--- a/packages/agent/src/tools/scratchpad-tools.ts
+++ b/packages/agent/src/tools/scratchpad-tools.ts
@@ -1,0 +1,79 @@
+import type { ToolDefinition } from '../provider/types';
+
+/**
+ * Tool definitions for scratchpad operations.
+ *
+ * These tools allow the leader agent to save, load, list, and query
+ * intermediate data stored in the per-session scratchpad.
+ */
+export const scratchpadTools: ToolDefinition[] = [
+  {
+    name: 'save_scratchpad',
+    description:
+      'Save query result rows as a named table in the session scratchpad. ' +
+      'Use this to store intermediate results that will be referenced in later analysis steps. ' +
+      'Table names must be valid identifiers (letters, numbers, underscores, starting with a letter or underscore).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        table_name: {
+          type: 'string',
+          description: 'Name for the scratchpad table (valid identifier)',
+        },
+        rows: {
+          type: 'array',
+          items: { type: 'object' },
+          description: 'Array of row objects to save',
+        },
+        description: {
+          type: 'string',
+          description: 'Human-readable description of what this table contains',
+        },
+      },
+      required: ['table_name', 'rows'],
+    },
+  },
+  {
+    name: 'load_scratchpad',
+    description:
+      'Load data from a named scratchpad table. ' +
+      'Use list_scratchpads first to see available tables.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        table_name: {
+          type: 'string',
+          description: 'Name of the scratchpad table to load',
+        },
+      },
+      required: ['table_name'],
+    },
+  },
+  {
+    name: 'list_scratchpads',
+    description:
+      'List all tables in the session scratchpad with their metadata ' +
+      '(name, description, columns, row count, creation time).',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'query_scratchpad',
+    description:
+      'Run a SQL query across scratchpad tables. ' +
+      'Requires DuckDB integration (not yet available). ' +
+      'Use load_scratchpad to access individual tables by name instead.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        sql: {
+          type: 'string',
+          description: 'SQL query to run against scratchpad tables',
+        },
+      },
+      required: ['sql'],
+    },
+  },
+];


### PR DESCRIPTION
## Summary

- **SessionScratchpad**: Per-session in-memory store for named intermediate tables with save/load/list/drop, type inference from row data, and configurable limits (10 tables, 100K rows/table, 100MB total)
- **ScratchpadManager**: Session lifecycle management with get-or-create semantics, automatic stale session cleanup (30min default), and graceful shutdown
- **Scratchpad tools**: `save_scratchpad`, `load_scratchpad`, `list_scratchpads`, `query_scratchpad` for leader agent use
- SQL queries via DuckDB integration deferred — `query()` returns a clear error directing to `loadTable()`

## Test plan

- [x] 16 scratchpad tests: save/load, copy safety, list, drop, limits, invalid names, size estimation
- [x] 7 manager tests: get-or-create, session count, destroy, cleanup, destroyAll
- [x] 61 total tests passing
- [x] TypeScript strict mode clean

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)