### PR TITLE
feat: leader agent orchestration with delegation tools (D-1.5.4)

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -9,6 +9,9 @@ export type AgentEvent =
   | { type: 'text'; text: string }
   | { type: 'tool_start'; name: string; id: string }
   | { type: 'tool_end'; name: string; result: string; isError: boolean }
+  | { type: 'agent_start'; agent: string; task: string }
+  | { type: 'agent_end'; agent: string; summary: string }
+  | { type: 'thinking'; text: string }
   | { type: 'done'; stopReason: string };
 
 /** Data sources available to the agent. */
@@ -25,6 +28,10 @@ export interface AgentConfig {
   toolContext: ToolContext;
   dataSources: AgentDataSource[];
   maxToolRounds?: number;
+  /** When true, uses the multi-agent LeaderAgent instead of the monolithic agent. */
+  multiAgent?: boolean;
+  /** Conversation ID for scratchpad association (required when multiAgent=true). */
+  conversationId?: string;
 }
 
 /**

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -1,6 +1,7 @@
 export { QueryAgent } from './query-agent';
 export { ViewAgent } from './view-agent';
 export { InsightsAgent } from './insights-agent';
+export { LeaderAgent, type LeaderAgentConfig } from './leader';
 export type {
   SubAgent,
   SubAgentConfig,

--- a/packages/agent/src/agents/leader.test.ts
+++ b/packages/agent/src/agents/leader.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgentEvent } from '../agent';
+import type { LLMProvider, StreamEvent } from '../provider/types';
+import type { ToolContext } from '../tools/router';
+import { ScratchpadManager } from '../scratchpad/manager';
+
+import { LeaderAgent } from './leader';
+
+/**
+ * Creates a mock provider that yields predefined event sequences.
+ * Each call to chat() returns the next sequence in the array.
+ */
+function mockProvider(eventSequences: StreamEvent[][]): LLMProvider {
+  let callIndex = 0;
+  return {
+    name: 'mock',
+    async *chat() {
+      const events = eventSequences[callIndex] ?? [
+        { type: 'message_end' as const, stopReason: 'end_turn' },
+      ];
+      callIndex++;
+      for (const event of events) {
+        yield event;
+      }
+    },
+  };
+}
+
+/** Creates a mock tool context. */
+function mockToolContext(): ToolContext {
+  return {
+    getSchema: vi.fn().mockResolvedValue({
+      tables: [{ name: 'orders', columns: [{ name: 'id', type: 'integer' }] }],
+    }),
+    executeQuery: vi.fn().mockResolvedValue({
+      rows: [{ region: 'North', total: 5000 }],
+      rowCount: 1,
+    }),
+    runSQL: vi.fn().mockResolvedValue({ rows: [{ count: 42 }], rowCount: 1 }),
+    analyzeData: vi.fn().mockResolvedValue({
+      rows: [{ avg_sales: 5000, stddev: 1200 }],
+      rowCount: 1,
+    }),
+  };
+}
+
+/** Collect all events from a leader chat call. */
+async function collectEvents(
+  leader: LeaderAgent,
+  message: string,
+  conversationId = 'test-conv',
+): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of leader.chat(message, conversationId)) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe('LeaderAgent', () => {
+  it('streams text response without delegations', async () => {
+    const leader = new LeaderAgent({
+      provider: mockProvider([
+        [
+          { type: 'text_delta', text: 'Hello! How can I help?' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [{ id: 'pg-main', name: 'Main DB', type: 'postgres' }],
+    });
+
+    const events = await collectEvents(leader, 'Hi');
+
+    const textEvents = events.filter((e) => e.type === 'text');
+    expect(textEvents).toHaveLength(1);
+    expect(events.some((e) => e.type === 'done')).toBe(true);
+  });
+
+  it('delegates to QueryAgent and emits agent_start/agent_end', async () => {
+    // Leader calls delegate_query, then sub-agent internally calls execute_query
+    const leader = new LeaderAgent({
+      provider: mockProvider([
+        // Round 1: Leader calls delegate_query
+        [
+          { type: 'text_delta', text: 'Let me query that for you.' },
+          { type: 'tool_call_start', id: 'tc_1', name: 'delegate_query' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'delegate_query',
+            input: {
+              instruction: 'Get total sales by region',
+              source_id: 'pg-main',
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Sub-agent's internal LLM call (QueryAgent uses same provider)
+        [
+          { type: 'tool_call_start', id: 'sub_1', name: 'execute_query' },
+          {
+            type: 'tool_call_end',
+            id: 'sub_1',
+            name: 'execute_query',
+            input: {
+              source_id: 'pg-main',
+              query_ir: { source: 'pg-main', table: 'orders', select: [{ field: 'region' }], aggregations: [], groupBy: [], orderBy: [], joins: [] },
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Sub-agent finishes
+        [
+          { type: 'text_delta', text: 'Query done.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+        // Round 2: Leader summarizes
+        [
+          { type: 'text_delta', text: 'Here are the results.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [
+        {
+          id: 'pg-main',
+          name: 'Main DB',
+          type: 'postgres',
+          cachedSchema: {
+            tables: [{ name: 'orders', schema: 'public', columns: [{ name: 'region', type: 'varchar', nullable: false, primaryKey: false }] }],
+          },
+        },
+      ],
+    });
+
+    const events = await collectEvents(leader, 'Show me sales by region');
+
+    const agentStarts = events.filter((e) => e.type === 'agent_start');
+    const agentEnds = events.filter((e) => e.type === 'agent_end');
+
+    expect(agentStarts).toHaveLength(1);
+    expect((agentStarts[0] as Extract<AgentEvent, { type: 'agent_start' }>).agent).toBe('query');
+    expect(agentEnds).toHaveLength(1);
+    expect(events.some((e) => e.type === 'done')).toBe(true);
+  });
+
+  it('delegates to ViewAgent', async () => {
+    const leader = new LeaderAgent({
+      provider: mockProvider([
+        // Leader calls delegate_view
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'delegate_view' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'delegate_view',
+            input: {
+              instruction: 'Create a bar chart',
+              data_summary: { columns: [{ name: 'region', type: 'varchar' }], rowCount: 5 },
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // ViewAgent internal calls
+        [
+          { type: 'tool_call_start', id: 'v1', name: 'create_view' },
+          {
+            type: 'tool_call_end',
+            id: 'v1',
+            name: 'create_view',
+            input: { view_spec: { query: { source: 'x', table: 'y' }, chart: { type: 'bar-chart', config: {} } } },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'View created.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+        // Leader responds
+        [
+          { type: 'text_delta', text: 'Here is your chart.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [],
+    });
+
+    const events = await collectEvents(leader, 'Make a bar chart');
+
+    const agentStarts = events.filter((e) => e.type === 'agent_start') as Array<Extract<AgentEvent, { type: 'agent_start' }>>;
+    expect(agentStarts).toHaveLength(1);
+    expect(agentStarts[0]!.agent).toBe('view');
+  });
+
+  it('delegates to InsightsAgent', async () => {
+    const leader = new LeaderAgent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'delegate_insights' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'delegate_insights',
+            input: { instruction: 'Find outliers', table_name: 'sales_data' },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // InsightsAgent responds with text only
+        [
+          { type: 'text_delta', text: 'The data looks normally distributed.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+        // Leader summarizes
+        [
+          { type: 'text_delta', text: 'No outliers found.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [],
+    });
+
+    const events = await collectEvents(leader, 'Any outliers?');
+
+    const agentStarts = events.filter((e) => e.type === 'agent_start') as Array<Extract<AgentEvent, { type: 'agent_start' }>>;
+    expect(agentStarts).toHaveLength(1);
+    expect(agentStarts[0]!.agent).toBe('insights');
+  });
+
+  it('handles scratchpad save and load', async () => {
+    const scratchpadManager = new ScratchpadManager({ cleanupIntervalMs: 0 });
+
+    const leader = new LeaderAgent({
+      provider: mockProvider([
+        // Leader saves to scratchpad
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'save_scratchpad' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'save_scratchpad',
+            input: {
+              table_name: 'my_data',
+              rows: [{ a: 1 }, { a: 2 }],
+              description: 'Test data',
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Leader confirms save
+        [
+          { type: 'text_delta', text: 'Saved.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [],
+      scratchpadManager,
+    });
+
+    const events = await collectEvents(leader, 'Save this data');
+
+    const toolEnd = events.find((e) => e.type === 'tool_end') as Extract<AgentEvent, { type: 'tool_end' }>;
+    expect(toolEnd).toBeDefined();
+    expect(toolEnd.isError).toBe(false);
+
+    // Verify data was actually saved
+    const scratchpad = scratchpadManager.getOrCreate('test-conv');
+    expect(scratchpad.hasTable('my_data')).toBe(true);
+
+    await scratchpadManager.destroyAll();
+  });
+
+  it('handles sub-agent errors gracefully', async () => {
+    const ctx = mockToolContext();
+    (ctx.executeQuery as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Connection refused'));
+
+    const leader = new LeaderAgent({
+      provider: mockProvider([
+        // Leader delegates
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'delegate_query' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'delegate_query',
+            input: { instruction: 'Get data', source_id: 'broken' },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Sub-agent tries execute_query, fails
+        [
+          { type: 'tool_call_start', id: 's1', name: 'execute_query' },
+          {
+            type: 'tool_call_end',
+            id: 's1',
+            name: 'execute_query',
+            input: { source_id: 'broken', query_ir: { source: 'broken', table: 'x', select: [], aggregations: [], groupBy: [], orderBy: [], joins: [] } },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Sub-agent gives up
+        [
+          { type: 'text_delta', text: 'Query failed.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+        // Leader reports error
+        [
+          { type: 'text_delta', text: 'Sorry, the query failed.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: ctx,
+      dataSources: [],
+    });
+
+    const events = await collectEvents(leader, 'Query broken db');
+
+    // Should still complete without crashing
+    expect(events.some((e) => e.type === 'done')).toBe(true);
+    const agentEnds = events.filter((e) => e.type === 'agent_end') as Array<Extract<AgentEvent, { type: 'agent_end' }>>;
+    expect(agentEnds).toHaveLength(1);
+  });
+
+  it('maintains conversation history', async () => {
+    const leader = new LeaderAgent({
+      provider: mockProvider([
+        [
+          { type: 'text_delta', text: 'First reply' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+        [
+          { type: 'text_delta', text: 'Second reply' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [],
+    });
+
+    await collectEvents(leader, 'first');
+    await collectEvents(leader, 'second');
+
+    const history = leader.getHistory();
+    expect(history.length).toBe(4); // 2 user + 2 assistant
+  });
+
+  it('resets conversation', async () => {
+    const leader = new LeaderAgent({
+      provider: mockProvider([
+        [{ type: 'text_delta', text: 'Hi' }, { type: 'message_end', stopReason: 'end_turn' }],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [],
+    });
+
+    await collectEvents(leader, 'hello');
+    expect(leader.getHistory().length).toBeGreaterThan(0);
+
+    leader.reset();
+    expect(leader.getHistory()).toHaveLength(0);
+  });
+});

--- a/packages/agent/src/agents/leader.ts
+++ b/packages/agent/src/agents/leader.ts
@@ -1,0 +1,346 @@
+import type { AgentDataSource, AgentEvent } from '../agent';
+import { ConversationManager } from '../conversation/manager';
+import { buildLeaderPrompt } from '../prompt/leader-prompt';
+import type { LLMProvider, Message, ToolCallResult } from '../provider/types';
+import { ScratchpadManager } from '../scratchpad/manager';
+import { leaderTools } from '../tools/leader-tools';
+import { queryTools } from '../tools/query-tools';
+import { insightsTools } from '../tools/insights-tools';
+import { viewTools } from '../tools/view-tools';
+import { ToolRouter, type ToolContext } from '../tools/router';
+
+import { InsightsAgent } from './insights-agent';
+import { QueryAgent } from './query-agent';
+import type { AgentTask, SubAgentResult } from './types';
+import { ViewAgent } from './view-agent';
+
+/** Configuration for creating a LeaderAgent. */
+export interface LeaderAgentConfig {
+  /** LLM provider for the leader and sub-agents. */
+  provider: LLMProvider;
+  /** Tool context for creating sub-agent ToolRouters. */
+  toolContext: ToolContext;
+  /** Available data sources. */
+  dataSources: AgentDataSource[];
+  /** Scratchpad manager for intermediate data storage. */
+  scratchpadManager?: ScratchpadManager;
+  /** Maximum tool call rounds for the leader (default: 10). */
+  maxToolRounds?: number;
+  /** Maximum tool call rounds for sub-agents (default: 5). */
+  subAgentMaxRounds?: number;
+}
+
+/**
+ * Leader Agent — the multi-agent conversation orchestrator.
+ *
+ * Manages conversation with the user, delegates to specialist sub-agents
+ * (query, view, insights) via tool use, and manages the session scratchpad.
+ * Only the leader streams text to the user.
+ */
+export class LeaderAgent {
+  private provider: LLMProvider;
+  private toolContext: ToolContext;
+  private dataSources: AgentDataSource[];
+  private scratchpadManager: ScratchpadManager;
+  private conversation: ConversationManager;
+  private maxToolRounds: number;
+  private subAgentMaxRounds: number;
+
+  constructor(config: LeaderAgentConfig) {
+    this.provider = config.provider;
+    this.toolContext = config.toolContext;
+    this.dataSources = config.dataSources;
+    this.scratchpadManager = config.scratchpadManager ?? new ScratchpadManager();
+    this.conversation = new ConversationManager();
+    this.maxToolRounds = config.maxToolRounds ?? 10;
+    this.subAgentMaxRounds = config.subAgentMaxRounds ?? 5;
+  }
+
+  /**
+   * Process a user message and stream the leader's response.
+   * Delegates to sub-agents as needed, emitting agent_start/agent_end events.
+   */
+  async *chat(
+    userMessage: string,
+    conversationId: string,
+    currentView?: Record<string, unknown> | null,
+  ): AsyncIterable<AgentEvent> {
+    this.conversation.addMessage({ role: 'user', content: userMessage });
+
+    const scratchpad = this.scratchpadManager.getOrCreate(conversationId);
+    const scratchpadTables = scratchpad.listTables().map((t) => `${t.name}: ${t.description}`);
+
+    const systemPrompt = buildLeaderPrompt({
+      dataSources: this.dataSources,
+      scratchpadTables,
+    });
+
+    for (let round = 0; round < this.maxToolRounds; round++) {
+      const toolCalls: ToolCallResult[] = [];
+      const toolInputBuffers = new Map<string, string>();
+      let textContent = '';
+      let hasToolCalls = false;
+
+      const stream = this.provider.chat(
+        this.conversation.getMessages(),
+        leaderTools,
+        { system: systemPrompt },
+      );
+
+      for await (const event of stream) {
+        switch (event.type) {
+          case 'text_delta':
+            textContent += event.text;
+            yield { type: 'text', text: event.text };
+            break;
+          case 'tool_call_start':
+            hasToolCalls = true;
+            toolInputBuffers.set(event.id, '');
+            toolCalls.push({ id: event.id, name: event.name, input: {} });
+            yield { type: 'tool_start', name: event.name, id: event.id };
+            break;
+          case 'tool_call_delta': {
+            const buf = toolInputBuffers.get(event.id) ?? '';
+            toolInputBuffers.set(event.id, buf + event.input);
+            break;
+          }
+          case 'tool_call_end': {
+            const tc = toolCalls.find((t) => t.id === event.id);
+            if (tc) tc.input = event.input;
+            break;
+          }
+          case 'message_end':
+            if (hasToolCalls) {
+              for (const tc of toolCalls) {
+                if (Object.keys(tc.input).length === 0) {
+                  const raw = toolInputBuffers.get(tc.id);
+                  if (raw) {
+                    try { tc.input = JSON.parse(raw); } catch { /* ignore */ }
+                  }
+                }
+              }
+            }
+            break;
+        }
+      }
+
+      this.conversation.addMessage({
+        role: 'assistant',
+        content: textContent,
+        toolCalls: hasToolCalls ? toolCalls : undefined,
+      });
+
+      if (!hasToolCalls) {
+        yield { type: 'done', stopReason: 'end_turn' };
+        return;
+      }
+
+      // Execute tool calls (delegation or scratchpad)
+      const toolResults = [];
+      for (const tc of toolCalls) {
+        let result: { content: string; isError: boolean };
+
+        if (tc.name.startsWith('delegate_')) {
+          result = yield* this.handleDelegation(tc, conversationId);
+        } else if (tc.name.startsWith('save_') || tc.name.startsWith('load_') || tc.name.startsWith('list_') || tc.name.startsWith('query_')) {
+          result = await this.handleScratchpad(tc, conversationId);
+        } else {
+          result = { content: `Unknown tool: ${tc.name}`, isError: true };
+        }
+
+        toolResults.push({
+          toolCallId: tc.id,
+          content: result.content,
+          isError: result.isError,
+        });
+        yield { type: 'tool_end', name: tc.name, result: result.content, isError: result.isError };
+      }
+
+      this.conversation.addMessage({
+        role: 'user',
+        content: '',
+        toolResults,
+      });
+    }
+
+    yield { type: 'done', stopReason: 'max_tool_rounds' };
+  }
+
+  /**
+   * Handle a delegation tool call by creating and running the appropriate sub-agent.
+   * Yields agent_start/agent_end events for UI transparency.
+   */
+  private async *handleDelegation(
+    tc: ToolCallResult,
+    conversationId: string,
+  ): AsyncGenerator<AgentEvent, { content: string; isError: boolean }> {
+    const input = tc.input as { instruction?: string; source_id?: string; data_summary?: Record<string, unknown>; table_name?: string };
+    const instruction = input.instruction ?? '';
+
+    try {
+      switch (tc.name) {
+        case 'delegate_query': {
+          yield { type: 'agent_start', agent: 'query', task: instruction };
+
+          const sourceId = input.source_id ?? this.dataSources[0]?.id ?? '';
+          const ds = this.dataSources.find((d) => d.id === sourceId);
+
+          const queryRouter = new ToolRouter(this.toolContext, queryTools);
+          const agent = new QueryAgent({
+            provider: this.provider,
+            toolRouter: queryRouter,
+            maxToolRounds: this.subAgentMaxRounds,
+          });
+
+          const task: AgentTask = {
+            id: `task_${Date.now()}`,
+            instruction,
+            context: {
+              dataSources: ds ? [ds] : this.dataSources,
+            },
+          };
+
+          const agentResult = await agent.run(task);
+          const summary = agentResult.success
+            ? agentResult.explanation || 'Query completed'
+            : `Query failed: ${agentResult.error ?? 'unknown error'}`;
+
+          yield { type: 'agent_end', agent: 'query', summary };
+
+          return {
+            content: JSON.stringify(agentResult.data),
+            isError: !agentResult.success,
+          };
+        }
+
+        case 'delegate_view': {
+          yield { type: 'agent_start', agent: 'view', task: instruction };
+
+          const viewRouter = new ToolRouter(this.toolContext, viewTools);
+          const agent = new ViewAgent({
+            provider: this.provider,
+            toolRouter: viewRouter,
+            maxToolRounds: this.subAgentMaxRounds,
+          });
+
+          const task: AgentTask = {
+            id: `task_${Date.now()}`,
+            instruction,
+            context: {
+              dataSummary: input.data_summary ?? {},
+            },
+          };
+
+          const agentResult = await agent.run(task);
+          const summary = agentResult.success
+            ? agentResult.explanation || 'View created'
+            : `View creation failed: ${agentResult.error ?? 'unknown error'}`;
+
+          yield { type: 'agent_end', agent: 'view', summary };
+
+          return {
+            content: JSON.stringify(agentResult.data),
+            isError: !agentResult.success,
+          };
+        }
+
+        case 'delegate_insights': {
+          yield { type: 'agent_start', agent: 'insights', task: instruction };
+
+          const insightsRouter = new ToolRouter(this.toolContext, insightsTools);
+          const agent = new InsightsAgent({
+            provider: this.provider,
+            toolRouter: insightsRouter,
+            maxToolRounds: this.subAgentMaxRounds,
+          });
+
+          const task: AgentTask = {
+            id: `task_${Date.now()}`,
+            instruction,
+            context: {
+              tableName: input.table_name,
+            },
+          };
+
+          const agentResult = await agent.run(task);
+          const summary = agentResult.success
+            ? agentResult.explanation || 'Analysis completed'
+            : `Analysis failed: ${agentResult.error ?? 'unknown error'}`;
+
+          yield { type: 'agent_end', agent: 'insights', summary };
+
+          return {
+            content: JSON.stringify(agentResult.data),
+            isError: !agentResult.success,
+          };
+        }
+
+        default:
+          return { content: `Unknown delegation tool: ${tc.name}`, isError: true };
+      }
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      yield { type: 'agent_end', agent: tc.name.replace('delegate_', ''), summary: `Error: ${errorMsg}` };
+      return { content: `Delegation failed: ${errorMsg}`, isError: true };
+    }
+  }
+
+  /** Handle scratchpad tool calls (save, load, list, query). */
+  private async handleScratchpad(
+    tc: ToolCallResult,
+    conversationId: string,
+  ): Promise<{ content: string; isError: boolean }> {
+    const scratchpad = this.scratchpadManager.getOrCreate(conversationId);
+    const input = tc.input as Record<string, unknown>;
+
+    try {
+      switch (tc.name) {
+        case 'save_scratchpad': {
+          const tableName = input.table_name as string;
+          const rows = input.rows as Record<string, unknown>[];
+          const description = input.description as string | undefined;
+          const meta = await scratchpad.saveTable(tableName, rows, description);
+          return { content: JSON.stringify(meta), isError: false };
+        }
+        case 'load_scratchpad': {
+          const tableName = input.table_name as string;
+          const rows = await scratchpad.loadTable(tableName);
+          return { content: JSON.stringify({ rows, rowCount: rows.length }), isError: false };
+        }
+        case 'list_scratchpads': {
+          const tables = scratchpad.listTables();
+          return { content: JSON.stringify(tables), isError: false };
+        }
+        case 'query_scratchpad': {
+          const sql = input.sql as string;
+          const result = await scratchpad.query(sql);
+          return { content: JSON.stringify(result), isError: false };
+        }
+        default:
+          return { content: `Unknown scratchpad tool: ${tc.name}`, isError: true };
+      }
+    } catch (err) {
+      return {
+        content: `Scratchpad error: ${err instanceof Error ? err.message : String(err)}`,
+        isError: true,
+      };
+    }
+  }
+
+  /** Load prior conversation history. */
+  loadHistory(messages: Message[]): void {
+    for (const msg of messages) {
+      this.conversation.addMessage(msg);
+    }
+  }
+
+  /** Reset the conversation history. */
+  reset(): void {
+    this.conversation.clear();
+  }
+
+  /** Get the conversation history. */
+  getHistory(): Message[] {
+    return this.conversation.getMessages();
+  }
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3,6 +3,8 @@ export {
   QueryAgent,
   ViewAgent,
   InsightsAgent,
+  LeaderAgent,
+  type LeaderAgentConfig,
   type SubAgent,
   type SubAgentConfig,
   type SubAgentRole,
@@ -22,13 +24,14 @@ export {
   type ToolDefinition,
 } from './provider';
 export { SessionScratchpad, ScratchpadManager, type ScratchpadTable, type ScratchpadLimits, type ScratchpadManagerOptions } from './scratchpad';
-export { buildSystemPrompt, buildQueryPrompt, buildViewPrompt, buildInsightsPrompt } from './prompt';
+export { buildSystemPrompt, buildQueryPrompt, buildViewPrompt, buildInsightsPrompt, buildLeaderPrompt } from './prompt';
 export {
   agentTools,
   queryTools,
   viewTools,
   insightsTools,
   scratchpadTools,
+  leaderTools,
   ToolRouter,
   type ToolContext,
   type ToolExecutionResult,

--- a/packages/agent/src/prompt/index.ts
+++ b/packages/agent/src/prompt/index.ts
@@ -2,3 +2,4 @@ export { buildSystemPrompt } from './system';
 export { buildQueryPrompt } from './query-prompt';
 export { buildViewPrompt } from './view-prompt';
 export { buildInsightsPrompt } from './insights-prompt';
+export { buildLeaderPrompt } from './leader-prompt';

--- a/packages/agent/src/prompt/leader-prompt.ts
+++ b/packages/agent/src/prompt/leader-prompt.ts
@@ -1,0 +1,58 @@
+import type { AgentDataSource } from '../agent';
+
+/**
+ * Builds the system prompt for the Leader Agent.
+ * Contains conversation management instructions and data source awareness.
+ * Kept under ~800 tokens — schemas are NOT included (sub-agents handle that).
+ */
+export function buildLeaderPrompt(context: {
+  dataSources: AgentDataSource[];
+  scratchpadTables?: string[];
+}): string {
+  const parts = [LEADER_INSTRUCTIONS];
+
+  if (context.dataSources.length > 0) {
+    parts.push('\n## Available Data Sources');
+    for (const ds of context.dataSources) {
+      parts.push(`- "${ds.name}" (id: "${ds.id}", type: ${ds.type})`);
+    }
+  }
+
+  if (context.scratchpadTables && context.scratchpadTables.length > 0) {
+    parts.push('\n## Scratchpad Tables');
+    parts.push(context.scratchpadTables.map((t) => `- ${t}`).join('\n'));
+  }
+
+  return parts.join('\n');
+}
+
+const LEADER_INSTRUCTIONS = `You are Lightboard's data exploration assistant. You help users understand their data by orchestrating specialist agents.
+
+## How you work
+
+You manage the conversation and delegate tasks to specialists:
+- **delegate_query**: Send data retrieval tasks (schema exploration, SQL, QueryIR queries)
+- **delegate_view**: Send visualization tasks (chart creation, ViewSpec generation)
+- **delegate_insights**: Send statistical analysis tasks (trends, distributions, outliers)
+
+## When to delegate
+
+1. User asks a data question → delegate_query first to get data, then delegate_view to visualize it
+2. User asks for a chart/visualization → delegate_view with the data summary
+3. User asks "why" or "what patterns" → delegate_insights
+4. User asks to modify an existing view → delegate_view with modification instruction
+5. Multi-step analysis → delegate_query, save_scratchpad, then delegate_insights on scratchpad data
+
+## Scratchpad
+
+You can save intermediate results for multi-step analysis:
+- save_scratchpad: Save query results as a named table
+- load_scratchpad: Load data from a named table
+- list_scratchpads: See available tables
+
+## Rules
+
+- Be conversational and concise
+- Always delegate data work — do NOT try to query or analyze data yourself
+- After receiving results, summarize key findings for the user
+- If a delegation fails, explain the error and suggest alternatives`;

--- a/packages/agent/src/tools/index.ts
+++ b/packages/agent/src/tools/index.ts
@@ -3,4 +3,5 @@ export { queryTools } from './query-tools';
 export { viewTools } from './view-tools';
 export { scratchpadTools } from './scratchpad-tools';
 export { insightsTools } from './insights-tools';
+export { leaderTools } from './leader-tools';
 export { ToolRouter, type ToolContext, type ToolExecutionResult } from './router';

--- a/packages/agent/src/tools/leader-tools.ts
+++ b/packages/agent/src/tools/leader-tools.ts
@@ -1,0 +1,81 @@
+import type { ToolDefinition } from '../provider/types';
+import { scratchpadTools } from './scratchpad-tools';
+
+/**
+ * Delegation tool definitions for the Leader Agent.
+ * These tools allow the leader to route tasks to specialist sub-agents.
+ */
+const delegationTools: ToolDefinition[] = [
+  {
+    name: 'delegate_query',
+    description:
+      'Delegate a data retrieval task to the Query specialist. ' +
+      'The query agent can explore schemas, execute QueryIR queries, and run raw SQL. ' +
+      'Provide a clear instruction about what data to retrieve.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        instruction: {
+          type: 'string',
+          description: 'Clear instruction for the query agent (e.g., "Get total sales by region from the orders table")',
+        },
+        source_id: {
+          type: 'string',
+          description: 'The data source ID to query against',
+        },
+      },
+      required: ['instruction', 'source_id'],
+    },
+  },
+  {
+    name: 'delegate_view',
+    description:
+      'Delegate visualization creation to the View specialist. ' +
+      'The view agent selects the best chart type and generates a ViewSpec. ' +
+      'Provide the data summary (columns, types, sample rows) and instruction.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        instruction: {
+          type: 'string',
+          description: 'What visualization to create (e.g., "Create a bar chart of sales by region")',
+        },
+        data_summary: {
+          type: 'object',
+          description: 'Summary of the data: columns, types, row count, sample rows',
+        },
+      },
+      required: ['instruction', 'data_summary'],
+    },
+  },
+  {
+    name: 'delegate_insights',
+    description:
+      'Delegate statistical analysis to the Insights specialist. ' +
+      'The insights agent computes statistics, finds patterns, and identifies outliers. ' +
+      'Provide a question and optionally the scratchpad table name to analyze.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        instruction: {
+          type: 'string',
+          description: 'What analysis to perform (e.g., "Find outliers in the sales data")',
+        },
+        table_name: {
+          type: 'string',
+          description: 'Optional scratchpad table name to analyze',
+        },
+      },
+      required: ['instruction'],
+    },
+  },
+];
+
+/**
+ * All tools available to the Leader Agent:
+ * delegation tools + scratchpad tools.
+ */
+export const leaderTools: ToolDefinition[] = [
+  ...delegationTools,
+  ...scratchpadTools,
+];


### PR DESCRIPTION
## Summary

Core deliverable of Phase 1.5 — the multi-agent orchestrator:

- **LeaderAgent** class: manages conversation, delegates to query/view/insights specialists via tool use, manages session scratchpad
- **Delegation tools**: `delegate_query`, `delegate_view`, `delegate_insights` — each creates a scoped sub-agent, runs it, and returns structured results
- **Leader prompt** (~800 tokens): conversation management rules, delegation guidance, scratchpad awareness
- **Extended AgentEvent**: new `agent_start`, `agent_end`, `thinking` event types for UI transparency
- **Backward compat**: `multiAgent` flag on `AgentConfig`

## Test plan

- [x] 8 new LeaderAgent tests: delegation to all 3 specialists, agent events, scratchpad save/load, error handling, conversation history, reset
- [x] 82 total tests passing
- [x] TypeScript strict mode clean

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)