### PR TITLE
docs: update Phase 1.5 exit criteria and commands (D-1.5.9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,14 +129,15 @@ Core tools: `list_data_sources`, `get_schema`, `execute_query`, `create_view`, `
 
 ```bash
 # Local dev
-docker compose up                    # Start full stack (app + Postgres + Redis + seed data)
-pnpm dev                             # Start Next.js dev server
+docker compose up -d                 # Start Postgres + Redis
+pnpm dev                             # Start Next.js dev server (Turbopack)
 pnpm test                            # Run all unit + component tests
-pnpm test:e2e                        # Run Playwright E2E tests against Docker stack
-pnpm lint                            # ESLint + Prettier + tsc --noEmit
+pnpm typecheck                       # TypeScript across all packages
+pnpm --filter @lightboard/web lint   # ESLint (catches unused imports, any types)
 pnpm build                           # Production build
 
 # Per-package
+pnpm --filter @lightboard/agent test -- --run   # Agent tests (82 tests)
 pnpm --filter @lightboard/query-ir test
 pnpm --filter @lightboard/viz-core storybook
 

--- a/documentation/phase_1.5.md
+++ b/documentation/phase_1.5.md
@@ -222,15 +222,15 @@ Week 4:  D-1.5.5 (API route wiring)
 
 ## Exit criteria
 
-- [ ] Leader agent delegates to query, view, and insights specialists
-- [ ] Each sub-agent has focused context under 2K tokens
+- [x] Leader agent delegates to query, view, and insights specialists
+- [x] Each sub-agent has focused context under 2K tokens
 - [ ] Multi-step analysis works: query -> save scratchpad -> query scratchpad -> visualize
-- [ ] Chat messages render markdown (tables, code blocks, lists)
-- [ ] Thinking state shows collapsible reasoning
-- [ ] Tool calls expand to show input/output details
-- [ ] Agent delegation indicators show which specialist is active
-- [ ] Backward compat: `multiAgent: false` uses existing single-agent loop
-- [ ] All existing Phase 1 tests continue to pass
+- [x] Chat messages render markdown (tables, code blocks, lists)
+- [x] Thinking state shows collapsible reasoning
+- [x] Tool calls expand to show input/output details
+- [x] Agent delegation indicators show which specialist is active
+- [x] Backward compat: `multiAgent: false` uses existing single-agent loop
+- [x] All existing Phase 1 tests continue to pass (82 tests)
 - [ ] E2E tests verify full multi-agent flow
 
 ## Risk register


### PR DESCRIPTION
## Summary

- Updated Phase 1.5 exit criteria: 8/10 items marked complete
- Updated CLAUDE.md commands section with current tooling

Remaining exit criteria (for D-1.5.8):
- [ ] Multi-step analysis: query -> scratchpad -> visualize
- [ ] E2E tests verify full multi-agent flow

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)