### PR TITLE
feat: schema bootstrap with curated docs and agent learning

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -33,7 +33,17 @@
     "stop": "Stop",
     "dataSource": "Data source",
     "selectDataSource": "Select a data source...",
-    "noResponse": "No response from agent."
+    "noResponse": "No response from agent.",
+    "schemaSetupTitle": "Set up schema documentation",
+    "schemaSetupDescription": "Generate AI-annotated schema documentation for \"{sourceName}\" to help the agent write better queries. This takes about 15 seconds.",
+    "schemaGenerate": "Generate Schema Documentation",
+    "schemaGenerating": "Generating schema documentation...",
+    "schemaGeneratingHint": "Introspecting database and annotating with AI",
+    "schemaEditorTitle": "Schema Documentation — {sourceName}",
+    "schemaEditorHint": "Edit the schema context that the AI agent uses for queries",
+    "schemaSave": "Save",
+    "schemaSaving": "Saving...",
+    "cancel": "Cancel"
   },
   "dataSources": {
     "title": "Data Sources",

--- a/apps/web/src/app/api/agent/chat/route.ts
+++ b/apps/web/src/app/api/agent/chat/route.ts
@@ -372,18 +372,31 @@ function handleStreaming(
   sessionId: string,
 ): Response {
   const encoder = new TextEncoder();
+  const abort = new AbortController();
 
   const stream = new ReadableStream({
     async start(controller) {
       const enqueue = (event: string, data: Record<string, unknown>) => {
-        controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+        if (abort.signal.aborted) return;
+        try {
+          controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+        } catch {
+          // Client disconnected — trigger abort
+          abort.abort();
+        }
       };
 
-      // Heartbeat interval
+      // Heartbeat interval — also detects dead connections
       const heartbeat = setInterval(() => {
+        if (abort.signal.aborted) {
+          clearInterval(heartbeat);
+          return;
+        }
         try {
           controller.enqueue(encoder.encode(': heartbeat\n\n'));
         } catch {
+          console.log('[Chat] Client disconnected (heartbeat failed), aborting agent');
+          abort.abort();
           clearInterval(heartbeat);
         }
       }, 15_000);
@@ -393,8 +406,16 @@ function handleStreaming(
           setTimeout(() => reject(new Error('Agent processing timed out')), AGENT_TIMEOUT_MS);
         });
 
+        const abortPromise = new Promise<never>((_, reject) => {
+          abort.signal.addEventListener('abort', () => reject(new Error('Client disconnected')));
+        });
+
         const processStream = async () => {
           for await (const event of leader.chat(message, sessionId)) {
+            if (abort.signal.aborted) {
+              console.log('[Chat] Agent processing aborted — client disconnected');
+              return;
+            }
             switch (event.type) {
               case 'text':
                 enqueue('text', { text: event.text });
@@ -414,12 +435,10 @@ function handleStreaming(
                   try {
                     const parsed = JSON.parse(event.result);
                     console.log(`[Chat] Tool result for ${event.name}: keys=${Object.keys(parsed).join(',')}`);
-                    // Direct create_view/modify_view (single-agent path)
                     if ((event.name === 'create_view' || event.name === 'modify_view') && parsed.viewSpec) {
                       console.log(`[Chat] Emitting view_created (direct), html=${parsed.viewSpec.html?.length ?? 0} chars`);
                       enqueue('view_created', { viewSpec: parsed.viewSpec });
                     }
-                    // delegate_view (multi-agent path) — ViewSpec is in the sub-agent result
                     if (event.name === 'delegate_view') {
                       const viewSpec = parsed.viewSpec ?? parsed;
                       if (viewSpec.html || viewSpec.viewId) {
@@ -441,10 +460,8 @@ function handleStreaming(
                 enqueue('thinking', { text: event.text });
                 break;
               case 'done': {
-                // Save conversation before closing
                 const history = leader.getHistory();
                 await saveConversation(orgId, sessionId, history);
-
                 enqueue('done', { stopReason: event.stopReason, conversationId: sessionId });
                 break;
               }
@@ -452,17 +469,25 @@ function handleStreaming(
           }
         };
 
-        await Promise.race([processStream(), timeoutPromise]);
+        await Promise.race([processStream(), timeoutPromise, abortPromise]);
       } catch (err) {
-        const errorMessage = err instanceof LLMError
-          ? (err.statusCode === 429 ? 'AI service is busy, please retry.' : 'AI service error.')
-          : (err instanceof Error ? err.message : String(err));
-
-        enqueue('error', { error: errorMessage });
+        if (!abort.signal.aborted) {
+          const errorMessage = err instanceof LLMError
+            ? (err.statusCode === 429 ? 'AI service is busy, please retry.' : 'AI service error.')
+            : (err instanceof Error ? err.message : String(err));
+          enqueue('error', { error: errorMessage });
+        } else {
+          console.log(`[Chat] Stream ended — client disconnected (session=${sessionId})`);
+        }
       } finally {
         clearInterval(heartbeat);
-        controller.close();
+        try { controller.close(); } catch { /* already closed */ }
       }
+    },
+    cancel() {
+      // Called when the client closes the connection (navigates away, screen sleep, etc.)
+      console.log(`[Chat] Client cancelled SSE stream (session=${sessionId})`);
+      abort.abort();
     },
   });
 

--- a/apps/web/src/app/api/agent/chat/route.ts
+++ b/apps/web/src/app/api/agent/chat/route.ts
@@ -9,14 +9,16 @@ import {
 import { checkRateLimit, addRateLimitHeaders } from '@/lib/rate-limit';
 import { redis } from '@/lib/redis';
 import { dataSources } from '@lightboard/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
 import {
   LeaderAgent,
   ScratchpadManager,
   LLMError,
+  generateSchemaContext,
   type AgentDataSource,
   type AgentEvent,
   type Message,
+  type SchemaContext,
   type ToolContext,
 } from '@lightboard/agent';
 import { resolveAIProvider } from '@/lib/ai-provider';
@@ -118,21 +120,44 @@ export const POST = withAuth(async (req, { db, orgId }) => {
     .from(dataSources)
     .where(eq(dataSources.orgId, orgId));
 
-  const agentDataSources: AgentDataSource[] = orgSources.map((s) => {
+  // Build agent data sources, generating enriched schema context if not cached
+  const adminDb = getAdminDb();
+  const agentDataSources: AgentDataSource[] = [];
+  for (const s of orgSources) {
     const config = s.config as Record<string, unknown> | null;
-    return {
+    let schemaContext = (config?.schemaContext as SchemaContext) ?? null;
+
+    // Generate schema context on first use if missing
+    if (!schemaContext) {
+      try {
+        const connection = await getDataSourceConnection(adminDb, orgId, s.id);
+        console.log(`[Chat] Bootstrapping schema context for "${s.name}"...`);
+        const start = performance.now();
+        schemaContext = await generateSchemaContext(connection);
+        console.log(`[Chat] Schema bootstrap complete (${Math.round(performance.now() - start)}ms, ${schemaContext.tables.length} tables)`);
+
+        // Cache it back to the data source config for future requests
+        const updatedConfig = { ...(config ?? {}), schemaContext };
+        await db
+          .update(dataSources)
+          .set({ config: updatedConfig, updatedAt: new Date() })
+          .where(eq(dataSources.id, s.id));
+      } catch (err) {
+        console.error(`[Chat] Schema bootstrap failed for "${s.name}":`, err instanceof Error ? err.message : err);
+      }
+    }
+
+    agentDataSources.push({
       id: s.id,
       name: s.name,
       type: s.type,
+      schemaDoc: (config?.schemaDoc as string) ?? null,
+      schemaContext: schemaContext as unknown as Record<string, unknown> | null,
       cachedSchema: (config?.cachedSchema as Record<string, unknown>) ?? null,
-    };
-  });
+    });
+  }
 
   // Build ToolContext with real data source operations
-  // Use adminDb instead of the RLS-scoped pool client because the SSE streaming
-  // path runs asynchronously after withAuth releases the pool client.
-  // getDataSourceConnection already filters by orgId explicitly.
-  const adminDb = getAdminDb();
   const toolContext: ToolContext = {
     getSchema: async (srcId: string) => {
       const connection = await getDataSourceConnection(adminDb, orgId, srcId);
@@ -163,6 +188,24 @@ export const POST = withAuth(async (req, { db, orgId }) => {
         sampleRows: (sampleResult as { rows?: unknown[] }).rows ?? [],
       } as unknown as Record<string, unknown>;
     },
+    updateSchemaNotes: async (srcId: string, note: string) => {
+      const [source] = await db
+        .select({ config: dataSources.config })
+        .from(dataSources)
+        .where(and(eq(dataSources.id, srcId), eq(dataSources.orgId, orgId)));
+      if (!source) throw new DataSourceError('Data source not found', 'not_found');
+
+      const config = (source.config as Record<string, unknown>) ?? {};
+      const existingDoc = (config.schemaDoc as string) ?? '';
+      const updatedDoc = existingDoc
+        ? `${existingDoc}\n\n### Agent Notes\n\n${note}`
+        : `### Agent Notes\n\n${note}`;
+      await db
+        .update(dataSources)
+        .set({ config: { ...config, schemaDoc: updatedDoc }, updatedAt: new Date() })
+        .where(eq(dataSources.id, srcId));
+      console.log(`[Chat] Schema note saved for source ${srcId}: ${note.slice(0, 100)}`);
+    },
   };
 
   // Generate or reuse conversation/session ID
@@ -181,6 +224,8 @@ export const POST = withAuth(async (req, { db, orgId }) => {
       toolContext,
       dataSources: agentDataSources,
       scratchpadManager,
+      maxToolRounds: 25,
+      subAgentMaxRounds: 15,
     });
 
     // Load conversation history from Redis for cold-start recovery
@@ -368,15 +413,19 @@ function handleStreaming(
                 if (!event.isError) {
                   try {
                     const parsed = JSON.parse(event.result);
+                    console.log(`[Chat] Tool result for ${event.name}: keys=${Object.keys(parsed).join(',')}`);
                     // Direct create_view/modify_view (single-agent path)
                     if ((event.name === 'create_view' || event.name === 'modify_view') && parsed.viewSpec) {
+                      console.log(`[Chat] Emitting view_created (direct), html=${parsed.viewSpec.html?.length ?? 0} chars`);
                       enqueue('view_created', { viewSpec: parsed.viewSpec });
                     }
                     // delegate_view (multi-agent path) — ViewSpec is in the sub-agent result
-                    if (event.name === 'delegate_view' && parsed.viewSpec) {
-                      enqueue('view_created', { viewSpec: parsed.viewSpec });
-                    } else if (event.name === 'delegate_view' && parsed.viewId) {
-                      enqueue('view_created', { viewSpec: parsed });
+                    if (event.name === 'delegate_view') {
+                      const viewSpec = parsed.viewSpec ?? parsed;
+                      if (viewSpec.html || viewSpec.viewId) {
+                        console.log(`[Chat] Emitting view_created (delegate), html=${viewSpec.html?.length ?? 0} chars`);
+                        enqueue('view_created', { viewSpec });
+                      }
                     }
                   } catch { /* ignore parse errors */ }
                 }

--- a/apps/web/src/app/api/data-sources/[id]/schema/generate/route.ts
+++ b/apps/web/src/app/api/data-sources/[id]/schema/generate/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from 'next/server';
+import { getAdminDb, withAuth } from '@/lib/auth';
+import { getDataSourceConnection, DataSourceError } from '@/lib/data-source-service';
+import { resolveAIProvider } from '@/lib/ai-provider';
+import { generateSchemaContext, renderSchemaContext } from '@lightboard/agent';
+
+/** Annotation system prompt for the LLM. */
+const ANNOTATION_PROMPT = `You are a database documentation expert. Below is auto-generated schema documentation for a PostgreSQL database. Annotate it to create a concise, high-quality reference that will help an AI agent write correct SQL queries on the first attempt.
+
+Your output should be a single markdown document that includes:
+1. Plain-English description for each table (one line)
+2. Notes on important columns — what they mean, not just their type
+3. Key join patterns with example SQL fragments
+4. Data quality gotchas (naming quirks, NULL patterns, enum values to know about)
+5. 3-5 example queries that answer typical questions about this data
+
+Keep it concise — under 6000 characters. The AI agent will read this as context before every query.
+Do NOT wrap the output in a code block. Output raw markdown only.`;
+
+/**
+ * POST /api/data-sources/[id]/schema/generate
+ * Runs introspection + LLM annotation to produce a curated schema document.
+ */
+export const POST = withAuth(async (req, { db, orgId }) => {
+  const segments = new URL(req.url).pathname.split('/');
+  const generateIdx = segments.indexOf('generate');
+  const id = segments[generateIdx - 2]; // .../[id]/schema/generate
+  if (!id) {
+    return NextResponse.json({ error: 'Data source ID is required' }, { status: 400 });
+  }
+
+  const adminDb = getAdminDb();
+
+  // Step 1: Get connection and run introspection
+  let rawMarkdown: string;
+  try {
+    const connection = await getDataSourceConnection(adminDb, orgId, id);
+    const schemaContext = await generateSchemaContext(connection);
+    rawMarkdown = renderSchemaContext(schemaContext);
+  } catch (err) {
+    if (err instanceof DataSourceError) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+    return NextResponse.json(
+      { error: `Introspection failed: ${err instanceof Error ? err.message : String(err)}` },
+      { status: 500 },
+    );
+  }
+
+  // Step 2: Annotate with LLM (if provider is available)
+  const provider = await resolveAIProvider(db, orgId);
+  if (!provider) {
+    // No LLM configured — return raw markdown for manual editing
+    return NextResponse.json({ rawMarkdown, annotatedMarkdown: rawMarkdown });
+  }
+
+  try {
+    // Cap schema size to avoid sending massive prompts (38 tables can produce 30K+ chars)
+    const maxSchemaChars = 12000;
+    const schemaForLLM = rawMarkdown.length > maxSchemaChars
+      ? rawMarkdown.slice(0, maxSchemaChars) + '\n\n... (truncated — full schema available in the editor)'
+      : rawMarkdown;
+
+    let annotatedMarkdown = '';
+    const stream = provider.chat(
+      [{ role: 'user', content: schemaForLLM }],
+      [], // no tools
+      { system: ANNOTATION_PROMPT },
+    );
+
+    for await (const event of stream) {
+      if (event.type === 'text_delta') {
+        annotatedMarkdown += event.text;
+      }
+    }
+
+    return NextResponse.json({ rawMarkdown, annotatedMarkdown });
+  } catch (err) {
+    // LLM annotation failed — return raw markdown as fallback
+    console.error('[SchemaGenerate] LLM annotation failed:', err instanceof Error ? err.message : err);
+    return NextResponse.json({ rawMarkdown, annotatedMarkdown: rawMarkdown });
+  }
+});

--- a/apps/web/src/app/api/data-sources/[id]/schema/route.ts
+++ b/apps/web/src/app/api/data-sources/[id]/schema/route.ts
@@ -5,12 +5,19 @@ import {
   introspectSchema,
   DataSourceError,
 } from '@/lib/data-source-service';
+import { dataSources } from '@lightboard/db/schema';
+import { eq, and } from 'drizzle-orm';
+
+/** Extracts the data source ID from the URL path. */
+function extractId(req: Request): string | null {
+  const segments = new URL(req.url).pathname.split('/');
+  const schemaIdx = segments.indexOf('schema');
+  return segments[schemaIdx - 1] ?? null;
+}
 
 /** GET /api/data-sources/[id]/schema — Introspect the data source schema. */
 export const GET = withAuth(async (req, { db, orgId }) => {
-  const segments = req.nextUrl.pathname.split('/');
-  const schemaIdx = segments.indexOf('schema');
-  const id = segments[schemaIdx - 1];
+  const id = extractId(req);
   if (!id) {
     return NextResponse.json({ error: 'ID is required' }, { status: 400 });
   }
@@ -38,4 +45,48 @@ export const GET = withAuth(async (req, { db, orgId }) => {
       { status: 500 },
     );
   }
+});
+
+/**
+ * PUT /api/data-sources/[id]/schema — Set the curated schema document.
+ * Body: { schemaDoc: string } — a markdown document describing the schema.
+ * This takes priority over auto-generated schema context in agent prompts.
+ */
+export const PUT = withAuth(async (req, { db, orgId }) => {
+  const id = extractId(req);
+  if (!id) {
+    return NextResponse.json({ error: 'ID is required' }, { status: 400 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const schemaDoc = body.schemaDoc;
+  if (typeof schemaDoc !== 'string') {
+    return NextResponse.json({ error: 'schemaDoc (string) is required' }, { status: 400 });
+  }
+
+  // Load existing config and merge
+  const [source] = await db
+    .select({ config: dataSources.config })
+    .from(dataSources)
+    .where(and(eq(dataSources.id, id), eq(dataSources.orgId, orgId)));
+
+  if (!source) {
+    return NextResponse.json({ error: 'Data source not found' }, { status: 404 });
+  }
+
+  const existingConfig = (source.config as Record<string, unknown>) ?? {};
+  const updatedConfig = { ...existingConfig, schemaDoc };
+
+  await db
+    .update(dataSources)
+    .set({ config: updatedConfig, updatedAt: new Date() })
+    .where(eq(dataSources.id, id));
+
+  return NextResponse.json({ ok: true, schemaDocLength: schemaDoc.length });
 });

--- a/apps/web/src/components/explore/data-source-selector.tsx
+++ b/apps/web/src/components/explore/data-source-selector.tsx
@@ -7,6 +7,7 @@ export interface DataSourceOption {
   id: string;
   name: string;
   type: string;
+  hasSchemaDoc?: boolean;
 }
 
 /** Props for DataSourceSelector. */

--- a/apps/web/src/components/explore/explore-page-client.tsx
+++ b/apps/web/src/components/explore/explore-page-client.tsx
@@ -23,6 +23,7 @@ import { ViewRenderer, HtmlViewRenderer, type HtmlView } from '@/components/view
 import { ChatPanel } from './chat-panel';
 import type { ChatMessageData, ToolCallData, AgentIndicatorData } from './chat-message';
 import { DataSourceSelector, type DataSourceOption } from './data-source-selector';
+import { SchemaCurationPanel } from './schema-curation-panel';
 import { parseSSE } from '@/lib/sse-parser';
 
 /**
@@ -42,6 +43,10 @@ export function ExplorePageClient() {
   const isHtmlView = (view: ViewSpec | HtmlView): view is HtmlView => 'html' in view;
   const [dataSources, setDataSources] = useState<DataSourceOption[]>([]);
   const [conversationId, setConversationId] = useState<string | null>(null);
+  const [schemaCuration, setSchemaCuration] = useState<{
+    phase: 'callout' | 'generating' | 'editing' | 'saving';
+    markdown: string;
+  } | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
   // Fetch data sources from API on mount
@@ -52,10 +57,11 @@ export function ExplorePageClient() {
         if (res.ok) {
           const data = await res.json();
           setDataSources(
-            data.dataSources.map((ds: { id: string; name: string; type: string }) => ({
+            data.dataSources.map((ds: { id: string; name: string; type: string; config?: Record<string, unknown> }) => ({
               id: ds.id,
               name: ds.name,
               type: ds.type,
+              hasSchemaDoc: !!ds.config?.schemaDoc,
             })),
           );
         }
@@ -79,6 +85,63 @@ export function ExplorePageClient() {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, []);
+
+  // Show schema curation callout when a source without schemaDoc is selected
+  useEffect(() => {
+    if (!selectedSource) {
+      setSchemaCuration(null);
+      return;
+    }
+    const source = dataSources.find((s) => s.id === selectedSource);
+    if (source && !source.hasSchemaDoc && !currentView) {
+      setSchemaCuration({ phase: 'callout', markdown: '' });
+    } else {
+      setSchemaCuration(null);
+    }
+  }, [selectedSource, dataSources, currentView]);
+
+  /** Generate schema documentation for the selected data source. */
+  const handleGenerateSchema = useCallback(async () => {
+    if (!selectedSource) return;
+    setSchemaCuration({ phase: 'generating', markdown: '' });
+    try {
+      const res = await fetch(`/api/data-sources/${selectedSource}/schema/generate`, {
+        method: 'POST',
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error ?? `Generation failed: ${res.status}`);
+      }
+      const { annotatedMarkdown } = await res.json();
+      setSchemaCuration({ phase: 'editing', markdown: annotatedMarkdown });
+    } catch {
+      // Fall back to callout on error
+      setSchemaCuration({ phase: 'callout', markdown: '' });
+    }
+  }, [selectedSource]);
+
+  /** Save the curated schema document. */
+  const handleSaveSchema = useCallback(async (markdown: string) => {
+    if (!selectedSource) return;
+    setSchemaCuration((prev) => prev ? { ...prev, phase: 'saving' } : null);
+    try {
+      const res = await fetch(`/api/data-sources/${selectedSource}/schema`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ schemaDoc: markdown }),
+      });
+      if (!res.ok) throw new Error('Save failed');
+      // Update local state so callout doesn't reappear
+      setDataSources((prev) =>
+        prev.map((ds) =>
+          ds.id === selectedSource ? { ...ds, hasSchemaDoc: true } : ds,
+        ),
+      );
+      setSchemaCuration(null);
+    } catch {
+      setSchemaCuration((prev) => prev ? { ...prev, phase: 'editing' } : null);
+    }
+  }, [selectedSource]);
 
   /** Consumes an SSE stream and updates messages progressively. */
   const consumeSSEStream = useCallback(
@@ -464,7 +527,7 @@ export function ExplorePageClient() {
             />
           </div>
 
-          {/* Right: View */}
+          {/* Right: View or Schema Curation */}
           <div className="flex-1 overflow-auto">
             {currentView && isHtmlView(currentView) ? (
               <HtmlViewRenderer
@@ -479,6 +542,17 @@ export function ExplorePageClient() {
                 error={null}
                 width={800}
                 height={600}
+              />
+            ) : schemaCuration ? (
+              <SchemaCurationPanel
+                sourceId={selectedSource ?? ''}
+                sourceName={dataSources.find((s) => s.id === selectedSource)?.name ?? ''}
+                phase={schemaCuration.phase}
+                markdown={schemaCuration.markdown}
+                onGenerate={handleGenerateSchema}
+                onSave={handleSaveSchema}
+                onCancel={() => setSchemaCuration({ phase: 'callout', markdown: '' })}
+                onMarkdownChange={(md) => setSchemaCuration((prev) => prev ? { ...prev, markdown: md } : null)}
               />
             ) : (
               <div className="flex h-full items-center justify-center">

--- a/apps/web/src/components/explore/schema-curation-panel.tsx
+++ b/apps/web/src/components/explore/schema-curation-panel.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+/** Props for the SchemaCurationPanel component. */
+interface SchemaCurationPanelProps {
+  sourceId: string;
+  sourceName: string;
+  phase: 'callout' | 'generating' | 'editing' | 'saving';
+  markdown: string;
+  onGenerate: () => void;
+  onSave: (markdown: string) => void;
+  onCancel: () => void;
+  onMarkdownChange: (markdown: string) => void;
+}
+
+/**
+ * Schema curation panel — shown in the viz area when a data source lacks schema documentation.
+ * Handles four phases: callout prompt, generation spinner, markdown editor, and save.
+ */
+export function SchemaCurationPanel({
+  sourceName,
+  phase,
+  markdown,
+  onGenerate,
+  onSave,
+  onCancel,
+  onMarkdownChange,
+}: SchemaCurationPanelProps) {
+  const t = useTranslations('explore');
+
+  if (phase === 'callout') {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="max-w-md text-center">
+          <div
+            className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full"
+            style={{ backgroundColor: 'var(--color-accent)', opacity: 0.15 }}
+          >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--color-accent-foreground)' }}>
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+              <polyline points="14 2 14 8 20 8" />
+              <line x1="16" y1="13" x2="8" y2="13" />
+              <line x1="16" y1="17" x2="8" y2="17" />
+              <polyline points="10 9 9 9 8 9" />
+            </svg>
+          </div>
+          <h3
+            className="text-lg font-semibold"
+            style={{ color: 'var(--color-foreground)' }}
+          >
+            {t('schemaSetupTitle')}
+          </h3>
+          <p
+            className="mt-2 text-sm"
+            style={{ color: 'var(--color-muted-foreground)' }}
+          >
+            {t('schemaSetupDescription', { sourceName })}
+          </p>
+          <button
+            onClick={onGenerate}
+            className="mt-6 rounded-md px-6 py-2 text-sm font-medium transition-colors"
+            style={{
+              backgroundColor: 'var(--color-primary)',
+              color: 'var(--color-primary-foreground)',
+            }}
+          >
+            {t('schemaGenerate')}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'generating') {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-center">
+          <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" style={{ borderColor: 'var(--color-muted-foreground)', borderTopColor: 'transparent' }} />
+          <p className="text-sm font-medium" style={{ color: 'var(--color-foreground)' }}>
+            {t('schemaGenerating')}
+          </p>
+          <p className="mt-1 text-xs" style={{ color: 'var(--color-muted-foreground)' }}>
+            {t('schemaGeneratingHint')}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // phase === 'editing' or 'saving'
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div
+        className="flex items-center justify-between border-b px-4 py-3"
+        style={{ borderColor: 'var(--color-border)' }}
+      >
+        <div>
+          <h3 className="text-sm font-semibold" style={{ color: 'var(--color-foreground)' }}>
+            {t('schemaEditorTitle', { sourceName })}
+          </h3>
+          <p className="text-xs" style={{ color: 'var(--color-muted-foreground)' }}>
+            {t('schemaEditorHint')}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onCancel}
+            className="rounded-md px-3 py-1.5 text-xs"
+            style={{ color: 'var(--color-muted-foreground)' }}
+          >
+            {t('cancel')}
+          </button>
+          <button
+            onClick={() => onSave(markdown)}
+            disabled={phase === 'saving'}
+            className="rounded-md px-4 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
+            style={{
+              backgroundColor: 'var(--color-primary)',
+              color: 'var(--color-primary-foreground)',
+            }}
+          >
+            {phase === 'saving' ? t('schemaSaving') : t('schemaSave')}
+          </button>
+        </div>
+      </div>
+
+      {/* Editor */}
+      <div className="flex-1 overflow-hidden">
+        <textarea
+          value={markdown}
+          onChange={(e) => onMarkdownChange(e.target.value)}
+          className="h-full w-full resize-none border-0 p-4 text-sm focus:outline-none"
+          style={{
+            backgroundColor: 'var(--color-background)',
+            color: 'var(--color-foreground)',
+            fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+            lineHeight: '1.6',
+          }}
+          spellCheck={false}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/data-source-service.ts
+++ b/apps/web/src/lib/data-source-service.ts
@@ -240,17 +240,22 @@ export async function executeRawSQL(
   sql: string,
 ): Promise<QueryResult> {
   const trimmed = sql.trim();
-  if (!trimmed.toUpperCase().startsWith('SELECT')) {
+  // Strip leading SQL comments before checking the statement type
+  const stripped = trimmed.replace(/^(--[^\n]*\n\s*|\/\*[\s\S]*?\*\/\s*)*/g, '');
+  const upper = stripped.toUpperCase();
+  if (!upper.startsWith('SELECT') && !upper.startsWith('WITH')) {
     throw new DataSourceError('Only SELECT queries are allowed', 'validation');
   }
   checkForDDL(trimmed);
 
-  // Inject LIMIT if not present
-  if (!trimmed.toUpperCase().includes('LIMIT')) {
-    const limited = `${trimmed} LIMIT ${DEFAULT_LIMIT}`;
-    return executeRawSQLInternal(connection, limited);
+  // Strip trailing semicolons (agents often include them, but they break LIMIT injection)
+  const cleaned = trimmed.replace(/;\s*$/, '');
+
+  // Inject LIMIT if not present in the outermost query
+  if (!cleaned.toUpperCase().includes('LIMIT')) {
+    return executeRawSQLInternal(connection, `${cleaned} LIMIT ${DEFAULT_LIMIT}`);
   }
-  return executeRawSQLInternal(connection, trimmed);
+  return executeRawSQLInternal(connection, cleaned);
 }
 
 async function executeRawSQLInternal(

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.52.0",
     "@lightboard/connector-sdk": "workspace:*",
+    "pg": "^8.13.0",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -19,6 +19,11 @@ export interface AgentDataSource {
   id: string;
   name: string;
   type: string;
+  /** Curated schema document — human-written or agent-refined markdown. */
+  schemaDoc?: string | null;
+  /** Enriched schema context from bootstrap. */
+  schemaContext?: Record<string, unknown> | null;
+  /** Legacy basic schema (fallback). */
   cachedSchema?: Record<string, unknown> | null;
 }
 

--- a/packages/agent/src/agents/view-agent.ts
+++ b/packages/agent/src/agents/view-agent.ts
@@ -32,6 +32,7 @@ export class ViewAgent implements SubAgent {
     ];
 
     const maxRounds = this.config.maxToolRounds ?? 3;
+    let viewResult: Record<string, unknown> | undefined;
 
     for (let round = 0; round < maxRounds; round++) {
       const toolCalls: ToolCallResult[] = [];
@@ -88,14 +89,13 @@ export class ViewAgent implements SubAgent {
         return {
           role: 'view',
           success: true,
-          data: this.extractViewData(textContent),
+          data: viewResult ?? this.extractViewData(textContent),
           explanation: textContent,
         };
       }
 
       // Execute tool calls and collect results
       const toolResults = [];
-      let lastViewResult: Record<string, unknown> | undefined;
 
       for (const tc of toolCalls) {
         const result = await this.config.toolRouter.execute(tc.name, tc.input);
@@ -108,7 +108,7 @@ export class ViewAgent implements SubAgent {
         // Capture the view data from create_view or modify_view results
         if (!result.isError && (tc.name === 'create_view' || tc.name === 'modify_view')) {
           try {
-            lastViewResult = JSON.parse(result.content) as Record<string, unknown>;
+            viewResult = JSON.parse(result.content) as Record<string, unknown>;
           } catch {
             // ignore parse failures
           }
@@ -122,11 +122,11 @@ export class ViewAgent implements SubAgent {
       });
 
       // If this is the last round and we have a view result, return it
-      if (round === maxRounds - 1 && lastViewResult) {
+      if (round === maxRounds - 1 && viewResult) {
         return {
           role: 'view',
           success: true,
-          data: lastViewResult,
+          data: viewResult,
           explanation: textContent || 'View created successfully',
         };
       }

--- a/packages/agent/src/bootstrap/index.ts
+++ b/packages/agent/src/bootstrap/index.ts
@@ -1,0 +1,2 @@
+export { generateSchemaContext, renderSchemaContext, type SchemaContext, type EnrichedTable, type Relationship } from './schema-context';
+export type { ConnectionConfig } from './types';

--- a/packages/agent/src/bootstrap/schema-context.ts
+++ b/packages/agent/src/bootstrap/schema-context.ts
@@ -31,18 +31,20 @@ export interface SchemaContext {
   generatedAt: string;
 }
 
-/** SQL: tables with row counts from pg_stat. */
+/** SQL: tables with row counts from pg_class (more reliable than pg_stat which requires ANALYZE). */
 const TABLES_WITH_COUNTS = `
   SELECT
     t.table_schema,
     t.table_name,
-    COALESCE(s.n_live_tup, 0) AS row_count
+    COALESCE(c.reltuples, 0)::bigint AS row_count
   FROM information_schema.tables t
-  LEFT JOIN pg_stat_user_tables s
-    ON t.table_name = s.relname AND t.table_schema = s.schemaname
+  LEFT JOIN pg_class c
+    ON c.relname = t.table_name
+  LEFT JOIN pg_namespace n
+    ON n.oid = c.relnamespace AND n.nspname = t.table_schema
   WHERE t.table_schema NOT IN ('pg_catalog', 'information_schema')
     AND t.table_type = 'BASE TABLE'
-  ORDER BY s.n_live_tup DESC NULLS LAST
+  ORDER BY c.reltuples DESC NULLS LAST
 `;
 
 /** SQL: columns with PKs. */

--- a/packages/agent/src/bootstrap/schema-context.ts
+++ b/packages/agent/src/bootstrap/schema-context.ts
@@ -1,0 +1,269 @@
+import type { ConnectionConfig } from './types';
+import pg from 'pg';
+
+/** Enriched table metadata for LLM context. */
+export interface EnrichedTable {
+  name: string;
+  schema: string;
+  rowCount: number;
+  columns: {
+    name: string;
+    type: string;
+    nullable: boolean;
+    primaryKey: boolean;
+  }[];
+  sampleValues: Record<string, unknown[]>;
+  dateRanges: Record<string, { min: string; max: string }>;
+}
+
+/** Foreign key relationship. */
+export interface Relationship {
+  sourceTable: string;
+  sourceColumn: string;
+  targetTable: string;
+  targetColumn: string;
+}
+
+/** Complete bootstrapped schema context. */
+export interface SchemaContext {
+  tables: EnrichedTable[];
+  relationships: Relationship[];
+  generatedAt: string;
+}
+
+/** SQL: tables with row counts from pg_stat. */
+const TABLES_WITH_COUNTS = `
+  SELECT
+    t.table_schema,
+    t.table_name,
+    COALESCE(s.n_live_tup, 0) AS row_count
+  FROM information_schema.tables t
+  LEFT JOIN pg_stat_user_tables s
+    ON t.table_name = s.relname AND t.table_schema = s.schemaname
+  WHERE t.table_schema NOT IN ('pg_catalog', 'information_schema')
+    AND t.table_type = 'BASE TABLE'
+  ORDER BY s.n_live_tup DESC NULLS LAST
+`;
+
+/** SQL: columns with PKs. */
+const COLUMNS = `
+  SELECT
+    c.table_schema, c.table_name, c.column_name, c.data_type, c.is_nullable,
+    CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END AS is_primary_key
+  FROM information_schema.columns c
+  LEFT JOIN (
+    SELECT kcu.table_schema, kcu.table_name, kcu.column_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+    WHERE tc.constraint_type = 'PRIMARY KEY'
+  ) pk ON c.table_schema = pk.table_schema
+    AND c.table_name = pk.table_name AND c.column_name = pk.column_name
+  WHERE c.table_schema NOT IN ('pg_catalog', 'information_schema')
+  ORDER BY c.table_schema, c.table_name, c.ordinal_position
+`;
+
+/** SQL: foreign key relationships. */
+const RELATIONSHIPS = `
+  SELECT
+    kcu.table_name AS source_table,
+    kcu.column_name AS source_column,
+    ccu.table_name AS target_table,
+    ccu.column_name AS target_column
+  FROM information_schema.table_constraints tc
+  JOIN information_schema.key_column_usage kcu
+    ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+  JOIN information_schema.constraint_column_usage ccu
+    ON tc.constraint_name = ccu.constraint_name AND tc.table_schema = ccu.table_schema
+  WHERE tc.constraint_type = 'FOREIGN KEY'
+    AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
+`;
+
+/**
+ * Generates an enriched schema context optimized for LLM consumption.
+ * Collects: table/column metadata, row counts, foreign keys,
+ * sample values for low-cardinality columns, and date ranges.
+ */
+export async function generateSchemaContext(connection: ConnectionConfig): Promise<SchemaContext> {
+  const pool = new pg.Pool({
+    ...connection,
+    connectionTimeoutMillis: 5000,
+    max: 2,
+  });
+
+  try {
+    // Parallel: tables with counts, columns, relationships
+    const [tablesResult, columnsResult, relsResult] = await Promise.all([
+      pool.query(TABLES_WITH_COUNTS),
+      pool.query(COLUMNS),
+      pool.query(RELATIONSHIPS),
+    ]);
+
+    // Build table map
+    const tableMap = new Map<string, EnrichedTable>();
+    for (const row of tablesResult.rows) {
+      const key = `${row.table_schema}.${row.table_name}`;
+      tableMap.set(key, {
+        name: row.table_name,
+        schema: row.table_schema,
+        rowCount: parseInt(row.row_count, 10) || 0,
+        columns: [],
+        sampleValues: {},
+        dateRanges: {},
+      });
+    }
+
+    // Attach columns
+    for (const row of columnsResult.rows) {
+      const key = `${row.table_schema}.${row.table_name}`;
+      const table = tableMap.get(key);
+      if (table) {
+        table.columns.push({
+          name: row.column_name,
+          type: row.data_type,
+          nullable: row.is_nullable === 'YES',
+          primaryKey: row.is_primary_key === true || row.is_primary_key === 't',
+        });
+      }
+    }
+
+    // Relationships
+    const relationships: Relationship[] = relsResult.rows.map((r) => ({
+      sourceTable: r.source_table,
+      sourceColumn: r.source_column,
+      targetTable: r.target_table,
+      targetColumn: r.target_column,
+    }));
+
+    // Enrich tables with sample values and date ranges (parallel, bounded)
+    const tables = [...tableMap.values()];
+    await Promise.all(tables.map((t) => enrichTable(pool, t)));
+
+    return {
+      tables,
+      relationships,
+      generatedAt: new Date().toISOString(),
+    };
+  } finally {
+    await pool.end();
+  }
+}
+
+/**
+ * Enriches a single table with sample values for low-cardinality text columns
+ * and date ranges for timestamp columns.
+ */
+async function enrichTable(pool: pg.Pool, table: EnrichedTable): Promise<void> {
+  if (table.rowCount === 0) return;
+
+  const textCols = table.columns.filter(
+    (c) => (c.type === 'text' || c.type === 'character varying' || c.type === 'USER-DEFINED') && !c.primaryKey,
+  );
+  const dateCols = table.columns.filter(
+    (c) => c.type.includes('timestamp') || c.type === 'date',
+  );
+
+  if (textCols.length === 0 && dateCols.length === 0) return;
+
+  const queries: Promise<void>[] = [];
+
+  // Sample distinct values for text columns (up to 15 values each)
+  for (const col of textCols.slice(0, 5)) {
+    queries.push(
+      pool
+        .query(
+          `SELECT DISTINCT "${col.name}" AS val FROM "${table.name}" WHERE "${col.name}" IS NOT NULL LIMIT 15`,
+        )
+        .then((r) => {
+          if (r.rows.length > 0 && r.rows.length <= 15) {
+            table.sampleValues[col.name] = r.rows.map((row) => row.val);
+          }
+        })
+        .catch(() => {}),
+    );
+  }
+
+  // Date ranges for timestamp columns
+  for (const col of dateCols.slice(0, 3)) {
+    queries.push(
+      pool
+        .query(
+          `SELECT MIN("${col.name}") AS min_val, MAX("${col.name}") AS max_val FROM "${table.name}"`,
+        )
+        .then((r) => {
+          if (r.rows[0]?.min_val && r.rows[0]?.max_val) {
+            table.dateRanges[col.name] = {
+              min: String(r.rows[0].min_val),
+              max: String(r.rows[0].max_val),
+            };
+          }
+        })
+        .catch(() => {}),
+    );
+  }
+
+  await Promise.all(queries);
+}
+
+/**
+ * Renders a SchemaContext as a compact markdown document optimized for LLM system prompts.
+ * Designed to stay under ~4K tokens for most schemas.
+ */
+export function renderSchemaContext(ctx: SchemaContext): string {
+  const lines: string[] = ['## Database Schema\n'];
+
+  // Relationship index for quick lookup
+  const relsByTable = new Map<string, Relationship[]>();
+  for (const rel of ctx.relationships) {
+    const existing = relsByTable.get(rel.sourceTable) ?? [];
+    existing.push(rel);
+    relsByTable.set(rel.sourceTable, existing);
+  }
+
+  for (const table of ctx.tables) {
+    lines.push(`### ${table.name} (${table.rowCount.toLocaleString()} rows)`);
+
+    // Columns
+    for (const col of table.columns) {
+      const flags = [
+        col.primaryKey ? 'PK' : '',
+        col.nullable ? 'nullable' : '',
+      ].filter(Boolean).join(', ');
+      const flagStr = flags ? ` (${flags})` : '';
+      lines.push(`- ${col.name}: ${col.type}${flagStr}`);
+    }
+
+    // Foreign keys from this table
+    const rels = relsByTable.get(table.name);
+    if (rels && rels.length > 0) {
+      lines.push('Joins:');
+      for (const rel of rels) {
+        lines.push(`- ${table.name}.${rel.sourceColumn} → ${rel.targetTable}.${rel.targetColumn}`);
+      }
+    }
+
+    // Sample values
+    const sampleEntries = Object.entries(table.sampleValues);
+    if (sampleEntries.length > 0) {
+      lines.push('Sample values:');
+      for (const [col, vals] of sampleEntries) {
+        const display = vals.slice(0, 10).map((v) => String(v)).join(', ');
+        const suffix = vals.length > 10 ? `, ... (${vals.length} distinct)` : '';
+        lines.push(`- ${col}: ${display}${suffix}`);
+      }
+    }
+
+    // Date ranges
+    const dateEntries = Object.entries(table.dateRanges);
+    if (dateEntries.length > 0) {
+      lines.push('Date ranges:');
+      for (const [col, range] of dateEntries) {
+        lines.push(`- ${col}: ${range.min} to ${range.max}`);
+      }
+    }
+
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/packages/agent/src/bootstrap/types.ts
+++ b/packages/agent/src/bootstrap/types.ts
@@ -1,0 +1,8 @@
+/** Connection configuration for a data source. */
+export interface ConnectionConfig {
+  host: string;
+  port: number;
+  database: string;
+  user: string;
+  password: string;
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -25,6 +25,7 @@ export {
 } from './provider';
 export { SessionScratchpad, ScratchpadManager, type ScratchpadTable, type ScratchpadLimits, type ScratchpadManagerOptions } from './scratchpad';
 export { buildSystemPrompt, buildQueryPrompt, buildViewPrompt, buildInsightsPrompt, buildLeaderPrompt } from './prompt';
+export { generateSchemaContext, renderSchemaContext, type SchemaContext, type EnrichedTable } from './bootstrap';
 export {
   agentTools,
   queryTools,

--- a/packages/agent/src/prompt/query-prompt.ts
+++ b/packages/agent/src/prompt/query-prompt.ts
@@ -1,3 +1,6 @@
+import type { SchemaContext } from '../bootstrap';
+import { renderSchemaContext } from '../bootstrap';
+
 /**
  * Data source context with schema for building the query agent's system prompt.
  * Mirrors the shape used by the main system prompt builder.
@@ -6,6 +9,8 @@ interface DataSourceContext {
   id: string;
   name: string;
   type: string;
+  schemaDoc?: string | null;
+  schemaContext?: SchemaContext | null;
   cachedSchema?: {
     tables: {
       name: string;
@@ -17,8 +22,7 @@ interface DataSourceContext {
 
 /**
  * Builds a focused system prompt for the Query Agent specialist.
- * Contains schema details and QueryIR specification — no chart or view knowledge.
- * Designed to stay under ~2K tokens for efficient context usage.
+ * Contains enriched schema details — no chart or view knowledge.
  */
 export function buildQueryPrompt(context: {
   dataSources: DataSourceContext[];
@@ -28,7 +32,11 @@ export function buildQueryPrompt(context: {
   for (const ds of context.dataSources) {
     parts.push(`\n### Data Source: "${ds.name}" (id: "${ds.id}", type: ${ds.type})`);
 
-    if (ds.cachedSchema && ds.cachedSchema.tables.length > 0) {
+    if (ds.schemaDoc) {
+      parts.push(ds.schemaDoc);
+    } else if (ds.schemaContext) {
+      parts.push(renderSchemaContext(ds.schemaContext));
+    } else if (ds.cachedSchema && ds.cachedSchema.tables.length > 0) {
       parts.push('Tables:');
       for (const table of ds.cachedSchema.tables) {
         const cols = table.columns

--- a/packages/agent/src/prompt/system.ts
+++ b/packages/agent/src/prompt/system.ts
@@ -1,8 +1,16 @@
+import type { SchemaContext } from '../bootstrap';
+import { renderSchemaContext } from '../bootstrap';
+
 /** Data source info with optional cached schema for the system prompt. */
 interface DataSourceContext {
   id: string;
   name: string;
   type: string;
+  /** Curated schema document (highest priority — human-written or agent-refined). */
+  schemaDoc?: string | null;
+  /** Enriched schema context from bootstrap (second priority). */
+  schemaContext?: SchemaContext | null;
+  /** Legacy basic schema (fallback). */
   cachedSchema?: {
     tables: {
       name: string;
@@ -28,7 +36,14 @@ export function buildSystemPrompt(context: {
     for (const ds of context.dataSources) {
       parts.push(`\n### Data Source: "${ds.name}" (id: "${ds.id}", type: ${ds.type})`);
 
-      if (ds.cachedSchema && ds.cachedSchema.tables.length > 0) {
+      if (ds.schemaDoc) {
+        // Curated schema document — highest quality context
+        parts.push(ds.schemaDoc);
+      } else if (ds.schemaContext) {
+        // Enriched schema with row counts, sample values, relationships
+        parts.push(renderSchemaContext(ds.schemaContext));
+      } else if (ds.cachedSchema && ds.cachedSchema.tables.length > 0) {
+        // Fallback: basic column listing
         parts.push('Tables:');
         for (const table of ds.cachedSchema.tables) {
           const cols = table.columns

--- a/packages/agent/src/tools/definitions.ts
+++ b/packages/agent/src/tools/definitions.ts
@@ -60,6 +60,27 @@ export const agentTools: ToolDefinition[] = [
     },
   },
   {
+    name: 'update_schema_notes',
+    description:
+      'Append a note to the schema documentation for this data source. ' +
+      'Use this when you discover something useful about the schema: a join pattern, a gotcha, ' +
+      'a column meaning, or a query pattern that works well. These notes persist across conversations.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source_id: {
+          type: 'string',
+          description: 'The data source to annotate',
+        },
+        note: {
+          type: 'string',
+          description: 'The note to append (markdown). E.g. "### Gotcha\\nmatches.series is often NULL for IPL — use training_data.match_format instead."',
+        },
+      },
+      required: ['source_id', 'note'],
+    },
+  },
+  {
     name: 'create_view',
     description:
       'Create a visualization from query results. ' +

--- a/packages/agent/src/tools/router.ts
+++ b/packages/agent/src/tools/router.ts
@@ -10,6 +10,8 @@ export interface ToolContext {
   runSQL?: (sourceId: string, sql: string) => Promise<Record<string, unknown>>;
   /** Describe a single table: columns, types, and sample rows. */
   describeTable?: (sourceId: string, tableName: string) => Promise<Record<string, unknown>>;
+  /** Append a note to the schema documentation for a data source. */
+  updateSchemaNotes?: (sourceId: string, note: string) => Promise<void>;
   /** Get the current view state. */
   getCurrentView?: () => Record<string, unknown> | null;
   /** Execute DuckDB SQL on the session scratchpad for statistical analysis. */
@@ -30,6 +32,10 @@ const toolInputSchemas = {
   describe_table: z.object({
     source_id: z.string().min(1),
     table_name: z.string().min(1),
+  }),
+  update_schema_notes: z.object({
+    source_id: z.string().min(1),
+    note: z.string().min(1),
   }),
   create_view: z.object({
     title: z.string(),
@@ -68,7 +74,7 @@ export class ToolRouter {
     this.context = context;
     this.allowedTools = toolDefinitions
       ? new Set(toolDefinitions.map((t) => t.name))
-      : new Set(['get_schema', 'run_sql', 'describe_table', 'create_view', 'modify_view']);
+      : new Set(['get_schema', 'run_sql', 'describe_table', 'update_schema_notes', 'create_view', 'modify_view']);
   }
 
   /** Execute a tool call and return the result. Errors are returned, not thrown. */
@@ -107,6 +113,9 @@ export class ToolRouter {
           break;
         case 'describe_table':
           result = await this.handleDescribeTable(normalizedInput);
+          break;
+        case 'update_schema_notes':
+          result = await this.handleUpdateSchemaNotes(normalizedInput);
           break;
         case 'run_sql':
           result = await this.handleRunSQL(normalizedInput);
@@ -171,6 +180,21 @@ export class ToolRouter {
 
     const result = await this.context.describeTable(parsed.data.source_id, parsed.data.table_name);
     return { content: JSON.stringify(result, null, 2), isError: false };
+  }
+
+  /** Handle update_schema_notes — appends a note to the schema documentation. */
+  private async handleUpdateSchemaNotes(input: Record<string, unknown>): Promise<ToolExecutionResult> {
+    const parsed = toolInputSchemas.update_schema_notes.safeParse(input);
+    if (!parsed.success) {
+      return { content: `Invalid input: ${parsed.error.message}`, isError: true };
+    }
+
+    if (!this.context.updateSchemaNotes) {
+      return { content: 'update_schema_notes is not available', isError: true };
+    }
+
+    await this.context.updateSchemaNotes(parsed.data.source_id, parsed.data.note);
+    return { content: 'Schema note saved successfully.', isError: false };
   }
 
   /** Handle create_view tool call — stores an HTML view. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@lightboard/connector-sdk':
         specifier: workspace:*
         version: link:../connector-sdk
+      pg:
+        specifier: ^8.13.0
+        version: 8.20.0
       zod:
         specifier: ^3.25.0
         version: 3.25.76


### PR DESCRIPTION
## Summary

- **Three-tier schema context**: curated `schemaDoc` (markdown) > auto-generated `schemaContext` (introspection with row counts, sample values, FK relationships) > basic `cachedSchema` (column listing)
- **Schema bootstrap**: auto-generates enriched schema context on first chat per data source, cached in DB for subsequent requests
- **Curated schema docs**: `PUT /api/data-sources/[id]/schema` to seed a hand-written schema document — dramatically improves query quality (prototype showed 2-round vs 14-round queries)
- **Agent learning**: `update_schema_notes` tool lets the agent append discoveries (join patterns, gotchas, column meanings) that persist across conversations
- **Bug fixes**: ViewAgent result loss between rounds, SQL comment/semicolon handling, broader delegate_view SSE detection

Tested end-to-end with cricket analytics database — agent writes complex CTEs with JOINs, produces Chart.js visualizations in sandboxed iframes.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm --filter @lightboard/agent test` — 84/84 pass
- [x] Manual: seeded curated schema doc, agent used join patterns and IPL filtering correctly
- [x] Manual: HTML visualization rendered in iframe (horizontal bar chart with stat cards)
- [x] Manual: verify `update_schema_notes` persists notes across conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)