### PR TITLE
feat: schema curation UI with human review and agent questions

### DIFF
--- a/apps/web/src/app/api/agent/chat/route.ts
+++ b/apps/web/src/app/api/agent/chat/route.ts
@@ -9,7 +9,7 @@ import {
 import { checkRateLimit, addRateLimitHeaders } from '@/lib/rate-limit';
 import { redis } from '@/lib/redis';
 import { dataSources } from '@lightboard/db/schema';
-import { eq, and } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import {
   LeaderAgent,
   ScratchpadManager,
@@ -188,23 +188,10 @@ export const POST = withAuth(async (req, { db, orgId }) => {
         sampleRows: (sampleResult as { rows?: unknown[] }).rows ?? [],
       } as unknown as Record<string, unknown>;
     },
-    updateSchemaNotes: async (srcId: string, note: string) => {
-      const [source] = await db
-        .select({ config: dataSources.config })
-        .from(dataSources)
-        .where(and(eq(dataSources.id, srcId), eq(dataSources.orgId, orgId)));
-      if (!source) throw new DataSourceError('Data source not found', 'not_found');
-
-      const config = (source.config as Record<string, unknown>) ?? {};
-      const existingDoc = (config.schemaDoc as string) ?? '';
-      const updatedDoc = existingDoc
-        ? `${existingDoc}\n\n### Agent Notes\n\n${note}`
-        : `### Agent Notes\n\n${note}`;
-      await db
-        .update(dataSources)
-        .set({ config: { ...config, schemaDoc: updatedDoc }, updatedAt: new Date() })
-        .where(eq(dataSources.id, srcId));
-      console.log(`[Chat] Schema note saved for source ${srcId}: ${note.slice(0, 100)}`);
+    saveSchemaDoc: async (_srcId: string, document: string) => {
+      // propose_schema_doc does NOT save — it returns the doc for human review.
+      // The frontend will show it in the editor; the user saves via PUT /api/data-sources/[id]/schema.
+      console.log(`[Chat] Schema doc proposed: ${document.length} chars (awaiting user review)`);
     },
   };
 
@@ -438,6 +425,10 @@ function handleStreaming(
                     if ((event.name === 'create_view' || event.name === 'modify_view') && parsed.viewSpec) {
                       console.log(`[Chat] Emitting view_created (direct), html=${parsed.viewSpec.html?.length ?? 0} chars`);
                       enqueue('view_created', { viewSpec: parsed.viewSpec });
+                    }
+                    // Emit schema_proposed when propose_schema_doc succeeds — sends doc to editor
+                    if (event.name === 'propose_schema_doc' && parsed.proposed) {
+                      enqueue('schema_proposed', { document: parsed.document });
                     }
                     if (event.name === 'delegate_view') {
                       const viewSpec = parsed.viewSpec ?? parsed;

--- a/apps/web/src/components/explore/explore-page-client.tsx
+++ b/apps/web/src/components/explore/explore-page-client.tsx
@@ -47,6 +47,7 @@ export function ExplorePageClient() {
     phase: 'callout' | 'generating' | 'editing' | 'saving';
     markdown: string;
   } | null>(null);
+  const schemaGenerationTriggered = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
 
   // Fetch data sources from API on mount
@@ -90,8 +91,11 @@ export function ExplorePageClient() {
   useEffect(() => {
     if (!selectedSource) {
       setSchemaCuration(null);
+      schemaGenerationTriggered.current = false;
       return;
     }
+    // Don't re-show callout if generation was already triggered in this session
+    if (schemaGenerationTriggered.current) return;
     const source = dataSources.find((s) => s.id === selectedSource);
     if (source && !source.hasSchemaDoc && !currentView) {
       setSchemaCuration({ phase: 'callout', markdown: '' });
@@ -99,26 +103,6 @@ export function ExplorePageClient() {
       setSchemaCuration(null);
     }
   }, [selectedSource, dataSources, currentView]);
-
-  /** Generate schema documentation for the selected data source. */
-  const handleGenerateSchema = useCallback(async () => {
-    if (!selectedSource) return;
-    setSchemaCuration({ phase: 'generating', markdown: '' });
-    try {
-      const res = await fetch(`/api/data-sources/${selectedSource}/schema/generate`, {
-        method: 'POST',
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err.error ?? `Generation failed: ${res.status}`);
-      }
-      const { annotatedMarkdown } = await res.json();
-      setSchemaCuration({ phase: 'editing', markdown: annotatedMarkdown });
-    } catch {
-      // Fall back to callout on error
-      setSchemaCuration({ phase: 'callout', markdown: '' });
-    }
-  }, [selectedSource]);
 
   /** Save the curated schema document. */
   const handleSaveSchema = useCallback(async (markdown: string) => {
@@ -298,6 +282,13 @@ export function ExplorePageClient() {
                       });
                   }
                 }
+              }
+              break;
+
+            case 'schema_proposed':
+              // Agent proposed a schema doc — open it in the editor for user review
+              if (data.document) {
+                setSchemaCuration({ phase: 'editing', markdown: data.document });
               }
               break;
 
@@ -492,6 +483,30 @@ export function ExplorePageClient() {
       prev.map((m) => (m.isStreaming ? { ...m, isStreaming: false } : m)),
     );
   }, []);
+
+  /** Generate schema documentation by sending a chat message that triggers exploration. */
+  const handleGenerateSchema = useCallback(() => {
+    if (!selectedSource) return;
+    schemaGenerationTriggered.current = true;
+    setSchemaCuration(null); // Hide callout while chat runs
+    const source = dataSources.find((s) => s.id === selectedSource);
+    const sourceName = source?.name ?? 'this database';
+    handleSend(
+      `I need you to explore the "${sourceName}" database (source_id: ${selectedSource}) and create schema documentation.\n\n` +
+      `Follow these steps IN ORDER:\n\n` +
+      `**Phase 1 — Explore:** Use get_schema, describe_table, and run_sql to understand the tables, columns, relationships, and data patterns. ` +
+      `Pay special attention to: foreign key columns (which ID columns link to which tables), ` +
+      `enum/categorical values, date ranges, and row counts.\n\n` +
+      `**Phase 2 — Ask Questions:** Before writing any documentation, you MUST ask me at least 3 questions about:\n` +
+      `- Which tables are most important for the use cases I care about\n` +
+      `- Any domain-specific terminology or gotchas I should know about\n` +
+      `- How specific filtering should work (e.g. how to identify certain subsets of data)\n` +
+      `Wait for my answers before proceeding.\n\n` +
+      `**Phase 3 — Propose:** After I answer your questions, call propose_schema_doc with source_id="${selectedSource}" ` +
+      `and the complete documentation as markdown. I will review and edit it before saving.\n\n` +
+      `The documentation should cover: table descriptions, key columns, join patterns, data gotchas, and example queries. Keep it under 6000 characters.`,
+    );
+  }, [selectedSource, dataSources, handleSend]);
 
   const handleNewConversation = useCallback(() => {
     handleStop();

--- a/packages/agent/src/agents/leader.ts
+++ b/packages/agent/src/agents/leader.ts
@@ -167,6 +167,10 @@ export class LeaderAgent {
 
         if (tc.name.startsWith('delegate_')) {
           result = yield* this.handleDelegation(tc, conversationId);
+        } else if (tc.name === 'propose_schema_doc') {
+          // Route propose_schema_doc through the ToolRouter for DB persistence
+          const router = new ToolRouter(this.toolContext);
+          result = await router.execute(tc.name, tc.input);
         } else if (tc.name === 'list_scratchpads') {
           const tables = scratchpad.listTables();
           result = { content: JSON.stringify(tables), isError: false };

--- a/packages/agent/src/tools/definitions.ts
+++ b/packages/agent/src/tools/definitions.ts
@@ -60,24 +60,27 @@ export const agentTools: ToolDefinition[] = [
     },
   },
   {
-    name: 'update_schema_notes',
+    name: 'propose_schema_doc',
     description:
-      'Append a note to the schema documentation for this data source. ' +
-      'Use this when you discover something useful about the schema: a join pattern, a gotcha, ' +
-      'a column meaning, or a query pattern that works well. These notes persist across conversations.',
+      'Propose schema documentation for the user to review and edit. ' +
+      'The document will be shown in an editor for the user to curate before saving. ' +
+      'The document should be a concise, LLM-optimized markdown reference covering: ' +
+      'table descriptions, key columns, join patterns, filtering gotchas, enum values, and example queries. ' +
+      'Keep it under 6000 characters. ' +
+      'IMPORTANT: Before calling this, you MUST ask the user questions about the domain to fill gaps in your understanding.',
     inputSchema: {
       type: 'object',
       properties: {
         source_id: {
           type: 'string',
-          description: 'The data source to annotate',
+          description: 'The data source to save documentation for',
         },
-        note: {
+        document: {
           type: 'string',
-          description: 'The note to append (markdown). E.g. "### Gotcha\\nmatches.series is often NULL for IPL — use training_data.match_format instead."',
+          description: 'The complete schema documentation as markdown',
         },
       },
-      required: ['source_id', 'note'],
+      required: ['source_id', 'document'],
     },
   },
   {

--- a/packages/agent/src/tools/leader-tools.ts
+++ b/packages/agent/src/tools/leader-tools.ts
@@ -81,6 +81,30 @@ export const leaderTools: ToolDefinition[] = [
     },
   },
   {
+    name: 'propose_schema_doc',
+    description:
+      'Propose schema documentation for the user to review and edit before saving. ' +
+      'The document will be shown in an editor — it is NOT saved automatically. ' +
+      'IMPORTANT: Before calling this, you MUST ask the user questions about the domain. ' +
+      'The document should be a concise, LLM-optimized markdown reference covering: ' +
+      'table descriptions, key columns, join patterns, filtering gotchas, enum values, and example queries. ' +
+      'Keep it under 6000 characters.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source_id: {
+          type: 'string',
+          description: 'The data source to save documentation for',
+        },
+        document: {
+          type: 'string',
+          description: 'The complete schema documentation as markdown',
+        },
+      },
+      required: ['source_id', 'document'],
+    },
+  },
+  {
     name: 'load_scratchpad',
     description:
       'Load a summary of a scratchpad table (columns, row count, sample rows). ' +

--- a/packages/agent/src/tools/router.ts
+++ b/packages/agent/src/tools/router.ts
@@ -10,8 +10,8 @@ export interface ToolContext {
   runSQL?: (sourceId: string, sql: string) => Promise<Record<string, unknown>>;
   /** Describe a single table: columns, types, and sample rows. */
   describeTable?: (sourceId: string, tableName: string) => Promise<Record<string, unknown>>;
-  /** Append a note to the schema documentation for a data source. */
-  updateSchemaNotes?: (sourceId: string, note: string) => Promise<void>;
+  /** Save the complete schema documentation for a data source. */
+  saveSchemaDoc?: (sourceId: string, document: string) => Promise<void>;
   /** Get the current view state. */
   getCurrentView?: () => Record<string, unknown> | null;
   /** Execute DuckDB SQL on the session scratchpad for statistical analysis. */
@@ -33,9 +33,9 @@ const toolInputSchemas = {
     source_id: z.string().min(1),
     table_name: z.string().min(1),
   }),
-  update_schema_notes: z.object({
+  propose_schema_doc: z.object({
     source_id: z.string().min(1),
-    note: z.string().min(1),
+    document: z.string().min(1),
   }),
   create_view: z.object({
     title: z.string(),
@@ -74,7 +74,7 @@ export class ToolRouter {
     this.context = context;
     this.allowedTools = toolDefinitions
       ? new Set(toolDefinitions.map((t) => t.name))
-      : new Set(['get_schema', 'run_sql', 'describe_table', 'update_schema_notes', 'create_view', 'modify_view']);
+      : new Set(['get_schema', 'run_sql', 'describe_table', 'propose_schema_doc', 'create_view', 'modify_view']);
   }
 
   /** Execute a tool call and return the result. Errors are returned, not thrown. */
@@ -114,8 +114,8 @@ export class ToolRouter {
         case 'describe_table':
           result = await this.handleDescribeTable(normalizedInput);
           break;
-        case 'update_schema_notes':
-          result = await this.handleUpdateSchemaNotes(normalizedInput);
+        case 'propose_schema_doc':
+          result = await this.handleSaveSchemaDoc(normalizedInput);
           break;
         case 'run_sql':
           result = await this.handleRunSQL(normalizedInput);
@@ -182,19 +182,19 @@ export class ToolRouter {
     return { content: JSON.stringify(result, null, 2), isError: false };
   }
 
-  /** Handle update_schema_notes — appends a note to the schema documentation. */
-  private async handleUpdateSchemaNotes(input: Record<string, unknown>): Promise<ToolExecutionResult> {
-    const parsed = toolInputSchemas.update_schema_notes.safeParse(input);
+  /** Handle propose_schema_doc — saves the complete schema documentation. */
+  private async handleSaveSchemaDoc(input: Record<string, unknown>): Promise<ToolExecutionResult> {
+    const parsed = toolInputSchemas.propose_schema_doc.safeParse(input);
     if (!parsed.success) {
       return { content: `Invalid input: ${parsed.error.message}`, isError: true };
     }
 
-    if (!this.context.updateSchemaNotes) {
-      return { content: 'update_schema_notes is not available', isError: true };
+    if (!this.context.saveSchemaDoc) {
+      return { content: 'propose_schema_doc is not available', isError: true };
     }
 
-    await this.context.updateSchemaNotes(parsed.data.source_id, parsed.data.note);
-    return { content: 'Schema note saved successfully.', isError: false };
+    await this.context.saveSchemaDoc(parsed.data.source_id, parsed.data.document);
+    return { content: JSON.stringify({ proposed: true, document: parsed.data.document }), isError: false };
   }
 
   /** Handle create_view tool call — stores an HTML view. */


### PR DESCRIPTION
## Summary

- **Schema curation callout** — right panel shows "Set up schema documentation" card when a data source has no `schemaDoc`
- **Conversational generation** — clicking "Generate" sends a structured chat message that guides the agent through explore → ask questions → propose
- **`propose_schema_doc` tool** — agent proposes a doc that opens in the editor for human review (does NOT save directly)
- **Markdown editor** — monospace textarea in the right panel, user edits and clicks Save to persist via PUT endpoint
- **Client disconnect abort** — SSE stream detects dead connections and stops agent processing immediately
- **pg_class row counts** — fixes tables showing 0 rows when ANALYZE hasn't run
- **SQL safety fixes** — CTEs with comments, trailing semicolons handled correctly
- **Schema generation API** — `POST /api/data-sources/[id]/schema/generate` for one-shot introspection + LLM annotation (fallback)

Tested with Nemotron (Ollama) on cricket analytics DB (38 tables) and SWITRS collision DB (3 tables). The curation loop works — model limitations are the bottleneck, not the infrastructure.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm --filter @lightboard/agent test` — 84/84 pass
- [x] Manual: callout appears for data source without schemaDoc
- [x] Manual: Generate triggers conversational schema exploration
- [x] Manual: propose_schema_doc opens editor with proposed doc
- [x] Manual: Save persists via PUT, callout disappears
- [x] Manual: client disconnect aborts agent processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)