### PR TITLE
feat: async bootstrap, PNG export, view timeline filmstrip

### DIFF
--- a/apps/web/src/app/api/agent/chat/route.ts
+++ b/apps/web/src/app/api/agent/chat/route.ts
@@ -18,7 +18,6 @@ import {
   type AgentDataSource,
   type AgentEvent,
   type Message,
-  type SchemaContext,
   type ToolContext,
 } from '@lightboard/agent';
 import { resolveAIProvider } from '@/lib/ai-provider';
@@ -120,42 +119,25 @@ export const POST = withAuth(async (req, { db, orgId }) => {
     .from(dataSources)
     .where(eq(dataSources.orgId, orgId));
 
-  // Build agent data sources, generating enriched schema context if not cached
+  // Build agent data sources — bootstrap deferred to SSE stream to avoid timeout
   const adminDb = getAdminDb();
-  const agentDataSources: AgentDataSource[] = [];
-  for (const s of orgSources) {
+  const agentDataSources: AgentDataSource[] = orgSources.map((s) => {
     const config = s.config as Record<string, unknown> | null;
-    let schemaContext = (config?.schemaContext as SchemaContext) ?? null;
-
-    // Generate schema context on first use if missing
-    if (!schemaContext) {
-      try {
-        const connection = await getDataSourceConnection(adminDb, orgId, s.id);
-        console.log(`[Chat] Bootstrapping schema context for "${s.name}"...`);
-        const start = performance.now();
-        schemaContext = await generateSchemaContext(connection);
-        console.log(`[Chat] Schema bootstrap complete (${Math.round(performance.now() - start)}ms, ${schemaContext.tables.length} tables)`);
-
-        // Cache it back to the data source config for future requests
-        const updatedConfig = { ...(config ?? {}), schemaContext };
-        await db
-          .update(dataSources)
-          .set({ config: updatedConfig, updatedAt: new Date() })
-          .where(eq(dataSources.id, s.id));
-      } catch (err) {
-        console.error(`[Chat] Schema bootstrap failed for "${s.name}":`, err instanceof Error ? err.message : err);
-      }
-    }
-
-    agentDataSources.push({
+    return {
       id: s.id,
       name: s.name,
       type: s.type,
       schemaDoc: (config?.schemaDoc as string) ?? null,
-      schemaContext: schemaContext as unknown as Record<string, unknown> | null,
+      schemaContext: (config?.schemaContext as unknown as Record<string, unknown>) ?? null,
       cachedSchema: (config?.cachedSchema as Record<string, unknown>) ?? null,
-    });
-  }
+    };
+  });
+
+  // Identify sources that need bootstrap (no schemaDoc AND no schemaContext)
+  const sourcesNeedingBootstrap = orgSources.filter((s) => {
+    const config = s.config as Record<string, unknown> | null;
+    return !config?.schemaDoc && !config?.schemaContext;
+  });
 
   // Build ToolContext with real data source operations
   const toolContext: ToolContext = {
@@ -178,14 +160,18 @@ export const POST = withAuth(async (req, { db, orgId }) => {
         throw new DataSourceError(`Table "${tableName}" not found`, 'not_found');
       }
       // Get sample rows
+      // Limit sample query to first 20 columns to avoid huge outputs for wide tables
+      const cols = table.columns as Array<{ name: string }>;
+      const colNames = cols.slice(0, 20).map((c) => `"${c.name}"`).join(', ');
       const sampleResult = await executeRawSQL(
         connection,
-        `SELECT * FROM "${tableName}" LIMIT 5`,
+        `SELECT ${colNames} FROM "${tableName}" LIMIT 5`,
       );
       return {
         table: tableName,
         columns: table.columns,
         sampleRows: (sampleResult as { rows?: unknown[] }).rows ?? [],
+        ...(cols.length > 20 ? { note: `Showing 20 of ${cols.length} columns in samples` } : {}),
       } as unknown as Record<string, unknown>;
     },
     saveSchemaDoc: async (_srcId: string, document: string) => {
@@ -232,7 +218,7 @@ export const POST = withAuth(async (req, { db, orgId }) => {
 
   console.log(`[Chat] Mode: ${wantsStream ? 'SSE streaming' : 'JSON'}, session=${sessionId}`);
   if (wantsStream) {
-    return handleStreaming(leader, message, orgId, sessionId);
+    return handleStreaming(leader, message, orgId, sessionId, sourcesNeedingBootstrap, adminDb, agentDataSources);
   }
 
   return handleNonStreaming(leader, message, orgId, sessionId);
@@ -357,6 +343,9 @@ function handleStreaming(
   message: string,
   orgId: string,
   sessionId: string,
+  sourcesNeedingBootstrap: Array<{ id: string; name: string; config: unknown }>,
+  adminDb: ReturnType<typeof getAdminDb>,
+  agentDataSources: AgentDataSource[],
 ): Response {
   const encoder = new TextEncoder();
   const abort = new AbortController();
@@ -389,6 +378,36 @@ function handleStreaming(
       }, 15_000);
 
       try {
+        // Run schema bootstrap inside the stream (avoids HTTP timeout)
+        if (sourcesNeedingBootstrap.length > 0) {
+          for (const s of sourcesNeedingBootstrap) {
+            if (abort.signal.aborted) break;
+            enqueue('status', { text: `Preparing schema for "${s.name}"...` });
+            try {
+              const connection = await getDataSourceConnection(adminDb, orgId, s.id);
+              console.log(`[Chat] Bootstrapping schema context for "${s.name}"...`);
+              const start = performance.now();
+              const schemaContext = await generateSchemaContext(connection);
+              console.log(`[Chat] Schema bootstrap complete (${Math.round(performance.now() - start)}ms, ${schemaContext.tables.length} tables)`);
+
+              // Cache to DB
+              const config = (s.config as Record<string, unknown>) ?? {};
+              const updatedConfig = { ...config, schemaContext };
+              await adminDb
+                .update(dataSources)
+                .set({ config: updatedConfig, updatedAt: new Date() })
+                .where(eq(dataSources.id, s.id));
+
+              // Update the agentDataSources in-memory so the leader uses it
+              const ds = agentDataSources.find((d) => d.id === s.id);
+              if (ds) ds.schemaContext = schemaContext as unknown as Record<string, unknown>;
+            } catch (err) {
+              console.error(`[Chat] Schema bootstrap failed for "${s.name}":`, err instanceof Error ? err.message : err);
+            }
+          }
+          enqueue('status', { text: '' }); // Clear status
+        }
+
         const timeoutPromise = new Promise<never>((_, reject) => {
           setTimeout(() => reject(new Error('Agent processing timed out')), AGENT_TIMEOUT_MS);
         });

--- a/apps/web/src/app/api/agent/chat/route.ts
+++ b/apps/web/src/app/api/agent/chat/route.ts
@@ -56,7 +56,7 @@ if (typeof leaderCleanupInterval === 'object' && 'unref' in leaderCleanupInterva
 }
 
 /** Maximum duration for agent processing in milliseconds. */
-const AGENT_TIMEOUT_MS = 300_000;
+const AGENT_TIMEOUT_MS = 600_000;
 
 /** Redis TTL for conversation sessions in seconds. */
 const CONVERSATION_TTL_SEC = 3600;

--- a/apps/web/src/components/explore/explore-page-client.tsx
+++ b/apps/web/src/components/explore/explore-page-client.tsx
@@ -158,6 +158,19 @@ export function ExplorePageClient() {
               );
               break;
 
+            case 'status':
+              // Server-side status updates (e.g. schema bootstrap progress)
+              if (data.text) {
+                setMessages((prev) =>
+                  prev.map((m) =>
+                    m.id === assistantMsgId
+                      ? { ...m, content: data.text }
+                      : m,
+                  ),
+                );
+              }
+              break;
+
             case 'tool_start': {
               const newToolCall: ToolCallData = {
                 name: data.name,

--- a/apps/web/src/components/explore/explore-page-client.tsx
+++ b/apps/web/src/components/explore/explore-page-client.tsx
@@ -24,6 +24,7 @@ import { ChatPanel } from './chat-panel';
 import type { ChatMessageData, ToolCallData, AgentIndicatorData } from './chat-message';
 import { DataSourceSelector, type DataSourceOption } from './data-source-selector';
 import { SchemaCurationPanel } from './schema-curation-panel';
+import { ViewFilmstrip } from './view-filmstrip';
 import { parseSSE } from '@/lib/sse-parser';
 
 /**
@@ -38,6 +39,8 @@ export function ExplorePageClient() {
   const [selectedSource, setSelectedSource] = useState<string | null>(null);
   const [currentView, setCurrentView] = useState<ViewSpec | HtmlView | null>(null);
   const [viewData, setViewData] = useState<Record<string, unknown>[] | null>(null);
+  const [viewHistory, setViewHistory] = useState<HtmlView[]>([]);
+  const [activeViewIndex, setActiveViewIndex] = useState(-1);
 
   /** Type guard: HTML views have an `html` property. */
   const isHtmlView = (view: ViewSpec | HtmlView): view is HtmlView => 'html' in view;
@@ -267,8 +270,10 @@ export function ExplorePageClient() {
             case 'view_created':
               if (data.viewSpec) {
                 setCurrentView(data.viewSpec);
-                // HTML views have data embedded — no need to fetch
+                // Track HTML views in history for filmstrip
                 if (data.viewSpec.html) {
+                  setViewHistory((prev) => [...prev, data.viewSpec as HtmlView]);
+                  setActiveViewIndex(-1); // -1 = latest (will be set to length after render)
                   setViewData(null);
                 } else if (data.queryResult?.rows) {
                   setViewData(data.queryResult.rows);
@@ -526,6 +531,8 @@ export function ExplorePageClient() {
     setMessages([]);
     setCurrentView(null);
     setViewData(null);
+    setViewHistory([]);
+    setActiveViewIndex(-1);
     setConversationId(null);
   }, [handleStop]);
 
@@ -556,7 +563,8 @@ export function ExplorePageClient() {
           </div>
 
           {/* Right: View or Schema Curation */}
-          <div className="flex-1 overflow-auto">
+          <div className="flex flex-1 flex-col overflow-hidden">
+            <div className="flex-1 overflow-auto">
             {currentView && isHtmlView(currentView) ? (
               <HtmlViewRenderer
                 view={currentView}
@@ -594,6 +602,16 @@ export function ExplorePageClient() {
                 </div>
               </div>
             )}
+            </div>
+            {/* View filmstrip */}
+            <ViewFilmstrip
+              views={viewHistory}
+              activeIndex={activeViewIndex === -1 ? viewHistory.length - 1 : activeViewIndex}
+              onSelect={(i) => {
+                setActiveViewIndex(i);
+                if (viewHistory[i]) setCurrentView(viewHistory[i]);
+              }}
+            />
           </div>
         </div>
       </div>

--- a/apps/web/src/components/explore/view-filmstrip.tsx
+++ b/apps/web/src/components/explore/view-filmstrip.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { HtmlView } from '@/components/view-renderer';
+
+/** Props for the ViewFilmstrip component. */
+interface ViewFilmstripProps {
+  views: HtmlView[];
+  activeIndex: number;
+  onSelect: (index: number) => void;
+}
+
+/**
+ * Horizontal scrollable strip of previous visualization thumbnails.
+ * Click any card to restore that view. Auto-scrolls to the newest view.
+ */
+export function ViewFilmstrip({ views, activeIndex, onSelect }: ViewFilmstripProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to newest view
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollRef.current.scrollWidth;
+    }
+  }, [views.length]);
+
+  if (views.length <= 1) return null;
+
+  return (
+    <div
+      className="shrink-0 border-t"
+      style={{ borderColor: 'var(--color-border)' }}
+    >
+      <div
+        ref={scrollRef}
+        className="flex gap-2 overflow-x-auto p-2"
+        style={{ scrollbarWidth: 'thin' }}
+      >
+        {views.map((view, i) => (
+          <button
+            key={i}
+            onClick={() => onSelect(i)}
+            className="shrink-0 rounded-md px-3 py-2 text-left transition-colors"
+            style={{
+              width: 140,
+              backgroundColor: i === activeIndex
+                ? 'var(--color-accent)'
+                : 'var(--color-muted)',
+              borderWidth: '1px',
+              borderStyle: 'solid',
+              borderColor: i === activeIndex
+                ? 'var(--color-accent-foreground)'
+                : 'transparent',
+            }}
+          >
+            <p
+              className="truncate text-xs font-medium"
+              style={{ color: 'var(--color-foreground)' }}
+            >
+              {view.title ?? `View ${i + 1}`}
+            </p>
+            <p
+              className="mt-0.5 truncate text-xs"
+              style={{ color: 'var(--color-muted-foreground)' }}
+            >
+              {view.description ?? ''}
+            </p>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/agent/src/prompt/view-prompt.ts
+++ b/packages/agent/src/prompt/view-prompt.ts
@@ -56,9 +56,28 @@ Use create_view with:
 - [ ] Responsive: works at 400px-1200px width
 - [ ] No scrollbars unless data table has many rows
 
+## PNG Export
+
+Include a small download button (top-right corner, semi-transparent) that exports the visualization as PNG:
+
+\`\`\`html
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<button id="download-btn" style="position:fixed;top:8px;right:8px;padding:4px 12px;font-size:12px;background:rgba(255,255,255,0.1);color:#e4e4e7;border:1px solid rgba(255,255,255,0.2);border-radius:4px;cursor:pointer;z-index:100">⬇ PNG</button>
+<script>
+document.getElementById('download-btn').onclick=function(){
+  this.style.display='none';
+  html2canvas(document.body,{backgroundColor:'#0a0a0f'}).then(function(c){
+    var a=document.createElement('a');a.href=c.toDataURL('image/png');a.download='chart.png';a.click();
+    document.getElementById('download-btn').style.display='';
+  });
+};
+</script>
+\`\`\`
+
 ## Rules
 
 - Always include title and description in the create_view call
 - Use create_view for new visualizations, modify_view for changes
 - The HTML must render correctly in a sandboxed iframe
-- Do NOT use document.cookie, localStorage, or fetch — the iframe is sandboxed`;
+- Do NOT use document.cookie, localStorage, or fetch — the iframe is sandboxed
+- Always include the PNG download button and html2canvas script`;

--- a/packages/agent/src/prompt/view-prompt.ts
+++ b/packages/agent/src/prompt/view-prompt.ts
@@ -30,7 +30,7 @@ Use create_view with:
 
 ## HTML Requirements
 
-1. **Data**: Embed the query results as \`const DATA = [...];\` in a <script> tag.
+1. **Data**: You MUST embed the actual query result rows directly as a JSON array literal: \`const DATA = [{...}, {...}, ...];\`. Do NOT use template variables like \${DATA} — the data must be hardcoded in the HTML string.
 2. **Charts**: Use Chart.js from CDN (\`https://cdn.jsdelivr.net/npm/chart.js\`) or pure SVG. Choose the best chart type for the data.
 3. **Layout**: Responsive, centered, max-width 900px. Use CSS Grid or Flexbox for multi-panel layouts.
 4. **Theme**: Dark background (#0a0a0f), light text (#e4e4e7), accent colors from this palette: #6366f1 (indigo), #22d3ee (cyan), #f59e0b (amber), #10b981 (emerald), #f43f5e (rose), #a855f7 (purple).

--- a/packages/agent/src/tools/router.ts
+++ b/packages/agent/src/tools/router.ts
@@ -91,9 +91,6 @@ export class ToolRouter {
       }
     }
 
-    // Log raw input for debugging
-    console.log(`[ToolRouter] Raw input: ${JSON.stringify(normalizedInput).slice(0, 300)}`);
-
     // Log tool call with compact input summary
     const inputSummary = toolName === 'run_sql'
       ? `sql=${JSON.stringify((normalizedInput as Record<string, unknown>).sql)}`


### PR DESCRIPTION
## Summary

Completes the remaining items from the simplification plan (Week 2).

### Async schema bootstrap
- Moved bootstrap from the synchronous POST handler into the SSE stream's `start()` callback
- Browser gets the SSE connection immediately, sees "Preparing schema..." status events while bootstrap runs
- Eliminates the 50s browser timeout for large databases
- Bootstrap only runs when data source has no `schemaDoc` AND no `schemaContext`

### PNG export
- View prompt instructs agent to include html2canvas CDN + download button in every visualization
- Runs entirely inside the sandboxed iframe (no parent access)
- No new npm dependencies

### View timeline filmstrip
- Horizontal scrollable strip of previous views below the main visualization
- Only appears when 2+ views exist in conversation
- Click to restore any previous view
- Auto-scrolls to newest, cleared on new conversation

### Polish
- Removed verbose raw input debug log from ToolRouter
- Capped describe_table sample query to 20 columns (fixes 30K+ char outputs for wide tables)
- Added `status` SSE event handling for bootstrap progress

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm --filter @lightboard/agent test` — 84/84 pass
- [ ] Manual: first chat with uncached data source shows "Preparing schema..." then proceeds
- [ ] Manual: agent-generated chart includes PNG download button
- [ ] Manual: multiple views in conversation show filmstrip, click restores view

🤖 Generated with [Claude Code](https://claude.com/claude-code)