### PR TITLE
feat(ui): PR 3 — top-bar nav + collapsible sidebar

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -12,11 +12,16 @@
   },
   "nav": {
     "home": "Home",
+    "dashboard": "Dashboard",
     "explore": "Explore",
-    "dataSources": "Data Sources",
     "views": "Views",
     "settings": "Settings",
     "logout": "Log out"
+  },
+  "topBar": {
+    "toggleSidebar": "Toggle sidebar",
+    "changeModel": "Change model",
+    "primaryNav": "Primary navigation"
   },
   "home": {
     "title": "Welcome to Lightboard",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,7 +32,8 @@
     "rehype-highlight": "^7.0.2",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",

--- a/apps/web/src/app/(dashboard)/dev/sigil/page.tsx
+++ b/apps/web/src/app/(dashboard)/dev/sigil/page.tsx
@@ -17,7 +17,7 @@ export default function SigilPreviewPage() {
 
   return (
     <div
-      className="min-h-[calc(100vh-56px)] -m-6 p-10 flex flex-col gap-10"
+      className="min-h-[calc(100vh-56px)] p-10 flex flex-col gap-10"
       style={{ backgroundColor: 'var(--bg-0)' }}
     >
       <header className="flex flex-col gap-2">

--- a/apps/web/src/components/layout/__tests__/nav-item.test.tsx
+++ b/apps/web/src/components/layout/__tests__/nav-item.test.tsx
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { NavItem, isNavItemActive } from '../nav-item';
+
+// `usePathname` is controlled per-test via this mutable ref. Placed above
+// `vi.mock` calls because mocks are hoisted but can still reference
+// module-scope `let` bindings thanks to closure — declaring here keeps
+// intent clear.
+let mockPathname: string = '/';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+vi.mock('next-view-transitions', () => ({
+  // A plain anchor tag is equivalent for component-tree assertions — we only
+  // care about href + active-state rendering here.
+  Link: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('next-intl', () => ({
+  // Translations aren't the subject — echo the key so assertions can match on
+  // the stable English label without wiring the full next-intl provider.
+  useTranslations: () => (key: string) => {
+    const map: Record<string, string> = {
+      dashboard: 'Dashboard',
+      explore: 'Explore',
+      views: 'Views',
+      settings: 'Settings',
+    };
+    return map[key] ?? key;
+  },
+}));
+
+describe('isNavItemActive', () => {
+  it('exact-matches the root href', () => {
+    expect(isNavItemActive('/', '/')).toBe(true);
+    expect(isNavItemActive('/explore', '/')).toBe(false);
+  });
+
+  it('prefix-matches non-root hrefs', () => {
+    expect(isNavItemActive('/explore', '/explore')).toBe(true);
+    expect(isNavItemActive('/explore/123', '/explore')).toBe(true);
+    expect(isNavItemActive('/exploration', '/explore')).toBe(false);
+  });
+
+  it('returns false for null pathname', () => {
+    expect(isNavItemActive(null, '/explore')).toBe(false);
+  });
+});
+
+describe('<NavItem>', () => {
+  // Project has no shared vitest setup file, so `@testing-library/react`'s
+  // auto-cleanup never registers. Unmount between tests explicitly so each
+  // `render` starts from an empty body.
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the translated label', () => {
+    mockPathname = '/';
+    const { getByText } = render(
+      <NavItem href="/explore" labelKey="explore" icon="explore" />,
+    );
+    expect(getByText('Explore')).toBeTruthy();
+  });
+
+  it('applies active state when pathname matches href', () => {
+    mockPathname = '/explore';
+    const { container } = render(
+      <NavItem href="/explore" labelKey="explore" icon="explore" />,
+    );
+    const link = container.querySelector('a');
+    expect(link?.getAttribute('data-active')).toBe('true');
+    expect(link?.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('does not apply active state when pathname differs', () => {
+    mockPathname = '/';
+    const { container } = render(
+      <NavItem href="/explore" labelKey="explore" icon="explore" />,
+    );
+    const link = container.querySelector('a');
+    expect(link?.getAttribute('data-active')).toBeNull();
+    expect(link?.getAttribute('aria-current')).toBeNull();
+  });
+});

--- a/apps/web/src/components/layout/__tests__/sidebar.test.tsx
+++ b/apps/web/src/components/layout/__tests__/sidebar.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { Sidebar } from '../sidebar';
+import { useUiStore } from '@/stores/ui-store';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => (key === 'logout' ? 'Log out' : key),
+}));
+
+describe('<Sidebar>', () => {
+  beforeEach(() => {
+    useUiStore.setState({ sidebarOpen: true });
+  });
+
+  // Project has no shared vitest setup file, so `@testing-library/react`'s
+  // auto-cleanup never registers. Unmount between tests explicitly so each
+  // `render` starts from an empty body.
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders children when open', () => {
+    const { getByText } = render(
+      <Sidebar>
+        <div>Per-route content</div>
+      </Sidebar>,
+    );
+    expect(getByText('Per-route content')).toBeTruthy();
+  });
+
+  it('expands to 240px when sidebarOpen is true', () => {
+    const { container } = render(<Sidebar>content</Sidebar>);
+    const aside = container.querySelector('aside');
+    expect(aside?.getAttribute('data-open')).toBe('true');
+    // The inline style carries the current pixel width — jsdom normalizes to
+    // the canonical `"240px"` form.
+    expect(aside?.style.width).toBe('240px');
+  });
+
+  it('collapses to 0px width when sidebarOpen is false', () => {
+    useUiStore.setState({ sidebarOpen: false });
+    const { container } = render(<Sidebar>content</Sidebar>);
+    const aside = container.querySelector('aside');
+    expect(aside?.getAttribute('data-open')).toBe('false');
+    expect(aside?.style.width).toBe('0px');
+    // Border collapses to transparent so the continuous top-bar border
+    // visually stays intact across the sidebar gutter.
+    expect(aside?.style.borderRight).toContain('transparent');
+  });
+
+  it('renders a logout button in the footer', () => {
+    const { getByText } = render(<Sidebar>content</Sidebar>);
+    expect(getByText('Log out')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/layout/agent-picker.tsx
+++ b/apps/web/src/components/layout/agent-picker.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+
+/**
+ * Rounded-pill model selector living in the right column of the top bar.
+ *
+ * TODO (backend-ui-polish-followups.md — "Agent-picker wiring"): hook this up
+ * to a real model list + selection state. For now the button is a no-op
+ * placeholder that renders the static "Haiku 4.5" label from the design mock.
+ */
+export function AgentPicker() {
+  const t = useTranslations('topBar');
+
+  return (
+    <button
+      type="button"
+      aria-label={t('changeModel')}
+      onClick={() => {
+        // TODO: open the model-picker dropdown — see
+        // documentation/backend-ui-polish-followups.md#agent-picker-wiring.
+      }}
+      className={cn(
+        'inline-flex items-center gap-2 rounded-lg px-[10px] py-[5px] pl-2',
+        'border border-[var(--line-1)] bg-transparent transition-all duration-150 ease-out',
+        'hover:bg-[var(--bg-6)]',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-warm)]',
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="h-[6px] w-[6px] rounded-full bg-[var(--kind-narrate)]"
+        style={{ boxShadow: '0 0 0 2px rgba(125,180,105,0.15)' }}
+      />
+      <span className="text-[12px] text-[var(--ink-1)]">Haiku 4.5</span>
+      <svg
+        width="8"
+        height="8"
+        viewBox="0 0 8 8"
+        aria-hidden="true"
+        className="text-[var(--ink-4,#6B6B73)]"
+      >
+        <path
+          d="M1 2.5L4 5.5L7 2.5"
+          stroke="currentColor"
+          strokeWidth="1.3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -2,18 +2,50 @@
 
 import { Sidebar } from './sidebar';
 import { TopBar } from './top-bar';
+import { useSidebarShortcut } from './use-sidebar-shortcut';
 
 /**
- * App shell layout with sidebar and top bar.
- * The shell renders instantly — only the content area shows loading states.
+ * Props for {@link AppShell}.
  */
-export function AppShell({ title, children }: { title?: string; children: React.ReactNode }) {
+export interface AppShellProps {
+  /** Main route content rendered to the right of the sidebar. */
+  children: React.ReactNode;
+  /**
+   * Per-route sidebar content. Routes that need custom sidebar widgets
+   * (e.g. Explore's DB picker + conversations list shipping in PR 4) inject
+   * them here via a client wrapper. Routes that don't need a sidebar panel
+   * omit this prop — the sidebar container still renders so the collapse
+   * animation stays consistent across routes.
+   */
+  sidebarSlot?: React.ReactNode;
+}
+
+/**
+ * App-shell layout for all authenticated routes. Composes:
+ *
+ * 1. A sticky 56px top bar with centered primary nav.
+ * 2. A collapsible 240px left sidebar hosting the per-route slot.
+ * 3. A scrollable main content area.
+ *
+ * Also mounts the global `Ctrl/Cmd + \` sidebar toggle shortcut. The shell
+ * itself renders instantly — only the content area shows loading states.
+ */
+export function AppShell({ children, sidebarSlot }: AppShellProps) {
+  useSidebarShortcut();
+
   return (
-    <div className="flex h-screen overflow-hidden">
-      <Sidebar />
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <TopBar title={title} />
-        <main className="flex-1 overflow-auto p-6">{children}</main>
+    <div
+      className="flex h-screen flex-col overflow-hidden"
+      style={{
+        background: 'var(--bg-0)',
+        color: 'var(--ink-1)',
+        fontFamily: 'var(--font-body), Inter, system-ui, sans-serif',
+      }}
+    >
+      <TopBar />
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar>{sidebarSlot}</Sidebar>
+        <main className="flex-1 overflow-auto">{children}</main>
       </div>
     </div>
   );

--- a/apps/web/src/components/layout/icon-button.tsx
+++ b/apps/web/src/components/layout/icon-button.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { forwardRef, type ButtonHTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Props for {@link IconButton}. Extends the native button element so callers
+ * can pass `onClick`, `aria-label`, `disabled`, etc. directly.
+ */
+export type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement>;
+
+/**
+ * Square 30x30 icon button used throughout the app shell — hamburger toggle,
+ * composer controls (future), filmstrip toggle (future). Mirrors the
+ * handoff's `IconButton` primitive (`Lightboard-handoff/project/components/Shell.jsx`)
+ * but swaps the inline styles for token-backed Tailwind classes so the hover
+ * states live alongside the rest of the app's design system.
+ */
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  function IconButton({ className, type = 'button', ...rest }, ref) {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={cn(
+          'inline-flex h-[30px] w-[30px] items-center justify-center rounded-lg',
+          'bg-transparent text-[var(--ink-3)] transition-[background-color,color]',
+          'duration-150 ease-out hover:bg-[var(--bg-6)] hover:text-[var(--ink-1)]',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-warm)]',
+          'disabled:pointer-events-none disabled:opacity-50',
+          className,
+        )}
+        {...rest}
+      />
+    );
+  },
+);

--- a/apps/web/src/components/layout/nav-item.tsx
+++ b/apps/web/src/components/layout/nav-item.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { Link } from 'next-view-transitions';
+import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+
+/** Names of the inline SVG icons supported by the top-bar nav. */
+export type NavIcon = 'dashboard' | 'explore' | 'views' | 'settings';
+
+/** Props for {@link NavItem}. */
+export interface NavItemProps {
+  /** Target pathname. Passed verbatim to the `next-view-transitions` Link. */
+  href: string;
+  /** Translation key under the `nav` namespace — e.g. `'explore'`. */
+  labelKey: string;
+  /** Which inline SVG icon to render on the left. */
+  icon: NavIcon;
+}
+
+/**
+ * Renders the 14x14 inline SVG glyph for a given {@link NavIcon}. The paths
+ * are ported verbatim from the design handoff's `Shell.jsx` so the stroke
+ * weights and cap styles match the rest of the shell iconography.
+ */
+function NavIconGlyph({ icon }: { icon: NavIcon }) {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+      {icon === 'dashboard' && (
+        <path
+          d="M1 1h5v5H1zM8 1h5v5H8zM1 8h5v5H1zM8 8h5v5H8z"
+          stroke="currentColor"
+          strokeWidth="1.1"
+          fill="none"
+        />
+      )}
+      {icon === 'explore' && (
+        <path
+          d="M4.5 10.5L1.5 13.5M10 6a4 4 0 11-8 0 4 4 0 018 0z"
+          stroke="currentColor"
+          strokeWidth="1.2"
+          fill="none"
+          strokeLinecap="round"
+        />
+      )}
+      {icon === 'views' && (
+        <path
+          d="M1 11.5l3.5-4 3 2.5L12 3"
+          stroke="currentColor"
+          strokeWidth="1.3"
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      )}
+      {icon === 'settings' && (
+        <path
+          d="M7 4.5a2.5 2.5 0 100 5 2.5 2.5 0 000-5zM7 1v1.5M7 11.5V13M13 7h-1.5M2.5 7H1M11.2 2.8l-1 1M3.8 10.2l-1 1M11.2 11.2l-1-1M3.8 3.8l-1-1"
+          stroke="currentColor"
+          strokeWidth="1.1"
+          fill="none"
+          strokeLinecap="round"
+        />
+      )}
+    </svg>
+  );
+}
+
+/**
+ * Determine whether `pathname` should render `href` as active. The dashboard
+ * home (`/`) is special-cased to exact-match so deeper routes don't all read
+ * as "Dashboard is active" — every other entry matches on prefix.
+ */
+export function isNavItemActive(pathname: string | null, href: string): boolean {
+  if (pathname == null) return false;
+  if (href === '/') return pathname === '/';
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+/**
+ * A single entry in the centered top-bar nav. Renders icon + label and,
+ * when active, an accent-warm underline positioned absolutely below the
+ * button so that toggling active state never shifts layout.
+ */
+export function NavItem({ href, labelKey, icon }: NavItemProps) {
+  const pathname = usePathname();
+  const t = useTranslations('nav');
+  const active = isNavItemActive(pathname, href);
+
+  return (
+    <Link
+      href={href}
+      data-active={active ? 'true' : undefined}
+      aria-current={active ? 'page' : undefined}
+      className={cn(
+        'relative inline-flex items-center gap-2 rounded-md px-[14px] py-2 text-[13px]',
+        'font-[var(--font-body)] transition-colors duration-[180ms] ease-out',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-warm)]',
+        active
+          ? 'font-medium text-[var(--ink-1)]'
+          : 'text-[var(--ink-3)] hover:text-[var(--ink-2)]',
+      )}
+    >
+      <NavIconGlyph icon={icon} />
+      <span>{t(labelKey)}</span>
+      {active && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-[-18px] left-[14px] right-[14px] h-[2px] rounded-[2px] bg-[var(--accent-warm)]"
+        />
+      )}
+    </Link>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,87 +1,73 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { Link } from 'next-view-transitions';
-import {
-  Compass,
-  Database,
-  LayoutDashboard,
-  LogOut,
-  type LucideIcon,
-  Settings,
-  SquareKanban,
-} from 'lucide-react';
+import { useUiStore } from '@/stores/ui-store';
 import { cn } from '@/lib/utils';
 
 /**
- * Navigation item definition for the sidebar.
+ * Props for {@link Sidebar}.
  */
-interface NavItem {
-  href: string;
-  labelKey: string;
-  icon: LucideIcon;
+export interface SidebarProps {
+  /**
+   * Per-route sidebar content. Each route that needs sidebar widgets
+   * (Explore's DB picker + conversations list, etc.) passes its own tree
+   * here via `AppShell`'s `sidebarSlot` prop. Routes that don't need a
+   * sidebar panel pass `undefined` — the container still renders so the
+   * collapse animation remains consistent.
+   */
+  children?: React.ReactNode;
 }
 
-const NAV_ITEMS: NavItem[] = [
-  { href: '/', labelKey: 'home', icon: LayoutDashboard },
-  { href: '/explore', labelKey: 'explore', icon: Compass },
-  { href: '/data-sources', labelKey: 'dataSources', icon: Database },
-  { href: '/views', labelKey: 'views', icon: SquareKanban },
-  { href: '/settings', labelKey: 'settings', icon: Settings },
-];
-
 /**
- * Application sidebar with navigation links.
- * Renders instantly from static content — no loading states.
+ * Collapsible 240px left sidebar. Primary nav was removed in PR 3 (it lives
+ * in the centered top bar now); this container is now purely a slot + a
+ * logout footer.
+ *
+ * When `sidebarOpen` is `false` the sidebar collapses to `width: 0` with
+ * `overflow: hidden` — a full hide, not an icon rail. The width + border
+ * transition uses `--ease-out-quint` over 280ms so collapse feels coherent
+ * with the rest of the shell motion.
  */
-export function Sidebar() {
-  const pathname = usePathname();
+export function Sidebar({ children }: SidebarProps) {
   const t = useTranslations('nav');
+  const open = useUiStore((s) => s.sidebarOpen);
 
   async function handleLogout() {
     await fetch('/api/auth/logout', { method: 'POST' });
-    // Use hard navigation to clear all client state and let middleware redirect
+    // Use hard navigation to clear all client state and let middleware redirect.
     window.location.href = '/login';
   }
 
   return (
-    <aside className="flex h-screen w-60 flex-col border-r border-sidebar-border bg-sidebar">
-      <div className="flex h-14 items-center border-b border-sidebar-border px-4">
-        <Link href="/" className="text-lg font-semibold text-sidebar-foreground">
-          Lightboard
-        </Link>
+    <aside
+      aria-label="Sidebar"
+      data-open={open ? 'true' : 'false'}
+      className={cn(
+        'flex h-full flex-none flex-col overflow-y-auto',
+        // Collapsed: width 0, hidden content, transparent border so the
+        // top-bar's bottom-border remains continuous across the edge.
+        !open && 'overflow-hidden',
+      )}
+      style={{
+        width: open ? 240 : 0,
+        background: 'var(--bg-1)',
+        borderRight: open ? '1px solid var(--line-1)' : '1px solid transparent',
+        padding: open ? '16px 14px' : '16px 0',
+        gap: 16,
+        transition:
+          'width 280ms var(--ease-out-quint), border-color 280ms var(--ease-out-quint), padding 280ms var(--ease-out-quint)',
+      }}
+    >
+      <div className="flex min-h-0 flex-1 flex-col gap-4">
+        {children}
       </div>
 
-      <nav className="flex-1 space-y-1 p-2">
-        {NAV_ITEMS.map((item) => {
-          const isActive = item.href === '/' ? pathname === '/' : pathname.startsWith(item.href);
-          const Icon = item.icon;
-
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={cn(
-                'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                isActive
-                  ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-                  : 'text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground',
-              )}
-            >
-              <Icon className="h-4 w-4" />
-              {t(item.labelKey)}
-            </Link>
-          );
-        })}
-      </nav>
-
-      <div className="border-t border-sidebar-border p-2">
+      <div className="flex-none pt-2">
         <button
           onClick={handleLogout}
-          className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+          className="rounded-md px-1 py-1 text-left text-[12.5px] text-[var(--ink-3)] transition-colors hover:text-[var(--ink-1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-warm)]"
+          style={{ fontFamily: 'var(--font-body), Inter, system-ui, sans-serif' }}
         >
-          <LogOut className="h-4 w-4" />
           {t('logout')}
         </button>
       </div>

--- a/apps/web/src/components/layout/top-bar.tsx
+++ b/apps/web/src/components/layout/top-bar.tsx
@@ -1,17 +1,68 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
+import { LightboardSigil } from '@/components/brand';
+import { useUiStore } from '@/stores/ui-store';
+import { AgentPicker } from './agent-picker';
+import { IconButton } from './icon-button';
+import { NavItem } from './nav-item';
+import { UserAvatar } from './user-avatar';
 
 /**
- * Top bar component with page title and actions.
- * Renders instantly from static content — no loading states.
+ * Top-of-shell navigation bar.
+ *
+ * Layout: 56px tall, sticky, with a three-column CSS grid
+ * (`260px | 1fr | 260px`):
+ * - **Left**: hamburger that toggles the sidebar + sigil wordmark.
+ * - **Center**: primary nav (Dashboard, Explore, Views, Settings). "Data
+ *   Sources" deliberately lives in Explore's sidebar context now instead of
+ *   the top nav — see PR 4.
+ * - **Right**: model picker + user avatar pill.
+ *
+ * The prior `title` prop has been removed — per-route titles now live inside
+ * the main content area instead of competing with primary nav.
  */
-export function TopBar({ title }: { title?: string }) {
-  const t = useTranslations('common');
+export function TopBar() {
+  const t = useTranslations('topBar');
+  const toggleSidebar = useUiStore((s) => s.toggleSidebar);
 
   return (
-    <header className="flex h-14 items-center border-b border-border bg-background px-6">
-      <h1 className="text-lg font-semibold">{title ?? t('appName')}</h1>
+    <header
+      className="sticky top-0 z-20 flex-none grid h-14 items-center px-6"
+      style={{
+        gridTemplateColumns: '260px 1fr 260px',
+        background: 'var(--bg-2)',
+        borderBottom: '1px solid var(--line-1)',
+      }}
+    >
+      <div className="flex items-center gap-[14px]">
+        <IconButton
+          aria-label={t('toggleSidebar')}
+          onClick={toggleSidebar}
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+            <path
+              d="M1 3h12M1 7h12M1 11h12"
+              stroke="currentColor"
+              strokeWidth="1.3"
+              strokeLinecap="round"
+            />
+          </svg>
+        </IconButton>
+        <LightboardSigil size={18} />
+      </div>
+
+      <nav className="flex justify-center gap-1" aria-label={t('primaryNav')}>
+        <NavItem href="/" labelKey="dashboard" icon="dashboard" />
+        <NavItem href="/explore" labelKey="explore" icon="explore" />
+        <NavItem href="/views" labelKey="views" icon="views" />
+        <NavItem href="/settings" labelKey="settings" icon="settings" />
+      </nav>
+
+      <div className="flex items-center justify-end gap-[14px]">
+        <AgentPicker />
+        <UserAvatar />
+      </div>
     </header>
   );
 }

--- a/apps/web/src/components/layout/use-sidebar-shortcut.ts
+++ b/apps/web/src/components/layout/use-sidebar-shortcut.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useUiStore } from '@/stores/ui-store';
+
+/**
+ * Returns `true` when an input-like element currently owns keyboard focus —
+ * used to bail out of global shortcuts so typing a backslash inside the
+ * composer doesn't collapse the sidebar underneath the user.
+ */
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+/**
+ * Global shortcut hook: `Ctrl/Cmd + \` toggles the sidebar.
+ *
+ * Mounted once at the shell level (`AppShell`). Bails out while the user is
+ * focused inside an input / textarea / contenteditable so typing the key in
+ * a field works normally. Other shortcuts (e.g. the Explore `Cmd+K` focus
+ * for the DB picker) are untouched — this listener only handles the
+ * backslash combo and calls `preventDefault` so the browser doesn't treat
+ * it as a page action either.
+ */
+export function useSidebarShortcut() {
+  const toggleSidebar = useUiStore((s) => s.toggleSidebar);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      const isToggleCombo =
+        (event.ctrlKey || event.metaKey) &&
+        !event.altKey &&
+        !event.shiftKey &&
+        event.key === '\\';
+      if (!isToggleCombo) return;
+      if (isTypingTarget(event.target)) return;
+      event.preventDefault();
+      toggleSidebar();
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [toggleSidebar]);
+}

--- a/apps/web/src/components/layout/user-avatar.tsx
+++ b/apps/web/src/components/layout/user-avatar.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Shape returned by `GET /api/auth/me`. Kept local to the component — the
+ * server route returns a slightly broader user shape, but only these fields
+ * are rendered in the top bar.
+ */
+interface MeResponse {
+  user?: {
+    name?: string | null;
+    email?: string | null;
+  };
+}
+
+/**
+ * Pick the initial to display in the gradient dot. Prefers the first
+ * character of the user's name; falls back to the email local-part so
+ * name-less accounts still render a meaningful letter. Returns `"U"` as a
+ * last resort so the avatar is never empty.
+ */
+function deriveInitial(name?: string | null, email?: string | null): string {
+  const source = (name ?? '').trim() || (email ?? '').trim();
+  if (!source) return 'U';
+  return source[0]!.toUpperCase();
+}
+
+/**
+ * Pick the label displayed next to the gradient dot — username if we have
+ * one, otherwise the email local-part, otherwise a generic `"User"` so the
+ * chip still parses at a glance.
+ */
+function deriveLabel(name?: string | null, email?: string | null): string {
+  const trimmedName = (name ?? '').trim();
+  if (trimmedName) return trimmedName;
+  const trimmedEmail = (email ?? '').trim();
+  if (trimmedEmail) return trimmedEmail.split('@')[0] ?? trimmedEmail;
+  return 'User';
+}
+
+/**
+ * Right-column avatar chip in the top bar. Renders a gradient dot with the
+ * user's initial plus the username in small mono-free body text.
+ *
+ * Data source: `GET /api/auth/me` is fetched once on mount via plain
+ * `fetch` — the app doesn't wire `@tanstack/react-query` yet. TODO (PR 8):
+ * migrate to react-query so the avatar shares a cached user object with
+ * future settings/profile surfaces.
+ */
+export function UserAvatar() {
+  const [label, setLabel] = useState('User');
+  const [initial, setInitial] = useState('U');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch('/api/auth/me', { cache: 'no-store' });
+        if (!res.ok) return;
+        const data = (await res.json()) as MeResponse;
+        if (cancelled) return;
+        const name = data.user?.name ?? null;
+        const email = data.user?.email ?? null;
+        setLabel(deriveLabel(name, email));
+        setInitial(deriveInitial(name, email));
+      } catch {
+        // Swallow errors — the placeholder "User"/"U" stays on screen, which
+        // is the correct UX for an unauthenticated or offline state.
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="inline-flex items-center gap-[10px] rounded-full border border-[var(--line-1)] py-1 pl-1 pr-[10px]">
+      <div
+        aria-hidden="true"
+        className="flex h-6 w-6 items-center justify-center rounded-full"
+        style={{
+          background: 'linear-gradient(135deg, var(--accent-warm), #B08CA8)',
+          fontFamily: 'var(--font-mono), ui-monospace, monospace',
+          fontSize: 10,
+          fontWeight: 700,
+          color: 'var(--bg-0)',
+        }}
+      >
+        {initial}
+      </div>
+      <span className="text-[12px] text-[var(--ink-2)]">{label}</span>
+    </div>
+  );
+}
+
+// Re-exported for unit tests so we can assert the initial/label derivation
+// without spinning up a full `render` + mocked fetch.
+export const __testing = { deriveInitial, deriveLabel };

--- a/apps/web/src/stores/__tests__/ui-store.test.ts
+++ b/apps/web/src/stores/__tests__/ui-store.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useUiStore } from '../ui-store';
+
+describe('useUiStore', () => {
+  beforeEach(() => {
+    // Reset to the initial state before each test so prior toggles don't leak
+    // between cases. Zustand `create()` memoizes per-module, so the same
+    // store instance is reused across tests.
+    useUiStore.setState({ sidebarOpen: true });
+    window.localStorage.clear();
+  });
+
+  it('defaults sidebarOpen to true', () => {
+    expect(useUiStore.getState().sidebarOpen).toBe(true);
+  });
+
+  it('toggleSidebar flips sidebarOpen', () => {
+    const { toggleSidebar } = useUiStore.getState();
+
+    toggleSidebar();
+    expect(useUiStore.getState().sidebarOpen).toBe(false);
+
+    toggleSidebar();
+    expect(useUiStore.getState().sidebarOpen).toBe(true);
+  });
+
+  it('setSidebarOpen writes the value deterministically', () => {
+    const { setSidebarOpen } = useUiStore.getState();
+
+    setSidebarOpen(false);
+    expect(useUiStore.getState().sidebarOpen).toBe(false);
+
+    setSidebarOpen(false);
+    expect(useUiStore.getState().sidebarOpen).toBe(false);
+
+    setSidebarOpen(true);
+    expect(useUiStore.getState().sidebarOpen).toBe(true);
+  });
+
+  it("persists to localStorage under 'lb:ui'", () => {
+    // Toggle to dirty the state, then read localStorage through the key used
+    // by the persist middleware. Zustand stores a JSON envelope shaped like
+    // { state: {...}, version: 0 } — we assert the inner slice.
+    useUiStore.getState().setSidebarOpen(false);
+
+    const raw = window.localStorage.getItem('lb:ui');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.state.sidebarOpen).toBe(false);
+  });
+});

--- a/apps/web/src/stores/ui-store.ts
+++ b/apps/web/src/stores/ui-store.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+/**
+ * Shape of the persisted UI store. Kept deliberately small — only state that
+ * must survive reloads lives here. Per-route ephemeral UI state should stay
+ * in local component state.
+ */
+export interface UiState {
+  /**
+   * Whether the app-shell sidebar is expanded. Defaults to `true` so a
+   * first-time user sees the full layout on their initial visit. Toggled via
+   * the top-bar hamburger and the `Ctrl/Cmd + \` keyboard shortcut.
+   */
+  sidebarOpen: boolean;
+  /** Flip {@link UiState.sidebarOpen}. */
+  toggleSidebar: () => void;
+  /** Set {@link UiState.sidebarOpen} to an explicit value. */
+  setSidebarOpen: (open: boolean) => void;
+}
+
+/**
+ * Safe `localStorage` accessor that falls back to an in-memory no-op on the
+ * server. Zustand's `persist` middleware calls `getItem` during the initial
+ * module evaluation — on the Next.js server pass that throws unless we guard
+ * the access, which would crash SSR for every route using this store.
+ */
+const storage =
+  typeof window === 'undefined'
+    ? {
+        getItem: () => null,
+        setItem: () => undefined,
+        removeItem: () => undefined,
+      }
+    : window.localStorage;
+
+/**
+ * Zustand store backing the app-shell. `persist` hydrates from
+ * `localStorage['lb:ui']` on the client; during SSR and the initial client
+ * render the default `sidebarOpen: true` is used, so hydration never
+ * mismatches the server HTML.
+ */
+export const useUiStore = create<UiState>()(
+  persist(
+    (set) => ({
+      sidebarOpen: true,
+      toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
+      setSidebarOpen: (open: boolean) => set({ sidebarOpen: open }),
+    }),
+    {
+      name: 'lb:ui',
+      storage: createJSONStorage(() => storage),
+      // Only persist the `sidebarOpen` slice — actions are recreated per session.
+      partialize: (state) => ({ sidebarOpen: state.sidebarOpen }),
+    },
+  ),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.5.0
+      zustand:
+        specifier: ^5.0.12
+        version: 5.0.12(@types/react@19.2.14)(react@19.2.4)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.5
@@ -5152,6 +5155,24 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -10146,5 +10167,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.25.76: {}
+
+  zustand@5.0.12(@types/react@19.2.14)(react@19.2.4):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

Rebuilds the app shell to match the design handoff (PR 3 of the UI polish
sequence; plan at `C:\Users\anura\.claude\plans\snuggly-jingling-bonbon.md`).
The shell is now a sticky 56px three-column top bar over a collapsible 240px
sidebar with a per-route content slot.

## What changed

### New files
- `apps/web/src/stores/ui-store.ts` — Zustand `useUiStore` persisted to
  `localStorage['lb:ui']`, SSR-safe (defaults match server render).
- `apps/web/src/components/layout/icon-button.tsx` — 30x30 token-backed
  IconButton primitive.
- `apps/web/src/components/layout/nav-item.tsx` — centered top-bar nav
  entry with inline SVG glyph and absolutely-positioned accent-warm
  active underline. Exports `isNavItemActive` for testing.
- `apps/web/src/components/layout/agent-picker.tsx` — rounded-pill model
  picker placeholder (click is a no-op; TODO points at the backend
  follow-up doc).
- `apps/web/src/components/layout/user-avatar.tsx` — gradient-dot pill
  that fetches `/api/auth/me` once on mount (react-query deferred to PR 8).
- `apps/web/src/components/layout/use-sidebar-shortcut.ts` — global
  `Ctrl/Cmd+\` handler that ignores input-focused targets.
- Unit tests for ui-store, nav-item, and sidebar.

### Rewrites
- `top-bar.tsx`: 56px 3-col grid `260px 1fr 260px`, hamburger + sigil,
  centered nav (Dashboard / Explore / Views / Settings), agent-picker +
  user-avatar. No more `title` prop.
- `sidebar.tsx`: 240px slot container + Log out footer; collapses to 0px
  width over 280ms with `--ease-out-quint`.
- `app-shell.tsx`: new `sidebarSlot?` prop; mounts the shortcut hook;
  background/foreground/font set at the shell level.

### Other
- `messages/en.json`: removed `nav.dataSources`, added `nav.dashboard`
  and `topBar.{toggleSidebar,changeModel,primaryNav}`.
- `/dev/sigil` page: dropped the `-m-6` that compensated for the
  now-removed shell padding.

## Deliberate deferrals

- **Agent-picker wiring** — the pill renders Haiku 4.5 statically and
  the click is a no-op. Filed under `documentation/backend-ui-polish-followups.md#agent-picker-wiring`.
- **Username source** — UserAvatar uses plain `fetch` because the web
  app doesn't wire react-query yet. TODO points at PR 8.
- **Data Sources nav move** — deliberately not in top nav; PR 4 will
  expose it from inside Explore's sidebar context.
- **Sidebar content for Explore** (DB picker, conversations list, new
  conversation button) — PR 4.

## Test plan

- [x] `pnpm --filter @lightboard/web lint` clean (no ESLint warnings).
- [x] `pnpm typecheck` clean across the workspace.
- [x] `pnpm --filter @lightboard/web test` — 29 tests pass (7 suites:
  ui-store, nav-item, sidebar, existing brand/utils/data-source/sse-parser).
- [x] `pnpm test` across the workspace — 8/8 tasks successful.
- [x] `pnpm --filter @lightboard/web build` — 18 routes generate cleanly.
- [x] Browser smoke on each route (`/`, `/explore`, `/data-sources`,
  `/settings`, `/views`): centered nav + active underline, hamburger
  collapses sidebar fully, `Ctrl/Cmd+\` toggles sidebar, sigil present
  in top bar.
- [x] `/login`, `/register` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)