### PR TITLE
feat(ui): PR 7 — suggestion chips with mock fixture per chart kind

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -67,7 +67,8 @@
     "filmstripEmpty": "No visualizations yet. Send a prompt to get started.",
     "filmstripClose": "Close filmstrip",
     "filmstripOpen": "Open filmstrip",
-    "filmstripPinned": "pinned"
+    "filmstripPinned": "pinned",
+    "suggestionsLabel": "Follow-up suggestions"
   },
   "dataSources": {
     "title": "Data Sources",

--- a/apps/web/src/components/explore/__tests__/suggestion-chips.test.tsx
+++ b/apps/web/src/components/explore/__tests__/suggestion-chips.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { SuggestionChips } from '../suggestion-chips';
+
+// Mirror the dict-stub pattern used by thread.test.tsx — resolve the i18n
+// key to real English copy so assertions can target literal text (and the
+// sr-only label actually reads the right string).
+vi.mock('next-intl', () => ({
+  useTranslations: () => {
+    const dict: Record<string, string> = {
+      suggestionsLabel: 'Follow-up suggestions',
+    };
+    return (key: string) => dict[key] ?? key;
+  },
+}));
+
+describe('<SuggestionChips>', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders one button per item', () => {
+    const { queryAllByRole } = render(
+      <SuggestionChips
+        items={['Alpha', 'Bravo', 'Charlie']}
+        onSelect={() => {}}
+      />,
+    );
+    const buttons = queryAllByRole('button');
+    expect(buttons.length).toBe(3);
+    expect(buttons.map((b) => b.textContent)).toEqual([
+      'Alpha',
+      'Bravo',
+      'Charlie',
+    ]);
+  });
+
+  it('renders nothing when items is empty (avoids a 20px phantom gap)', () => {
+    const { container } = render(
+      <SuggestionChips items={[]} onSelect={() => {}} />,
+    );
+    // Component returns null, so the wrapper fragment has no children.
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('calls onSelect with the clicked chip label', () => {
+    const onSelect = vi.fn();
+    const { queryAllByRole } = render(
+      <SuggestionChips items={['Alpha', 'Bravo']} onSelect={onSelect} />,
+    );
+    const buttons = queryAllByRole('button');
+    fireEvent.click(buttons[1]!);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('Bravo');
+  });
+
+  it('emits the eyebrow label via an sr-only span so screen readers announce the group', () => {
+    const { getByText, container } = render(
+      <SuggestionChips items={['Alpha']} onSelect={() => {}} />,
+    );
+    const label = getByText('Follow-up suggestions');
+    expect(label.tagName.toLowerCase()).toBe('span');
+    expect(label.className).toContain('sr-only');
+    // The group is labelled by the eyebrow (aria-labelledby -> eyebrow id).
+    const group = container.querySelector('[data-suggestion-chips]');
+    expect(group?.getAttribute('aria-labelledby')).toBe(label.id);
+  });
+
+  it('renders real <button type="button"> elements so keyboard nav works for free', () => {
+    const { queryAllByRole } = render(
+      <SuggestionChips items={['A', 'B', 'C']} onSelect={() => {}} />,
+    );
+    const buttons = queryAllByRole('button');
+    for (const btn of buttons) {
+      expect(btn.tagName.toLowerCase()).toBe('button');
+      expect(btn.getAttribute('type')).toBe('button');
+    }
+
+    // Chips aren't inside a nested focus trap — each one is focusable in
+    // source order, which is what Tab would traverse. JSDOM doesn't simulate
+    // a real Tab-key walk, but focusing the first and the last button
+    // directly confirms both ends of the group are reachable.
+    buttons[0]!.focus();
+    expect(document.activeElement).toBe(buttons[0]);
+    buttons[buttons.length - 1]!.focus();
+    expect(document.activeElement).toBe(buttons[buttons.length - 1]);
+  });
+});

--- a/apps/web/src/components/explore/__tests__/suggestions-fixture.test.ts
+++ b/apps/web/src/components/explore/__tests__/suggestions-fixture.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { buildSuggestionsForView, __testing } from '../suggestions-fixture';
+import type { HtmlView } from '@/components/view-renderer';
+import type { ViewSpec } from '@lightboard/viz-core';
+
+function htmlView(html: string, title = 'Seed view'): HtmlView {
+  return { title, sql: 'SELECT 1', html };
+}
+
+function viewSpec(panelType: string): ViewSpec {
+  return {
+    query: {
+      source: 's1',
+      table: 't1',
+      select: [],
+      aggregations: [],
+      groupBy: [],
+      orderBy: [],
+      joins: [],
+    },
+    chart: { type: panelType, config: {} },
+    controls: [],
+  };
+}
+
+describe('buildSuggestionsForView', () => {
+  const { FIXTURES, DEFAULT_FIXTURE } = __testing;
+
+  it('returns the bar fixture for bar-kind views', () => {
+    const out = buildSuggestionsForView(
+      htmlView(`new Chart(ctx, { type: 'bar', data: [] })`),
+    );
+    expect(out).toEqual(FIXTURES.bar);
+  });
+
+  it('returns the scatter fixture for scatter-kind views (including bubble)', () => {
+    const scatter = buildSuggestionsForView(
+      htmlView(`new Chart(ctx, { type: 'scatter' })`),
+    );
+    expect(scatter).toEqual(FIXTURES.scatter);
+
+    const bubble = buildSuggestionsForView(
+      htmlView(`new Chart(ctx, { type: 'bubble' })`),
+    );
+    expect(bubble).toEqual(FIXTURES.scatter);
+  });
+
+  it('returns the line fixture for line-kind views', () => {
+    const htmlOut = buildSuggestionsForView(
+      htmlView(`new Chart(ctx, { type: 'line' })`),
+    );
+    expect(htmlOut).toEqual(FIXTURES.line);
+
+    const specOut = buildSuggestionsForView(viewSpec('time-series-line'));
+    expect(specOut).toEqual(FIXTURES.line);
+  });
+
+  it('returns the hist fixture for histogram-kind views', () => {
+    const out = buildSuggestionsForView(
+      htmlView(`// histogram of strike rates per batter`),
+    );
+    expect(out).toEqual(FIXTURES.hist);
+  });
+
+  it('falls back to the default fixture when no chart kind is detectable', () => {
+    // `detectKind` returns 'bar' as a fallback for HtmlView with no chart
+    // markers, so to test the explicit default-fixture branch we drop the
+    // fixture map entry via a mocked kind — not needed here because the
+    // current `detectKind` never returns a value outside the FIXTURES keys.
+    // Instead, assert that the fallback CONSTANT itself is the expected one.
+    expect(DEFAULT_FIXTURE).toEqual([
+      'Refine the filter',
+      'Break down further',
+      'Switch chart type',
+      'Drill into a row',
+    ]);
+  });
+
+  it('returns a fresh array each call (no shared mutable reference)', () => {
+    const a = buildSuggestionsForView(
+      htmlView(`new Chart(ctx, { type: 'bar' })`),
+    );
+    const b = buildSuggestionsForView(
+      htmlView(`new Chart(ctx, { type: 'bar' })`),
+    );
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b);
+    // Mutating `a` must not affect `b` or the shared fixture.
+    a.push('Should not leak');
+    expect(b).not.toContain('Should not leak');
+    expect(FIXTURES.bar).not.toContain('Should not leak');
+  });
+});

--- a/apps/web/src/components/explore/explore-page-client.tsx
+++ b/apps/web/src/components/explore/explore-page-client.tsx
@@ -37,6 +37,7 @@ import { Composer } from './composer';
 import { FilmstripButton } from './filmstrip-button';
 import { FilmstripPanel, type FilmstripItem } from './filmstrip-panel';
 import { createReducer, parseSSEJson, type Reducer } from './sse-reducer';
+import { buildSuggestionsForView } from './suggestions-fixture';
 import type { DataSourceOption } from './types';
 import { ExploreSidebar } from './sidebar/explore-sidebar';
 import { Thread } from './thread';
@@ -102,6 +103,43 @@ export function ExplorePageClient() {
       }
     }
     return out;
+  }, [messages]);
+
+  /**
+   * TODO(backend-suggestions): Replace this with an SSE `suggestions` event
+   * so the agent can supply dimension/measure-aware follow-ups. For PR 7 we
+   * backfill the suggestions part from a hardcoded fixture keyed off the
+   * first view's chart kind so the UI surface ships without a backend
+   * dependency. See `suggestions-fixture.ts` for the deletion trigger.
+   *
+   * Trigger conditions:
+   *   1. The message is a completed assistant turn (not `isStreaming`).
+   *   2. It carries at least one `{ kind: 'view' }` part — chips are a
+   *      visual follow-up for chart turns, not for tool-only or pure-text
+   *      replies.
+   *   3. It does not already have a `{ kind: 'suggestions' }` part — keeps
+   *      the effect idempotent across re-renders and avoids appending
+   *      duplicates when other parts of `messages` change.
+   */
+  useEffect(() => {
+    setMessages((prev) => {
+      let changed = false;
+      const next = prev.map((m) => {
+        if (m.role !== 'assistant' || m.isStreaming) return m;
+        const viewPart = m.parts.find((p) => p.kind === 'view');
+        if (!viewPart || viewPart.kind !== 'view') return m;
+        const hasSuggestions = m.parts.some((p) => p.kind === 'suggestions');
+        if (hasSuggestions) return m;
+        const items = buildSuggestionsForView(viewPart.view);
+        if (items.length === 0) return m;
+        changed = true;
+        return {
+          ...m,
+          parts: [...m.parts, { kind: 'suggestions' as const, items }],
+        };
+      });
+      return changed ? next : prev;
+    });
   }, [messages]);
 
   /**
@@ -713,6 +751,7 @@ export function ExplorePageClient() {
           onSchemaMarkdownChange={(md) =>
             setSchemaCuration((prev) => (prev ? { ...prev, markdown: md } : null))
           }
+          onSuggestionClick={handleSend}
         />
 
         {/*

--- a/apps/web/src/components/explore/suggestion-chips.tsx
+++ b/apps/web/src/components/explore/suggestion-chips.tsx
@@ -1,51 +1,117 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
+
 /**
  * Props for {@link SuggestionChips}.
  */
 interface SuggestionChipsProps {
-  /** Chip labels; clicking a chip invokes {@link SuggestionChipsProps.onClick}. */
+  /** Chip labels; clicking a chip invokes {@link SuggestionChipsProps.onSelect}. */
   items: string[];
   /** Called with the clicked chip's label text. */
-  onClick: (text: string) => void;
+  onSelect: (text: string) => void;
 }
 
 /**
- * Horizontal follow-up suggestion chips rendered at the end of an assistant
- * turn. Currently ships as a hardcoded no-op (the `items` array is always
- * empty in this PR); PR 7 wires real suggestions from the agent pipeline.
+ * Horizontal row of follow-up suggestion chips rendered at the end of an
+ * assistant turn. Each chip is a real `<button type="button">` so keyboard
+ * navigation (Tab between chips, Enter/Space to activate) works without any
+ * extra handling. The container is labelled via `aria-labelledby` pointing at
+ * an sr-only eyebrow — screen readers announce "Follow-up suggestions" when
+ * the user first lands inside the group.
  *
- * Returns `null` when `items` is empty so empty turns don't leave a blank
- * 20px gap below the last message.
+ * Visual treatment mirrors the editorial handoff
+ * (`Lightboard-handoff/project/components/Thread.jsx#Suggestion`):
+ *   - Pill shape (`border-radius: 999px`).
+ *   - Idle: `--bg-4` background, `--line-3` border, `--ink-2` text.
+ *   - Hover: `--bg-6` background, `--ink-1` text.
+ *   - Focus-visible: accent background + border so keyboard users see a
+ *     clear ring that doesn't depend on the hover state.
+ *
+ * Empty-items guard: renders `null` so an assistant turn with no suggestions
+ * doesn't leave a blank 20px gap below the last block.
  */
-export function SuggestionChips({ items, onClick }: SuggestionChipsProps) {
+export function SuggestionChips({ items, onSelect }: SuggestionChipsProps) {
+  const t = useTranslations('explore');
+
   if (items.length === 0) return null;
 
   return (
-    <div className="flex flex-wrap gap-2 pl-[40px]">
+    <div
+      role="group"
+      aria-labelledby="suggestion-chips-label"
+      data-suggestion-chips
+      className="flex flex-wrap gap-2 pl-[40px]"
+    >
+      {/* Visually hidden eyebrow so screen readers announce the group purpose.
+          The handoff design renders no visible label — the chips are their
+          own call-to-action. */}
+      <span id="suggestion-chips-label" className="sr-only">
+        {t('suggestionsLabel')}
+      </span>
       {items.map((text) => (
-        <button
-          key={text}
-          type="button"
-          onClick={() => onClick(text)}
-          className="rounded-full px-3 py-[7px] text-[12px] transition-colors"
-          style={{
-            background: 'var(--bg-3)',
-            border: '1px solid var(--line-3)',
-            color: 'var(--ink-2)',
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.background = 'var(--bg-6)';
-            e.currentTarget.style.color = 'var(--ink-1)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.background = 'var(--bg-3)';
-            e.currentTarget.style.color = 'var(--ink-2)';
-          }}
-        >
-          {text}
-        </button>
+        <SuggestionChip key={text} label={text} onSelect={onSelect} />
       ))}
     </div>
+  );
+}
+
+/**
+ * A single pill-shaped suggestion button. Factored out so the hover/focus
+ * inline styles can own their own React state without leaking it into the
+ * parent map. Hover is driven by an `onMouseEnter`/`onMouseLeave` class swap
+ * because Tailwind v4 doesn't scan `packages/` by default and the project
+ * convention for theme-dependent colors is to use inline `var()` references.
+ */
+function SuggestionChip({
+  label,
+  onSelect,
+}: {
+  label: string;
+  onSelect: (text: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      data-suggestion-chip
+      onClick={() => onSelect(label)}
+      className="rounded-full px-3 py-[7px] text-[12px] transition-colors focus:outline-none focus-visible:ring-2"
+      style={{
+        background: 'var(--bg-4)',
+        border: '1px solid var(--line-3)',
+        color: 'var(--ink-2)',
+        // Focus ring color — overridden via inline outline on focus-visible
+        // below so we don't ship a token-less Tailwind ring color.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- CSS custom property on style object
+        ['--tw-ring-color' as any]: 'var(--accent-border, #F2C265)',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.background = 'var(--bg-6)';
+        e.currentTarget.style.color = 'var(--ink-1)';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = 'var(--bg-4)';
+        e.currentTarget.style.color = 'var(--ink-2)';
+      }}
+      onFocus={(e) => {
+        // Keyboard focus: swap to the accent tokens so the indicator is
+        // visible without depending on hover state. Guarded behind
+        // `matches(':focus-visible')` so we only light up for keyboard
+        // users — a click on the chip would otherwise briefly flash
+        // accent colors before the click handler resolves.
+        if (e.currentTarget.matches(':focus-visible')) {
+          e.currentTarget.style.background = 'var(--accent-bg, var(--bg-6))';
+          e.currentTarget.style.borderColor = 'var(--accent-border, var(--line-3))';
+          e.currentTarget.style.color = 'var(--ink-1)';
+        }
+      }}
+      onBlur={(e) => {
+        e.currentTarget.style.background = 'var(--bg-4)';
+        e.currentTarget.style.borderColor = 'var(--line-3)';
+        e.currentTarget.style.color = 'var(--ink-2)';
+      }}
+    >
+      {label}
+    </button>
   );
 }

--- a/apps/web/src/components/explore/suggestions-fixture.ts
+++ b/apps/web/src/components/explore/suggestions-fixture.ts
@@ -1,0 +1,75 @@
+import type { ViewSpec } from '@lightboard/viz-core';
+import type { HtmlView } from '@/components/view-renderer';
+import { __testing as thumbnailTesting } from './procedural-thumbnail';
+
+/**
+ * TODO(backend-suggestions): Delete this file once the backend emits a real
+ * SSE `suggestions` event. See `documentation/backend-ui-polish-followups.md`
+ * §2 for the event shape and the call-site in `explore-page-client.tsx` that
+ * currently invokes this helper.
+ *
+ * Rationale for a hardcoded fixture: PR 7's scope is the UI surface for
+ * follow-up suggestions. Real dimension/measure-aware suggestions require
+ * reading into the view's SQL + result shape, which is the backend ticket's
+ * responsibility. Shipping a fixture keyed off the chart kind lets the UI
+ * ship its visual polish + click-through behaviour without blocking on the
+ * backend.
+ */
+
+const FIXTURES = {
+  bar: [
+    'Flip to batters who exceeded model',
+    'Break down by phase of innings',
+    'Filter to 2020 onwards',
+    'Switch to scatter vs xRuns',
+  ],
+  scatter: [
+    'Switch to bubble sized by sample size',
+    'Highlight top quartile',
+    'Add regression line',
+    'Filter to qualifiers only',
+  ],
+  line: [
+    'Zoom to last 3 seasons',
+    'Compare vs league average',
+    'Break down by venue',
+    'Switch to cumulative view',
+  ],
+  hist: [
+    'Bucket at 5 instead of 10',
+    'Split by role',
+    'Overlay expected distribution',
+    'Filter tails above 95th percentile',
+  ],
+} as const;
+
+const DEFAULT_FIXTURE = [
+  'Refine the filter',
+  'Break down further',
+  'Switch chart type',
+  'Drill into a row',
+];
+
+/**
+ * Build a hardcoded list of follow-up chip labels for a given view, keyed off
+ * the detected chart kind. See the TODO at the top of this file for the
+ * deletion trigger.
+ *
+ * Returns a defensive copy each call so callers that mutate the array (for
+ * example to append an agent-provided extra) don't poison the shared
+ * fixture constant.
+ */
+export function buildSuggestionsForView(view: HtmlView | ViewSpec): string[] {
+  const kind = thumbnailTesting.detectKind(view);
+  const fixture = FIXTURES[kind] ?? DEFAULT_FIXTURE;
+  return [...fixture];
+}
+
+/**
+ * Exposed for tests that want to assert on the raw fixture maps without
+ * having to construct an `HtmlView`/`ViewSpec` first.
+ */
+export const __testing = {
+  FIXTURES,
+  DEFAULT_FIXTURE,
+};

--- a/apps/web/src/components/explore/thread.tsx
+++ b/apps/web/src/components/explore/thread.tsx
@@ -70,6 +70,14 @@ interface ThreadProps {
   onSaveSchema?: (markdown: string) => void;
   onCancelSchema?: () => void;
   onSchemaMarkdownChange?: (markdown: string) => void;
+  /**
+   * Invoked when the user clicks a follow-up suggestion chip on any turn.
+   * Receives the chip's label text, which the page client sends through
+   * as the next user prompt. Optional so the Thread still renders in
+   * contexts (tests, future preview surfaces) that don't need chip
+   * click-through behavior.
+   */
+  onSuggestionClick?: (text: string) => void;
 }
 
 /**
@@ -98,6 +106,7 @@ export function Thread({
   onSaveSchema,
   onCancelSchema,
   onSchemaMarkdownChange,
+  onSuggestionClick,
 }: ThreadProps) {
   const t = useTranslations('explore');
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -161,8 +170,13 @@ export function Thread({
                 key={turn.user.id ?? `turn-${i}`}
                 userMessage={turn.user}
                 assistantMessage={turn.assistant}
-                // Suggestions stay empty in PR 4 — PR 7 populates them.
+                // Suggestions come from `assistantMessage.parts` (the
+                // `{ kind: 'suggestions' }` part the page client backfills
+                // once the turn has produced at least one view). The
+                // explicit prop here stays empty — Turn prefers the parts
+                // path whenever it finds one.
                 suggestions={[]}
+                onSuggestionClick={onSuggestionClick}
               />
             ))}
           </div>

--- a/apps/web/src/components/explore/turn.tsx
+++ b/apps/web/src/components/explore/turn.tsx
@@ -69,7 +69,7 @@ export function Turn({
       )}
 
       {allSuggestions.length > 0 && onSuggestionClick && (
-        <SuggestionChips items={allSuggestions} onClick={onSuggestionClick} />
+        <SuggestionChips items={allSuggestions} onSelect={onSuggestionClick} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Rewrites `SuggestionChips` to match the handoff: rounded-full pill buttons with `--bg-4`/`--line-3` idle, `--bg-6` hover, accent tokens on `:focus-visible`, and a visually hidden `aria-labelledby` eyebrow driven by `explore.suggestionsLabel`. Each chip is a real `<button type="button">` so keyboard nav works for free. The prop name is `onSelect` (matches the editorial handoff).
- Wires chips into every assistant turn that produced a chart under the **PR 5 `parts[]` message model**. The mock fixture lives in `suggestions-fixture.ts` keyed off the chart kind (via the existing `detectKind` helper): bar/scatter/line/hist each get a 4-item list from the handoff copy, with a generic default fallback. A `useEffect` in `ExplorePageClient` scans `messages[]` and appends a `{ kind: 'suggestions', items }` part to any completed assistant message that has at least one `{ kind: 'view' }` part and no existing suggestions part — idempotent, so re-renders never append duplicates. Chip clicks dispatch straight into `handleSend(text)`.
- Ships behind a prominent `TODO(backend-suggestions)` at every touchpoint that links to `documentation/backend-ui-polish-followups.md` §2. **When the backend emits real `suggestions` SSE events, delete the fixture file, the `useEffect` in `explore-page-client.tsx`, and the TODO comments** — the `SuggestionChips` component itself stays as-is.

## Rebased onto parts[] model
Previously this branch added `suggestions?: string[]` as a flat field on `ChatMessageData` because the parts[] union wasn't on main yet. PR 5 redux (#90) has since landed on main with the `{ kind: 'suggestions'; items: string[] }` variant already in the union, so this branch was rebased onto current main and rewired to push a `suggestions` part into `parts[]` instead of a parallel flat field. `AssistantStream` already skips the `suggestions` kind; `Turn` extracts the part and renders `SuggestionChips` as the terminal element of the turn.

## Test plan
- [x] `pnpm --filter @lightboard/web typecheck` — clean
- [x] `pnpm typecheck` (full workspace, 9 packages) — clean
- [x] `pnpm --filter @lightboard/web lint` — no warnings/errors
- [x] `pnpm --filter @lightboard/web test` — 109 passing (16 test files): PR 5 redux base of 98 + 5 `suggestion-chips.test.tsx` + 6 `suggestions-fixture.test.ts`
- [x] Browser-verified end-to-end on `localhost:3000`:
  - Bar-chart turn renders the bar fixture ("Flip to batters who exceeded model", "Break down by phase of innings", "Filter to 2020 onwards", "Switch to scatter vs xRuns") at the end of the turn, below the takeaways paragraph.
  - Clicking "Filter to 2020 onwards" submits it as a new user turn.
  - Tab focus lands on chips; Enter on the focused chip dispatches `handleSend` with the chip label.
  - Turn with no view part renders zero chips (verified on the errored follow-up turn).
  - Filmstrip slide-out still opens and lists the 1 chart card — no regression from the parts[]-based filmstrip lookup added in PR 5.
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)