### PR TITLE
feat(ui): PR 8 — token propagation sweep across auth, dashboard, and shared UI

### DIFF
--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -8,7 +8,7 @@ export default async function AuthLayout({ children }: { children: React.ReactNo
 
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>
-      <div className="flex min-h-screen items-center justify-center" style={{ backgroundColor: 'var(--color-muted)' }}>
+      <div className="flex min-h-screen items-center justify-center bg-background">
         {children}
       </div>
     </NextIntlClientProvider>

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslations } from 'next-intl';
 import { Link } from 'next-view-transitions';
 import { useState } from 'react';
+import { LightboardSigil } from '@/components/brand/lightboard-sigil';
 
 /** Props for the LoginForm component. */
 interface LoginFormProps {
@@ -40,13 +41,16 @@ export function LoginForm({ onSubmit, error }: LoginFormProps) {
 
   return (
     <Card className="w-full max-w-md">
-      <CardHeader>
+      <CardHeader className="items-center text-center">
+        <div className="mb-4 flex justify-center">
+          <LightboardSigil size={22} />
+        </div>
         <CardTitle>{t('login')}</CardTitle>
         <CardDescription>{t('loginDescription')}</CardDescription>
       </CardHeader>
       <form onSubmit={handleSubmit}>
         <CardContent className="space-y-4">
-          {error && <p className="text-sm" style={{ color: 'var(--color-destructive)' }}>{error}</p>}
+          {error && <p className="text-sm text-destructive">{error}</p>}
           <div className="space-y-2">
             <Label htmlFor="email">{t('email')}</Label>
             <Input
@@ -72,9 +76,9 @@ export function LoginForm({ onSubmit, error }: LoginFormProps) {
           <Button type="submit" className="w-full" disabled={loading}>
             {loading ? '...' : t('login')}
           </Button>
-          <p className="text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
+          <p className="text-sm text-muted-foreground">
             {t('loginPrompt')}{' '}
-            <Link href="/register" className="underline" style={{ color: 'var(--color-foreground)' }}>
+            <Link href="/register" className="text-foreground underline">
               {t('register')}
             </Link>
           </p>

--- a/apps/web/src/components/auth/register-form.tsx
+++ b/apps/web/src/components/auth/register-form.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslations } from 'next-intl';
 import { Link } from 'next-view-transitions';
 import { useState } from 'react';
+import { LightboardSigil } from '@/components/brand/lightboard-sigil';
 
 /** Props for the RegisterForm component. */
 interface RegisterFormProps {
@@ -42,13 +43,16 @@ export function RegisterForm({ onSubmit, error }: RegisterFormProps) {
 
   return (
     <Card className="w-full max-w-md">
-      <CardHeader>
+      <CardHeader className="items-center text-center">
+        <div className="mb-4 flex justify-center">
+          <LightboardSigil size={22} />
+        </div>
         <CardTitle>{t('register')}</CardTitle>
         <CardDescription>{t('registerDescription')}</CardDescription>
       </CardHeader>
       <form onSubmit={handleSubmit}>
         <CardContent className="space-y-4">
-          {error && <p className="text-sm" style={{ color: 'var(--color-destructive)' }}>{error}</p>}
+          {error && <p className="text-sm text-destructive">{error}</p>}
           <div className="space-y-2">
             <Label htmlFor="orgName">{t('orgName')}</Label>
             <Input
@@ -93,9 +97,9 @@ export function RegisterForm({ onSubmit, error }: RegisterFormProps) {
           <Button type="submit" className="w-full" disabled={loading}>
             {loading ? '...' : t('register')}
           </Button>
-          <p className="text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
+          <p className="text-sm text-muted-foreground">
             {t('registerPrompt')}{' '}
-            <Link href="/login" className="underline" style={{ color: 'var(--color-foreground)' }}>
+            <Link href="/login" className="text-foreground underline">
               {t('login')}
             </Link>
           </p>

--- a/apps/web/src/components/data-sources/add-data-source-form.tsx
+++ b/apps/web/src/components/data-sources/add-data-source-form.tsx
@@ -79,14 +79,7 @@ export function AddDataSourceForm({ onSave, onCancel, onTestConnection }: AddDat
             id="ds-type"
             value={type}
             onChange={(e) => setType(e.target.value)}
-            className="flex h-10 w-full rounded-md px-3 py-2 text-sm"
-            style={{
-              borderWidth: '1px',
-              borderStyle: 'solid',
-              borderColor: 'var(--color-input)',
-              backgroundColor: 'transparent',
-              color: 'var(--color-foreground)',
-            }}
+            className="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm text-foreground"
           >
             {CONNECTOR_TYPES.map((ct) => (
               <option key={ct.value} value={ct.value}>{ct.label}</option>
@@ -125,8 +118,12 @@ export function AddDataSourceForm({ onSave, onCancel, onTestConnection }: AddDat
           <div
             className="rounded-md p-3 text-sm"
             style={{
-              backgroundColor: testResult.success ? 'rgba(34,197,94,0.1)' : 'rgba(239,68,68,0.1)',
-              color: testResult.success ? '#22c55e' : '#ef4444',
+              // Tint the feedback with the matching semantic token so success
+              // reads as the warm-green narrate kind and failure as destructive.
+              backgroundColor: testResult.success
+                ? 'color-mix(in oklab, var(--kind-narrate) 14%, transparent)'
+                : 'color-mix(in oklab, var(--color-destructive) 14%, transparent)',
+              color: testResult.success ? 'var(--kind-narrate)' : 'var(--color-destructive)',
             }}
           >
             {testResult.success ? t('connected') : t('disconnected')}: {testResult.message}
@@ -136,8 +133,7 @@ export function AddDataSourceForm({ onSave, onCancel, onTestConnection }: AddDat
       <CardFooter className="flex justify-between">
         <button
           onClick={onCancel}
-          className="rounded-md px-4 py-2 text-sm"
-          style={{ borderWidth: '1px', borderStyle: 'solid', borderColor: 'var(--color-border)', color: 'var(--color-muted-foreground)' }}
+          className="rounded-md border border-border px-4 py-2 text-sm text-muted-foreground"
         >
           {t('cancel')}
         </button>
@@ -145,8 +141,7 @@ export function AddDataSourceForm({ onSave, onCancel, onTestConnection }: AddDat
           <button
             onClick={handleTest}
             disabled={testing || !host || !database}
-            className="rounded-md px-4 py-2 text-sm font-medium disabled:opacity-50"
-            style={{ borderWidth: '1px', borderStyle: 'solid', borderColor: 'var(--color-border)', color: 'var(--color-foreground)' }}
+            className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground disabled:opacity-50"
           >
             {testing ? '...' : t('testConnection')}
           </button>

--- a/apps/web/src/components/data-sources/data-source-list.tsx
+++ b/apps/web/src/components/data-sources/data-source-list.tsx
@@ -21,6 +21,22 @@ interface DataSourceListProps {
   onBrowseSchema: (id: string) => void;
 }
 
+/**
+ * Map a health status to a token-backed CSS color string.
+ * healthy -> --kind-narrate (warm green), unhealthy -> --color-destructive,
+ * unknown -> --ink-5 (muted).
+ */
+function statusDotColor(status: DataSourceRecord['status']): string {
+  switch (status) {
+    case 'healthy':
+      return 'var(--kind-narrate)';
+    case 'unhealthy':
+      return 'var(--color-destructive)';
+    default:
+      return 'var(--ink-5)';
+  }
+}
+
 /** List of configured data sources with health status indicators. */
 export function DataSourceList({ sources, onAdd, onEdit, onDelete, onBrowseSchema }: DataSourceListProps) {
   const t = useTranslations('dataSources');
@@ -28,14 +44,11 @@ export function DataSourceList({ sources, onAdd, onEdit, onDelete, onBrowseSchem
 
   return (
     <div className="p-6">
-      <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-semibold" style={{ color: 'var(--color-foreground)' }}>
-          {t('title')}
-        </h2>
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-foreground">{t('title')}</h2>
         <button
           onClick={onAdd}
-          className="rounded-md px-4 py-2 text-sm font-medium"
-          style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-primary-foreground)' }}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
         >
           {t('addNew')}
         </button>
@@ -43,55 +56,37 @@ export function DataSourceList({ sources, onAdd, onEdit, onDelete, onBrowseSchem
 
       {sources.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16">
-          <p className="text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
-            {t('emptyState')}
-          </p>
+          <p className="text-sm text-muted-foreground">{t('emptyState')}</p>
         </div>
       ) : (
         <div className="space-y-2">
           {sources.map((source) => (
             <div
               key={source.id}
-              className="flex items-center justify-between rounded-lg p-4"
-              style={{
-                borderWidth: '1px',
-                borderStyle: 'solid',
-                borderColor: 'var(--color-border)',
-                backgroundColor: 'var(--color-card)',
-              }}
+              className="flex items-center justify-between rounded-lg border border-border bg-card p-4"
             >
               <div className="flex items-center gap-3">
-                {/* Health status dot */}
+                {/* Health status dot — semantic tokens, not raw hex. */}
                 <span
                   className="h-2.5 w-2.5 rounded-full"
-                  style={{
-                    backgroundColor:
-                      source.status === 'healthy' ? '#22c55e' :
-                      source.status === 'unhealthy' ? '#ef4444' : '#6b7280',
-                  }}
+                  style={{ backgroundColor: statusDotColor(source.status) }}
                 />
                 <div>
-                  <p className="font-medium text-sm" style={{ color: 'var(--color-foreground)' }}>
-                    {source.name}
-                  </p>
-                  <p className="text-xs" style={{ color: 'var(--color-muted-foreground)' }}>
-                    {source.type}
-                  </p>
+                  <p className="text-sm font-medium text-foreground">{source.name}</p>
+                  <p className="text-xs text-muted-foreground">{source.type}</p>
                 </div>
               </div>
 
               <div className="flex items-center gap-2">
                 <button
                   onClick={() => onBrowseSchema(source.id)}
-                  className="rounded px-3 py-1 text-xs"
-                  style={{ borderWidth: '1px', borderStyle: 'solid', borderColor: 'var(--color-border)', color: 'var(--color-muted-foreground)' }}
+                  className="rounded border border-border px-3 py-1 text-xs text-muted-foreground"
                 >
                   {t('browseSchema')}
                 </button>
                 <button
                   onClick={() => onEdit(source.id)}
-                  className="rounded px-3 py-1 text-xs"
-                  style={{ borderWidth: '1px', borderStyle: 'solid', borderColor: 'var(--color-border)', color: 'var(--color-muted-foreground)' }}
+                  className="rounded border border-border px-3 py-1 text-xs text-muted-foreground"
                 >
                   {t('edit')}
                 </button>
@@ -99,15 +94,13 @@ export function DataSourceList({ sources, onAdd, onEdit, onDelete, onBrowseSchem
                   <div className="flex gap-1">
                     <button
                       onClick={() => { onDelete(source.id); setDeleteConfirm(null); }}
-                      className="rounded px-3 py-1 text-xs"
-                      style={{ backgroundColor: 'var(--color-destructive)', color: 'var(--color-destructive-foreground)' }}
+                      className="rounded bg-destructive px-3 py-1 text-xs text-destructive-foreground"
                     >
                       {t('confirmDelete')}
                     </button>
                     <button
                       onClick={() => setDeleteConfirm(null)}
-                      className="rounded px-3 py-1 text-xs"
-                      style={{ borderWidth: '1px', borderStyle: 'solid', borderColor: 'var(--color-border)', color: 'var(--color-muted-foreground)' }}
+                      className="rounded border border-border px-3 py-1 text-xs text-muted-foreground"
                     >
                       {t('cancel')}
                     </button>
@@ -115,8 +108,7 @@ export function DataSourceList({ sources, onAdd, onEdit, onDelete, onBrowseSchem
                 ) : (
                   <button
                     onClick={() => setDeleteConfirm(source.id)}
-                    className="rounded px-3 py-1 text-xs"
-                    style={{ color: 'var(--color-destructive)' }}
+                    className="rounded px-3 py-1 text-xs text-destructive"
                   >
                     {t('delete')}
                   </button>

--- a/apps/web/src/components/data-sources/data-sources-page-client.tsx
+++ b/apps/web/src/components/data-sources/data-sources-page-client.tsx
@@ -117,7 +117,7 @@ export function DataSourcesPageClient() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
-        <p className="text-sm" style={{ color: 'var(--color-muted-foreground)' }}>Loading...</p>
+        <p className="text-sm text-muted-foreground">Loading...</p>
       </div>
     );
   }

--- a/apps/web/src/components/data-sources/schema-browser.tsx
+++ b/apps/web/src/components/data-sources/schema-browser.tsx
@@ -42,25 +42,24 @@ export function SchemaBrowser({ tables, onClose, sourceName, loading }: SchemaBr
 
   return (
     <div className="p-6">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold" style={{ color: 'var(--color-foreground)' }}>
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-foreground">
           {t('schemaOf', { name: sourceName })}
         </h3>
         <button
           onClick={onClose}
-          className="rounded px-3 py-1 text-xs"
-          style={{ borderWidth: '1px', borderStyle: 'solid', borderColor: 'var(--color-border)', color: 'var(--color-muted-foreground)' }}
+          className="rounded border border-border px-3 py-1 text-xs text-muted-foreground"
         >
           {t('close')}
         </button>
       </div>
 
       {loading ? (
-        <p className="text-sm animate-pulse" style={{ color: 'var(--color-muted-foreground)' }}>
+        <p className="animate-pulse text-sm text-muted-foreground">
           Loading schema...
         </p>
       ) : tables.length === 0 ? (
-        <p className="text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
+        <p className="text-sm text-muted-foreground">
           {t('noTables')}
         </p>
       ) : (
@@ -69,14 +68,13 @@ export function SchemaBrowser({ tables, onClose, sourceName, loading }: SchemaBr
             <div key={`${table.schema}.${table.name}`}>
               <button
                 onClick={() => toggleTable(table.name)}
-                className="flex w-full items-center gap-2 rounded px-3 py-2 text-sm text-left transition-colors"
-                style={{ color: 'var(--color-foreground)' }}
+                className="flex w-full items-center gap-2 rounded px-3 py-2 text-left text-sm text-foreground transition-colors"
               >
-                <span className="text-xs" style={{ color: 'var(--color-muted-foreground)' }}>
+                <span className="text-xs text-muted-foreground">
                   {expanded.has(table.name) ? '▼' : '▶'}
                 </span>
                 <span className="font-medium">{table.name}</span>
-                <span className="text-xs" style={{ color: 'var(--color-muted-foreground)' }}>
+                <span className="text-xs text-muted-foreground">
                   ({table.columns.length} {t('columns')})
                 </span>
               </button>
@@ -88,14 +86,14 @@ export function SchemaBrowser({ tables, onClose, sourceName, loading }: SchemaBr
                       key={col.name}
                       className="flex items-center gap-2 rounded px-2 py-1 text-xs"
                     >
-                      <span style={{ color: 'var(--color-foreground)' }}>
+                      <span className="text-foreground">
                         {col.primaryKey ? '🔑 ' : ''}{col.name}
                       </span>
-                      <span style={{ color: 'var(--color-muted-foreground)' }}>
+                      <span className="text-muted-foreground">
                         {col.type}
                       </span>
                       {col.nullable && (
-                        <span style={{ color: 'var(--color-muted-foreground)', opacity: 0.6 }}>
+                        <span className="text-muted-foreground opacity-60">
                           nullable
                         </span>
                       )}

--- a/apps/web/src/components/settings/ai-model-settings.tsx
+++ b/apps/web/src/components/settings/ai-model-settings.tsx
@@ -64,7 +64,7 @@ export function AIModelSettings() {
     <Card className="max-w-lg">
       <CardHeader>
         <CardTitle>{t('title')}</CardTitle>
-        <p className="text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
+        <p className="text-sm text-muted-foreground">
           {t('description')}
         </p>
       </CardHeader>
@@ -76,14 +76,7 @@ export function AIModelSettings() {
             id="ai-provider"
             value={providerType}
             onChange={(e) => setProviderType(e.target.value as 'claude' | 'openai-compatible')}
-            className="flex h-10 w-full rounded-md px-3 py-2 text-sm"
-            style={{
-              borderWidth: '1px',
-              borderStyle: 'solid',
-              borderColor: 'var(--color-input)',
-              backgroundColor: 'transparent',
-              color: 'var(--color-foreground)',
-            }}
+            className="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm text-foreground"
           >
             <option value="openai-compatible">{t('providerOpenAI')}</option>
             <option value="claude">{t('providerClaude')}</option>
@@ -137,8 +130,16 @@ export function AIModelSettings() {
           <div
             className="rounded-md p-3 text-sm"
             style={{
-              backgroundColor: feedback.type === 'success' ? 'rgba(34,197,94,0.1)' : 'rgba(239,68,68,0.1)',
-              color: feedback.type === 'success' ? '#22c55e' : '#ef4444',
+              // Tint success with the warm-green narrate kind and error with
+              // the destructive token so feedback reads on-brand on dark.
+              backgroundColor:
+                feedback.type === 'success'
+                  ? 'color-mix(in oklab, var(--kind-narrate) 14%, transparent)'
+                  : 'color-mix(in oklab, var(--color-destructive) 14%, transparent)',
+              color:
+                feedback.type === 'success'
+                  ? 'var(--kind-narrate)'
+                  : 'var(--color-destructive)',
             }}
           >
             {feedback.message}

--- a/apps/web/src/components/view-renderer/controls/date-range-control.tsx
+++ b/apps/web/src/components/view-renderer/controls/date-range-control.tsx
@@ -21,7 +21,7 @@ const PRESETS = [
 export function DateRangeControl({ spec, value, onChange }: DateRangeControlProps) {
   return (
     <div className="flex flex-col gap-1">
-      <label className="text-xs font-medium" style={{ color: 'var(--color-muted-foreground)' }}>
+      <label className="text-xs font-medium text-muted-foreground">
         {spec.label}
       </label>
       <div className="flex items-center gap-2">
@@ -31,14 +31,7 @@ export function DateRangeControl({ spec, value, onChange }: DateRangeControlProp
             const [from, to] = e.target.value.split('|');
             if (from && to) onChange({ from, to });
           }}
-          className="h-8 rounded-md px-2 text-sm"
-          style={{
-            borderWidth: '1px',
-            borderStyle: 'solid',
-            borderColor: 'var(--color-input)',
-            backgroundColor: 'transparent',
-            color: 'var(--color-foreground)',
-          }}
+          className="h-8 rounded-md border border-input bg-transparent px-2 text-sm text-foreground"
         >
           {PRESETS.map((p) => (
             <option key={p.label} value={`${p.from}|${p.to}`}>
@@ -54,28 +47,14 @@ export function DateRangeControl({ spec, value, onChange }: DateRangeControlProp
               type="date"
               value={value.from}
               onChange={(e) => onChange({ ...value, from: e.target.value })}
-              className="h-8 rounded-md px-2 text-sm"
-              style={{
-                borderWidth: '1px',
-                borderStyle: 'solid',
-                borderColor: 'var(--color-input)',
-                backgroundColor: 'transparent',
-                color: 'var(--color-foreground)',
-              }}
+              className="h-8 rounded-md border border-input bg-transparent px-2 text-sm text-foreground"
             />
-            <span style={{ color: 'var(--color-muted-foreground)' }}>to</span>
+            <span className="text-muted-foreground">to</span>
             <input
               type="date"
               value={value.to}
               onChange={(e) => onChange({ ...value, to: e.target.value })}
-              className="h-8 rounded-md px-2 text-sm"
-              style={{
-                borderWidth: '1px',
-                borderStyle: 'solid',
-                borderColor: 'var(--color-input)',
-                backgroundColor: 'transparent',
-                color: 'var(--color-foreground)',
-              }}
+              className="h-8 rounded-md border border-input bg-transparent px-2 text-sm text-foreground"
             />
           </div>
         )}

--- a/apps/web/src/components/view-renderer/controls/dropdown-control.tsx
+++ b/apps/web/src/components/view-renderer/controls/dropdown-control.tsx
@@ -17,20 +17,13 @@ export function DropdownControl({ spec, value, onChange }: DropdownControlProps)
 
   return (
     <div className="flex flex-col gap-1">
-      <label className="text-xs font-medium" style={{ color: 'var(--color-muted-foreground)' }}>
+      <label className="text-xs font-medium text-muted-foreground">
         {spec.label}
       </label>
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="h-8 rounded-md px-2 text-sm"
-        style={{
-          borderWidth: '1px',
-          borderStyle: 'solid',
-          borderColor: 'var(--color-input)',
-          backgroundColor: 'transparent',
-          color: 'var(--color-foreground)',
-        }}
+        className="h-8 rounded-md border border-input bg-transparent px-2 text-sm text-foreground"
       >
         <option value="">{t('selectPlaceholder')}</option>
         {options.map((opt) => (

--- a/apps/web/src/components/view-renderer/controls/text-input-control.tsx
+++ b/apps/web/src/components/view-renderer/controls/text-input-control.tsx
@@ -30,7 +30,7 @@ export function TextInputControl({ spec, value, onChange }: TextInputControlProp
 
   return (
     <div className="flex flex-col gap-1">
-      <label className="text-xs font-medium" style={{ color: 'var(--color-muted-foreground)' }}>
+      <label className="text-xs font-medium text-muted-foreground">
         {spec.label}
       </label>
       <input
@@ -38,14 +38,7 @@ export function TextInputControl({ spec, value, onChange }: TextInputControlProp
         value={localValue}
         onChange={(e) => handleChange(e.target.value)}
         placeholder={spec.label}
-        className="h-8 rounded-md px-2 text-sm"
-        style={{
-          borderWidth: '1px',
-          borderStyle: 'solid',
-          borderColor: 'var(--color-input)',
-          backgroundColor: 'transparent',
-          color: 'var(--color-foreground)',
-        }}
+        className="h-8 rounded-md border border-input bg-transparent px-2 text-sm text-foreground"
       />
     </div>
   );

--- a/apps/web/src/components/view-renderer/controls/toggle-control.tsx
+++ b/apps/web/src/components/view-renderer/controls/toggle-control.tsx
@@ -13,22 +13,20 @@ interface ToggleControlProps {
 export function ToggleControl({ spec, value, onChange }: ToggleControlProps) {
   return (
     <div className="flex flex-col gap-1">
-      <label className="text-xs font-medium" style={{ color: 'var(--color-muted-foreground)' }}>
+      <label className="text-xs font-medium text-muted-foreground">
         {spec.label}
       </label>
       <button
         role="switch"
         aria-checked={value}
         onClick={() => onChange(!value)}
-        className="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full transition-colors"
-        style={{
-          backgroundColor: value ? 'var(--color-primary)' : 'var(--color-input)',
-        }}
+        className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full transition-colors ${
+          value ? 'bg-primary' : 'bg-input'
+        }`}
       >
         <span
-          className="pointer-events-none block h-5 w-5 rounded-full shadow-lg ring-0 transition-transform"
+          className="pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform"
           style={{
-            backgroundColor: 'var(--color-background)',
             transform: value ? 'translateX(20px) translateY(2px)' : 'translateX(2px) translateY(2px)',
           }}
         />

--- a/apps/web/src/components/view-renderer/html-view-renderer.tsx
+++ b/apps/web/src/components/view-renderer/html-view-renderer.tsx
@@ -48,14 +48,14 @@ export function HtmlViewRenderer({ view, isLoading }: HtmlViewRendererProps) {
     <div className="flex h-full flex-col">
       {/* Header */}
       {(view.title || view.description) && (
-        <div className="shrink-0 border-b px-6 py-4" style={{ borderColor: 'var(--color-border)' }}>
+        <div className="shrink-0 border-b border-border px-6 py-4">
           {view.title && (
-            <h2 className="text-lg font-semibold" style={{ color: 'var(--color-foreground)' }}>
+            <h2 className="text-lg font-semibold text-foreground">
               {view.title}
             </h2>
           )}
           {view.description && (
-            <p className="mt-1 text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
+            <p className="mt-1 text-sm text-muted-foreground">
               {view.description}
             </p>
           )}

--- a/apps/web/src/components/view-renderer/view-renderer.tsx
+++ b/apps/web/src/components/view-renderer/view-renderer.tsx
@@ -83,11 +83,11 @@ export function ViewRenderer({
       {/* Title */}
       {spec.title && (
         <div className="px-4 pt-3">
-          <h3 className="text-lg font-semibold" style={{ color: 'var(--color-foreground)' }}>
+          <h3 className="text-lg font-semibold text-foreground">
             {spec.title}
           </h3>
           {spec.description && (
-            <p className="text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
+            <p className="text-sm text-muted-foreground">
               {spec.description}
             </p>
           )}
@@ -104,11 +104,8 @@ export function ViewRenderer({
       {/* Chart area */}
       <div className="flex-1 relative">
         {isLoading && !data && (
-          <div
-            className="absolute inset-0 flex items-center justify-center"
-            style={{ backgroundColor: 'var(--color-muted)', opacity: 0.5 }}
-          >
-            <div className="animate-pulse text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
+          <div className="absolute inset-0 flex items-center justify-center bg-muted/50">
+            <div className="animate-pulse text-sm text-muted-foreground">
               {t('loading')}
             </div>
           </div>
@@ -116,12 +113,9 @@ export function ViewRenderer({
 
         {error && (
           <div className="p-4">
-            <div
-              className="rounded-md p-3"
-              style={{ backgroundColor: 'var(--color-destructive)', color: 'var(--color-destructive-foreground)', opacity: 0.9 }}
-            >
+            <div className="rounded-md bg-destructive/90 p-3 text-destructive-foreground">
               <p className="text-sm font-medium">{t('queryError')}</p>
-              <p className="text-xs mt-1 opacity-80">{error}</p>
+              <p className="mt-1 text-xs opacity-80">{error}</p>
             </div>
           </div>
         )}
@@ -137,20 +131,14 @@ export function ViewRenderer({
         )}
 
         {data && !plugin && (
-          <div className="p-4 text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
+          <div className="p-4 text-sm text-muted-foreground">
             {t('unknownChartType', { type: spec.chart.type })}
           </div>
         )}
 
         {/* Stale indicator during re-fetch */}
         {isLoading && data && (
-          <div
-            className="absolute top-2 right-2 rounded px-2 py-1 text-xs"
-            style={{
-              backgroundColor: 'var(--color-muted)',
-              color: 'var(--color-muted-foreground)',
-            }}
-          >
+          <div className="absolute top-2 right-2 rounded bg-muted px-2 py-1 text-xs text-muted-foreground">
             {t('updating')}
           </div>
         )}

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -42,7 +42,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     <button
       ref={ref}
       className={cn(
-        'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+        'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-border)] focus-visible:ring-offset-0 disabled:pointer-events-none disabled:opacity-50',
         sizes[size],
         className,
       )}

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -11,7 +11,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       type={type}
       ref={ref}
       className={cn(
-        'flex h-10 w-full rounded-md bg-transparent px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        'flex h-10 w-full rounded-md bg-transparent px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-border)] focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       style={{


### PR DESCRIPTION
## Summary

- **What was swept** — replaced hardcoded hex (`#22c55e`, `#ef4444`, `#6b7280`), raw `rgba()` literals, and inline `style={{ color/backgroundColor/borderColor: 'var(--color-*)' }}` across auth routes (`login-form`, `register-form`, `(auth)/layout`), dashboard feature components (`data-source-list`, `add-data-source-form`, `schema-browser`, `data-sources-page-client`, `ai-model-settings`), the view-renderer React chrome (`html-view-renderer`, `view-renderer`, and the four legacy controls), and the shared shadcn primitives (`Button`, `Input`) with token-backed Tailwind utilities (`text-foreground`, `text-muted-foreground`, `text-destructive`, `bg-card`, `bg-primary`, `bg-destructive`, `border-border`, `border-input`) and semantic tokens (`--kind-narrate` for success/healthy, `--color-destructive` for failure, `--ink-5` for unknown). Tinted feedback banners use `color-mix(in oklab, var(--kind-narrate|--color-destructive) 14%, transparent)`. Shared primitive focus rings now point at `--accent-border` instead of an unstyled default. The LIGHTBOARD sigil now sits centered at the top of the login and register cards, and the `(auth)` layout drops to `bg-background` so the `--bg-4` card reads cleanly above `--bg-0`.
- **What was explicitly not touched** — `components/explore/*`, `components/layout/*`, `components/brand/*`, `components/chat/markdown-renderer.tsx`, iframe `srcDoc` HTML, and anything in `packages/viz-core/*` or `documentation/*`. Information architecture, layout, and copy on all swept routes are unchanged — this is strictly a color/token sweep.
- **Grep audit result** — zero hits for `bg-white|text-black|text-gray-[0-9]+|bg-gray-[0-9]+`, zero hex color literals, and zero `rgb(255,...)|rgb(0,...)` across the sweep surface (`apps/web/src/app`, `apps/web/src/components/{data-sources,settings,view-renderer}`, `packages/ui/src/components`).

Screenshots in `G:/tmp/`: `pr8-login.png`, `pr8-register.png`, `pr8-home.png`, `pr8-data-sources.png`, `pr8-views.png`, `pr8-settings.png`, `pr8-explore.png`.

## Test plan

- [x] `pnpm --filter @lightboard/web typecheck` — clean
- [x] `pnpm --filter @lightboard/web lint` — clean
- [x] `pnpm --filter @lightboard/web test -- --run` — 109/109 pass (16 files)
- [x] Grep audit (12 patterns across sweep scope) — zero hits
- [x] Browser verified in isolated context for `/login`, `/register` and signed-in session for `/`, `/data-sources`, `/views`, `/settings`, `/explore` — all render dark, no white surfaces, no blue focus rings, sigil draws in on auth cards, Explore unchanged.
- [ ] CI passes

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>