### PR TITLE
docs: refresh project_overview.md + README.md to match current architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,12 @@ Lightboard is a TypeScript monorepo built with Turborepo and pnpm workspaces.
 lightboard/
 ├── apps/web/              # Next.js 15 (app router) — main application
 ├── packages/
-│   ├── db/                # Drizzle ORM schema, auth, migrations
-│   ├── ui/                # shadcn/ui component library
-│   ├── connector-sdk/     # Data source adapter interface
-│   ├── query-ir/          # Query intermediate representation
-│   ├── compute/           # DuckDB + Apache Arrow pipeline
-│   ├── viz-core/          # visx chart components
-│   └── agent/             # AI agent with tool use
+│   ├── agent/             # Multi-agent orchestration (leader + specialists)
+│   ├── connector-sdk/     # Data source adapter interface (JSON rows)
+│   ├── connectors/        # Postgres connector
+│   ├── db/                # Drizzle schema, auth, migrations
+│   ├── telemetry/         # OpenTelemetry SDK + built-in data source
+│   └── ui/                # shadcn/ui component library
 ├── docker/                # Docker Compose for local dev
 └── e2e/                   # Playwright E2E tests
 ```
@@ -26,13 +25,13 @@ lightboard/
 | Layer | Technology |
 |-------|-----------|
 | Framework | Next.js 15 (app router, Turbopack) |
-| UI | shadcn/ui + Tailwind CSS v4 |
-| Visualization | visx + d3 |
+| UI | shadcn/ui + Tailwind CSS v4 (dark-only, design-system tokens) |
+| Typography | Space Grotesk · Inter · JetBrains Mono |
+| Visualization | Agent-generated HTML in a sandboxed iframe |
 | State | Zustand (client), @tanstack/react-query (server) |
 | ORM | Drizzle ORM + PostgreSQL |
 | Auth | Session-based (Argon2 + oslo) |
 | i18n | next-intl |
-| Compute | DuckDB (native + WASM) + Apache Arrow |
 | Testing | Vitest + Playwright + Testing Library |
 
 ## Getting Started

--- a/documentation/project_overview.md
+++ b/documentation/project_overview.md
@@ -9,7 +9,7 @@ Lightboard is **not** a Grafana fork, **not** a monitoring tool, and **not** a B
 ## Core principles
 
 1. **AI-first interaction**: Users explore data through conversation. The agent understands schemas, generates interactive views, and iterates on follow-ups.
-2. **Opinionated visualization**: Charts follow data viz best practices by default. Auto-selection of chart types, sane defaults, publication-quality output without config hell.
+2. **Opinionated visualization**: Charts follow data viz best practices by default. The agent composes full HTML views with editorial framing (figure-number eyebrow, display-sans headline, body subtitle, mono footnotes) — no config hell.
 3. **Deploy anywhere**: Cloud SaaS, on-prem Docker, fully airgapped Kubernetes — same codebase, same features (with graceful degradation for AI in airgap mode).
 4. **Native app feel on the web**: Snappy UI with aggressive caching, skeleton loaders only for data fetches, instant navigation between views.
 
@@ -22,34 +22,31 @@ Lightboard is **not** a Grafana fork, **not** a monitoring tool, and **not** a B
 ├─────────────────────────────────────────────────┤
 │         Multi-agent orchestration                │
 │  Leader agent · Query agent · View agent         │
-│  Insights agent · Session scratchpad (DuckDB)    │
+│  Insights agent · Session scratchpad (in-memory) │
 ├─────────────────────────────────────────────────┤
 │              AI provider layer                   │
 │  Claude API / Local LLM · Tool use · Streaming   │
 ├─────────────────────────────────────────────────┤
-│            Visualization engine                  │
-│  visx · Panel adapter protocol · Canvas fallback │
-├─────────────────────────────────────────────────┤
-│             Compute engine                       │
-│  DuckDB (native + WASM) · Apache Arrow IPC       │
+│              Visualization                       │
+│  Agent-generated HTML in sandboxed iframe        │
 ├─────────────────────────────────────────────────┤
 │           Data integration layer                 │
-│  Connector SDK · Query IR · Schema cache         │
+│  Connector SDK · Schema cache                    │
 ├─────────────────────────────────────────────────┤
 │              Infrastructure                      │
 │  Postgres · Redis · S3-compat · Docker/K8s       │
 └─────────────────────────────────────────────────┘
 ```
 
-### Multi-agent architecture (Phase 1.5)
+### Multi-agent architecture
 
 Instead of a single monolithic agent, Lightboard uses a chain of specialized LLM-powered agents:
 
-- **Leader Agent**: Manages conversation, routes intent to specialists, handles scratchpad operations, streams responses to user
-- **Query Agent**: Schema exploration, query construction (QueryIR + raw SQL for JOINs). Receives full schema, focused on data retrieval.
-- **View Agent**: Chart type selection, ViewSpec generation, interactive control wiring. Receives data summaries, not raw schemas.
-- **Insights Agent**: Statistical observations, anomaly detection, trend analysis. Runs analytics via DuckDB.
-- **Session Scratchpad**: Per-conversation DuckDB instance for intermediate data storage. Agents can save query results as named tables and query across them for multi-step analysis.
+- **Leader Agent**: Manages conversation, routes intent to specialists, handles scratchpad operations, streams responses to user.
+- **Query Agent**: Schema exploration and SQL authoring via `run_sql` and `describe_table`. Receives curated schema context, focused on data retrieval.
+- **View Agent**: Composes a complete HTML document — charts, layout, inline styles, embedded data — rendered in a sandboxed iframe on the client. Receives data summaries, not raw schemas.
+- **Insights Agent**: Statistical observations, anomaly detection, trend analysis.
+- **Session Scratchpad**: Per-conversation in-memory store for intermediate JSON rows. Agents save query results by name and reference them across turns for multi-step analysis.
 
 The leader invokes sub-agents as tools (native tool_use). Sub-agents are "headless" — they run their own tool loops internally and return structured results. Only the leader streams text to the user.
 
@@ -60,15 +57,13 @@ The leader invokes sub-agents as tools (native tool_use). Sub-agents are "headle
 | Runtime | Node.js 22+ | MIT |
 | Framework | Next.js 15 (app router) | MIT |
 | Language | TypeScript (strict mode) | Apache-2.0 |
-| UI components | shadcn/ui + Radix primitives | MIT |
-| Visualization | visx + d3-scale + d3-shape | MIT |
-| Data tables | TanStack Table (react-table) | MIT |
+| UI components | shadcn/ui + Radix primitives · Tailwind CSS 4 (dark-only, design-system tokens) | MIT |
+| Typography | Space Grotesk · Inter · JetBrains Mono (via `next/font/google`) | OFL |
+| Visualization | Agent-generated HTML rendered in a sandboxed iframe | — |
 | Server state | TanStack Query (react-query) | MIT |
 | Client state | Zustand | MIT |
 | URL state | nuqs | MIT |
 | Layout | react-grid-layout | MIT |
-| Compute engine | DuckDB (native + WASM) | MIT |
-| Data interchange | Apache Arrow IPC | Apache-2.0 |
 | ORM | Drizzle ORM | Apache-2.0 |
 | Database | PostgreSQL | PostgreSQL License |
 | Cache | Redis / KeyDB | BSD-3 / BSD-2 |
@@ -87,44 +82,47 @@ Lightboard uses a **shared database, shared schema** multi-tenancy model with Po
 - API middleware extracts `org_id` from the session token and sets the Postgres session variable before every query
 - Data source credentials are encrypted with per-org key derivation
 - Rate limiting is per-org via Redis token bucket
-- DuckDB compute uses ephemeral per-request instances to prevent data leakage between tenants
 
 ## Key concepts
 
-### Query IR (Intermediate Representation)
-The lingua franca of the system. The AI agent produces it. The visual query builder produces it. Template variables interpolate into it. Each connector translates it to native query syntax (SQL, PromQL, etc).
+### HtmlView
+
+The agent's primary output. A complete, self-contained HTML document — charts, layout, inline styles, embedded data — rendered in a sandboxed iframe on the client. Persisted to the database for later recall and sharing.
 
 ```typescript
-interface QueryIR {
-  source: string;              // data source uid
-  select: FieldRef[];          // columns to return
-  filters: FilterClause[];     // where conditions (AND/OR trees)
-  groupBy: FieldRef[];         // group by columns
-  aggregations: Aggregation[]; // sum, avg, count, min, max, percentile, distinct_count
-  orderBy: OrderClause[];      // sort
-  limit?: number;
-  timeRange?: TimeRange;       // { from, to, field }
-  variables?: Record<string, string>; // template variable references
+interface HtmlView {
+  title: string;
+  description: string;
+  sql: string;    // the SQL that produced the data
+  html: string;   // full, self-contained document
 }
 ```
 
-### View spec
-The agent's primary output. A declarative JSON document describing a complete interactive panel: query, chart type + config, interactive controls bound to template variables, layout hints.
-
-### Panel adapter protocol
-The interface for plugging any React component into Lightboard as a visualization panel. Exposes: data (Arrow tables), config (auto-generated from JSON Schema), dimensions, theme tokens, and interaction callbacks.
-
 ### Connector SDK
-TypeScript interface for data source plugins. Methods: `connect`, `introspect`, `query`, `stream`, `healthCheck`, `capabilities`. Each connector is an npm package or local tarball.
+
+TypeScript interface for data source plugins. Methods: `connect`, `introspect`, `querySQL`, `healthCheck`, `capabilities`. The agent executes raw SQL via `querySQL`, which returns JSON rows (`{ columns, rows, rowCount }`). Each connector is an npm package or local tarball.
+
+### Agent tools
+
+The five tools the leader (and specialists) use:
+
+- `get_schema(source_id)` — returns the cached/bootstrapped schema document.
+- `describe_table(source_id, table_name)` — columns, types, sample values, enum cardinality.
+- `run_sql(source_id, sql)` — executes raw SQL against the source; returns JSON rows (LIMIT-enforced).
+- `create_view({ title, description, sql, html })` — persists an `HtmlView`, emits `view_created` over SSE.
+- `modify_view(view_id, patch)` — updates an existing HtmlView.
+
+### Message model (`parts[]`)
+
+The Explore chat state lives in `apps/web/src/components/explore/chat-message.tsx`. Each assistant message is an ordered `parts[]` array; each part is one of: `thinking`, `text`, `status`, `tool_call`, `agent_delegation`, `view`, `suggestions`. A pure reducer at `apps/web/src/components/explore/sse-reducer.ts` projects streaming SSE events onto the list, preserving temporal ordering between text and tool calls so the trace renders in the exact sequence the agent produced.
 
 ## Performance strategy
 
-1. **Push to source**: 90% of queries execute in the data source. The server is a proxy.
-2. **DuckDB for compute**: Cross-source joins, CSV analysis, post-query transforms run in DuckDB (C++ speed via native bindings on server, WASM in browser). 10-100x faster than JavaScript for analytical workloads.
-3. **Apache Arrow as wire format**: Zero-copy data transfer between DuckDB, Node.js, browser Web Workers, and the rendering layer.
-4. **Tiered rendering**: SVG for <5K points, Canvas for 5-50K, LTTB downsampling + WebGL (deck.gl) for 50K+.
+1. **Push to source**: Queries execute in the user's data source. The server is a proxy.
+2. **LIMIT-enforced result sets**: The agent's `run_sql` tool enforces a row cap so result payloads stay small and visualizations stay snappy.
+3. **Iframe isolation**: Generated HTML views render inside sandboxed iframes. View code (embedded scripts, inline styles) can never leak into the page shell or sibling views.
 
-## Repository structure (target)
+## Repository structure
 
 ```
 lightboard/
@@ -133,35 +131,26 @@ lightboard/
 │       ├── app/                # App router pages
 │       ├── components/         # React components
 │       ├── lib/                # Shared utilities
-│       ├── styles/             # Global styles + theme tokens
-│       └── i18n/               # Internationalization
+│       ├── messages/           # i18n catalogs (next-intl)
+│       ├── stores/             # Zustand stores
+│       └── styles/             # Global styles + design tokens
 ├── packages/
-│   ├── connector-sdk/          # Connector interface + types
-│   ├── connectors/
-│   │   ├── postgres/
-│   │   ├── mysql/
-│   │   ├── clickhouse/
-│   │   ├── rest-api/
-│   │   ├── csv-parquet/
-│   │   ├── prometheus/
-│   │   └── elasticsearch/
-│   ├── query-ir/               # IR types + validators
-│   ├── compute/                # DuckDB integration + Arrow pipeline
-│   ├── viz-core/               # visx chart components + panel adapter
-│   ├── agent/                  # Multi-agent orchestration (leader + specialists)
-│   │   ├── agents/             # Sub-agent implementations (query, view, insights)
-│   │   ├── scratchpad/         # DuckDB session scratchpad for intermediate data
+│   ├── agent/                  # Multi-agent orchestration (leader + query + view + insights)
+│   │   ├── agents/             # Sub-agent implementations
+│   │   ├── scratchpad/         # Per-session in-memory store
 │   │   ├── prompt/             # Per-agent system prompts
 │   │   └── tools/              # Per-agent tool definitions + router
-│   ├── ui/                     # Shared UI components (shadcn-based)
-│   ├── telemetry/              # Telemetry collection + built-in data source
-│   ├── mcp-server/             # MCP server for UI operations
-│   └── db/                     # Drizzle schema + migrations
+│   ├── connector-sdk/          # Connector interface + JSON-row query types
+│   ├── connectors/
+│   │   └── postgres/           # Postgres connector (additional connectors deferred)
+│   ├── db/                     # Drizzle schema + migrations + auth
+│   ├── telemetry/              # OpenTelemetry SDK + built-in data source
+│   └── ui/                     # Shared UI components (shadcn-based)
 ├── plugins/                    # Plugin directory (tarball loading)
 ├── docker/                     # Dockerfiles + compose
 ├── helm/                       # Kubernetes Helm charts
 ├── e2e/                        # Playwright E2E tests
-└── docs/                       # Documentation
+└── documentation/              # Documentation
 ```
 
 ## Deployment modes


### PR DESCRIPTION
## Summary

- Removes all references to the retired legacy system (QueryIR, ViewSpec legacy, visx, panel adapter protocol, DuckDB compute tier, Apache Arrow, deleted `compute/` and `mcp-server/` packages) from the two public-facing docs.
- Adds descriptions of the current architecture: HtmlView as the primary output, the five agent tools (`get_schema`, `describe_table`, `run_sql`, `create_view`, `modify_view`), and the `parts[]` message model with its pure SSE reducer.
- Updates the tech stack and repo-structure diagrams to match what's actually on disk (typography, dark-only tokens, no more `compute/`/`mcp-server/`/visx).

`CLAUDE.md` was already accurate and is unchanged; this PR brings the two public docs into alignment with it. Docs-only — no source-code changes.

## Test plan

- [x] `grep -E "QueryIR|Query IR|DuckDB|Apache Arrow|Arrow IPC|visx|panel adapter|ViewSpec|compute/|mcp-server/" documentation/project_overview.md README.md` → zero hits
- [x] `grep -E "Space Grotesk|parts\[\]|HtmlView|run_sql" documentation/project_overview.md` → all new subsections landed
- [x] Full read-through of both files — narrative flows, no orphan references to deleted concepts
- [x] `git diff` touches only the two files