### PR TITLE
feat(ui): PR 10 — unified LightboardLoader across all loading surfaces

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -94,7 +94,9 @@
     "schemaOf": "Schema: {name}",
     "close": "Close",
     "noTables": "No tables found.",
-    "columns": "columns"
+    "columns": "columns",
+    "loadingSchema": "Loading schema…",
+    "loadingSources": "Loading data sources…"
   },
   "views": {
     "title": "Views",

--- a/apps/web/src/components/auth/auth-card.module.css
+++ b/apps/web/src/components/auth/auth-card.module.css
@@ -205,10 +205,6 @@
   transform: translateX(2px);
 }
 
-.spinner {
-  animation: lb-auth-spin 0.9s linear infinite;
-}
-
 .btnGoogle {
   background: var(--bg-6);
   color: var(--ink-1);
@@ -266,12 +262,6 @@
   border-bottom-color: var(--line-5);
 }
 
-@keyframes lb-auth-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   .btn,
   .btnPrimary,
@@ -281,9 +271,6 @@
   .labelAux,
   .finePrintLink {
     transition: none;
-  }
-  .spinner {
-    animation: none;
   }
   .btnPrimary:hover:not(:disabled) {
     transform: none;

--- a/apps/web/src/components/auth/field-icons.tsx
+++ b/apps/web/src/components/auth/field-icons.tsx
@@ -123,30 +123,6 @@ export function ArrowIcon({ className }: { className?: string }) {
   );
 }
 
-/** Spinner — shown in the primary button while submitting. */
-export function SpinnerIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 12 12"
-      aria-hidden="true"
-      className={className}
-    >
-      <circle
-        cx="6"
-        cy="6"
-        r="4.5"
-        stroke="currentColor"
-        strokeWidth="1.3"
-        fill="none"
-        strokeDasharray="18 10"
-        strokeLinecap="round"
-      />
-    </svg>
-  );
-}
-
 /** Google brand glyph — decorative; the button's visible label carries the name. */
 export function GoogleIcon() {
   return (

--- a/apps/web/src/components/auth/grid-backdrop.tsx
+++ b/apps/web/src/components/auth/grid-backdrop.tsx
@@ -1,27 +1,8 @@
 'use client';
 
 import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { SIGIL_PALETTE } from '../brand/sigil-palette';
 import styles from './grid-backdrop.module.css';
-
-/**
- * Palette for the streaking traces. These literal hex values mirror the
- * `--sigil-1..10` tokens in `globals.css`; they are duplicated here because
- * each trace needs its color baked into a `linear-gradient(...)` and a
- * `box-shadow` string at spawn time — a `var(--sigil-1)` inside those strings
- * would pin every trace to the same runtime value instead of capturing the
- * chosen one. If the sigil palette changes, update this array in lockstep.
- */
-const TRACE_COLORS = [
-  '#F4A261',
-  '#E76F51',
-  '#E9C46A',
-  '#D9A441',
-  '#8AB4B8',
-  '#5E8B95',
-  '#6A7BA2',
-  '#B08CA8',
-  '#D4846F',
-] as const;
 
 /** Grid pitch (one square edge, in CSS pixels). Matches the handoff. */
 const GRID_PITCH = 48;
@@ -146,7 +127,7 @@ function TraceField() {
     const spawn = (now: number) => {
       const id = idRef.current++;
       const horizontal = Math.random() > 0.5;
-      const color = TRACE_COLORS[Math.floor(Math.random() * TRACE_COLORS.length)]!;
+      const color = SIGIL_PALETTE[Math.floor(Math.random() * SIGIL_PALETTE.length)]!;
       const duration = 5000 + Math.random() * 3500;
       const reverse = Math.random() > 0.5;
 

--- a/apps/web/src/components/auth/submit-button.tsx
+++ b/apps/web/src/components/auth/submit-button.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
-import { ArrowIcon, SpinnerIcon } from './field-icons';
+import { LightboardLoader } from '../brand';
+import { ArrowIcon } from './field-icons';
 import styles from './auth-card.module.css';
 
 /** Props for {@link SubmitButton}. */
@@ -37,7 +38,7 @@ export function SubmitButton({
     >
       {loading ? (
         <>
-          <SpinnerIcon className={styles.spinner} />
+          <LightboardLoader size={12} />
           {loadingLabel}
         </>
       ) : (

--- a/apps/web/src/components/brand/__tests__/lightboard-loader.test.tsx
+++ b/apps/web/src/components/brand/__tests__/lightboard-loader.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { LightboardLoader } from '../lightboard-loader';
+
+// Stub next-intl — the loader looks up `common.loading` and falls back to any
+// explicit ariaLabel the caller passes. We mirror `en.json`'s mapping here so
+// the default aria-label assertion is exact.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const map: Record<string, string> = {
+      loading: 'Loading...',
+    };
+    return map[key] ?? key;
+  },
+}));
+
+/**
+ * jsdom doesn't provide matchMedia. Every test in this file reaches the
+ * loader's reduced-motion probe, so we install a deterministic shim that can
+ * be flipped per test.
+ */
+function installMatchMedia(prefersReducedMotion: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes('prefers-reduced-motion') && prefersReducedMotion,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+}
+
+describe('LightboardLoader', () => {
+  afterEach(() => cleanup());
+
+  describe('with motion enabled', () => {
+    beforeEach(() => installMatchMedia(false));
+
+    it('renders a status element with the i18n default aria-label', () => {
+      const { container } = render(<LightboardLoader size={48} />);
+      const root = container.firstElementChild;
+      expect(root).not.toBeNull();
+      expect(root?.getAttribute('role')).toBe('status');
+      expect(root?.getAttribute('aria-label')).toBe('Loading...');
+    });
+
+    it('honors an explicit ariaLabel over the i18n default', () => {
+      const { container } = render(
+        <LightboardLoader size={48} ariaLabel="Fetching schema" />,
+      );
+      const root = container.firstElementChild as HTMLElement | null;
+      expect(root?.getAttribute('aria-label')).toBe('Fetching schema');
+    });
+
+    it('reflects size on the root element when width/height are absent', () => {
+      const { container } = render(<LightboardLoader size={72} />);
+      const root = container.firstElementChild as HTMLElement | null;
+      expect(root?.style.width).toBe('72px');
+      expect(root?.style.height).toBe('72px');
+    });
+
+    it('respects explicit width/height over size', () => {
+      const { container } = render(
+        <LightboardLoader size={48} width={280} height={52} />,
+      );
+      const root = container.firstElementChild as HTMLElement | null;
+      expect(root?.style.width).toBe('280px');
+      expect(root?.style.height).toBe('52px');
+    });
+  });
+
+  describe('with prefers-reduced-motion: reduce', () => {
+    beforeEach(() => installMatchMedia(true));
+
+    it('renders the static crosshatch with exactly four segments', () => {
+      const { container } = render(<LightboardLoader size={48} />);
+      const root = container.firstElementChild as HTMLElement | null;
+      expect(root).not.toBeNull();
+      // Four absolutely-positioned beam segments — two horizontal + two
+      // vertical — and nothing else inside the loader root.
+      const children = root?.children ?? ([] as unknown as HTMLCollection);
+      expect(children.length).toBe(4);
+    });
+
+    it('does not start a rAF loop under reduced motion', () => {
+      const rafSpy = vi.spyOn(window, 'requestAnimationFrame');
+      render(<LightboardLoader size={48} />);
+      expect(rafSpy).not.toHaveBeenCalled();
+      rafSpy.mockRestore();
+    });
+  });
+});

--- a/apps/web/src/components/brand/index.ts
+++ b/apps/web/src/components/brand/index.ts
@@ -6,3 +6,8 @@
  */
 export { LightboardSigil, type LightboardSigilProps } from './lightboard-sigil';
 export { SigilLoader, type SigilLoaderProps } from './sigil-loader';
+export {
+  LightboardLoader,
+  type LightboardLoaderProps,
+} from './lightboard-loader';
+export { SIGIL_PALETTE, type SigilPaletteColor } from './sigil-palette';

--- a/apps/web/src/components/brand/lightboard-loader.tsx
+++ b/apps/web/src/components/brand/lightboard-loader.tsx
@@ -1,0 +1,358 @@
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react';
+import { useTranslations } from 'next-intl';
+import { SIGIL_PALETTE } from './sigil-palette';
+
+/** Props for {@link LightboardLoader}. */
+export interface LightboardLoaderProps {
+  /** Bounding square in CSS pixels. Ignored if both {@link width} and {@link height} are supplied. */
+  size?: number;
+  /** Optional non-square width override. */
+  width?: number;
+  /** Optional non-square height override. */
+  height?: number;
+  /** Override the default concurrent beam count (2 at xs/sm, 3 at md, 5 at lg/xl). */
+  beams?: number;
+  /** Animation speed multiplier. 1 = default, <1 slower, >1 faster. */
+  speed?: number;
+  /** Arbitrary style overrides applied to the loader root. */
+  style?: CSSProperties;
+  /** Arbitrary className applied to the loader root. */
+  className?: string;
+  /**
+   * Accessible label for screen readers. Overrides the default i18n lookup of
+   * `common.loading`.
+   */
+  ariaLabel?: string;
+}
+
+/** Shape of a single in-flight beam on the rAF loop. */
+interface Beam {
+  id: number;
+  horizontal: boolean;
+  color: string;
+  /** Lifetime in milliseconds. */
+  duration: number;
+  /** Whether this beam travels right→left (horizontal) or bottom→top (vertical). */
+  reverse: boolean;
+  /** Cross-axis coordinate, in CSS pixels, at the center of the lane. */
+  pos: number;
+  /** `performance.now()` timestamp at spawn (may be pre-dated for staggering). */
+  start: number;
+}
+
+/**
+ * Unified loading indicator — rainbow light-beam animation on a transparent
+ * ground, reusing the login-backdrop visual language at every size.
+ *
+ * Sizing philosophy:
+ * - {@link size} sets a bounding square (default 48px).
+ * - {@link width} / {@link height} override for non-square strips.
+ * - Beams travel along an internal 4-lane grid (pitch = S/4). Thickness,
+ *   glow radius, and beam length scale with the shorter axis.
+ * - Concurrent beam count auto-scales (2 at <28px, 3 at <80px, 5 beyond) —
+ *   pass {@link beams} to override.
+ *
+ * The component respects `prefers-reduced-motion: reduce` by skipping the
+ * rAF loop entirely and rendering a static rainbow "#" crosshatch — two
+ * horizontal and two vertical beam segments at `S/4` and `3*S/4` on each
+ * axis, one color each from {@link SIGIL_PALETTE}. Reads as a quiet
+ * "rainbow hash" that echoes both the animated beams and the `#` glyph.
+ *
+ * Inline per-frame styles on beam elements are a documented exception to
+ * the "no inline styles" rule — same rationale as `grid-backdrop.tsx`:
+ * the values are rAF positional output and color-bearing gradient strings
+ * that cannot be expressed as Tailwind utilities or CSS-module rules.
+ */
+export function LightboardLoader({
+  size = 48,
+  width,
+  height,
+  beams,
+  speed = 1,
+  style,
+  className,
+  ariaLabel,
+}: LightboardLoaderProps) {
+  const t = useTranslations('common');
+  const label = ariaLabel ?? t('loading');
+
+  const W = width ?? size;
+  const H = height ?? size;
+  const S = Math.min(W, H);
+
+  const defaultBeams = S < 28 ? 2 : S < 80 ? 3 : 5;
+  const beamCount = beams ?? defaultBeams;
+
+  // Visual params scale with the shorter axis. Clamped so tiny loaders still
+  // render a visible streak and huge loaders still have proportional glow.
+  const thickness = Math.max(1, Math.round(S / 48));
+  const glow = Math.max(4, Math.round(S / 6));
+  const beamLen = Math.max(14, Math.round(S * 0.85));
+
+  // Internal grid: four lanes across each axis. At smaller sizes we use all
+  // lanes; at larger sizes we leave a 1-cell margin to avoid grazing edges.
+  const pitch = S / 4;
+  const edgeMargin = S >= 48 ? 1 : 0;
+
+  // Probe reduced-motion *synchronously* via a useState initializer so the
+  // rAF effect below sees the correct value on first run — deferring this to
+  // a post-mount useEffect would let the animated branch kick off one rAF
+  // cycle before being torn down. One-shot only: we don't subscribe to live
+  // changes, mirroring `sigil-loader.tsx`.
+  const [prefersReducedMotion] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
+  // Bumping `tick` forces a render each rAF frame. Beams themselves live in
+  // a ref so we don't reallocate the array each tick.
+  const [, setTick] = useState(0);
+  const beamsRef = useRef<Beam[]>([]);
+  const idRef = useRef(0);
+  const rafRef = useRef(0);
+
+  const makeBeam = useCallback(
+    (now: number): Beam => {
+      const id = idRef.current++;
+      const horizontal = Math.random() > 0.5;
+      const color =
+        SIGIL_PALETTE[Math.floor(Math.random() * SIGIL_PALETTE.length)]!;
+      const duration = (1400 + Math.random() * 1200) / speed;
+      const reverse = Math.random() > 0.5;
+      const laneCount = Math.floor((horizontal ? H : W) / pitch);
+      const minLane = edgeMargin;
+      const maxLane = Math.max(minLane + 1, laneCount - edgeMargin);
+      const lane = minLane + Math.floor(Math.random() * (maxLane - minLane));
+      const pos = lane * pitch + pitch / 2;
+      return { id, horizontal, color, duration, reverse, pos, start: now };
+    },
+    [W, H, pitch, edgeMargin, speed],
+  );
+
+  useEffect(() => {
+    if (prefersReducedMotion) return;
+
+    const t0 = performance.now();
+    beamsRef.current = [];
+    for (let i = 0; i < beamCount; i += 1) {
+      const b = makeBeam(t0);
+      // Stagger: offset start times by evenly spaced fractions of duration
+      // so the loader never begins with a blank frame.
+      b.start = t0 - (i * b.duration) / beamCount;
+      beamsRef.current.push(b);
+    }
+
+    const loop = (now: number) => {
+      beamsRef.current = beamsRef.current.map((b) =>
+        now - b.start >= b.duration ? makeBeam(now) : b,
+      );
+      setTick((n) => (n + 1) % 1000);
+      rafRef.current = requestAnimationFrame(loop);
+    };
+    rafRef.current = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [beamCount, makeBeam, prefersReducedMotion]);
+
+  const rootStyle: CSSProperties = {
+    position: 'relative',
+    width: W,
+    height: H,
+    overflow: 'hidden',
+    display: 'inline-block',
+    ...style,
+  };
+
+  if (prefersReducedMotion) {
+    return (
+      <div
+        role="status"
+        aria-label={label}
+        className={className}
+        style={rootStyle}
+      >
+        <ReducedMotionCrosshatch
+          W={W}
+          H={H}
+          thickness={thickness}
+          glow={glow}
+        />
+      </div>
+    );
+  }
+
+  const now = typeof performance !== 'undefined' ? performance.now() : 0;
+  return (
+    <div
+      role="status"
+      aria-label={label}
+      className={className}
+      style={rootStyle}
+    >
+      {beamsRef.current.map((beam) => (
+        <LoaderBeam
+          key={beam.id}
+          beam={beam}
+          now={now}
+          W={W}
+          H={H}
+          beamLen={beamLen}
+          thickness={thickness}
+          glow={glow}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Props for a single animated {@link LoaderBeam}. */
+interface LoaderBeamProps {
+  beam: Beam;
+  now: number;
+  W: number;
+  H: number;
+  beamLen: number;
+  thickness: number;
+  glow: number;
+}
+
+/**
+ * One streaking beam — either horizontal (rides a row) or vertical (rides a
+ * column), fading in at 12% of its lifetime and fading out at 88%.
+ */
+function LoaderBeam({
+  beam,
+  now,
+  W,
+  H,
+  beamLen,
+  thickness,
+  glow,
+}: LoaderBeamProps) {
+  const t = (now - beam.start) / beam.duration;
+  if (t < 0 || t > 1) return null;
+
+  const opacity = t < 0.12 ? t / 0.12 : t > 0.88 ? (1 - t) / 0.12 : 1;
+  const borderRadius = Math.max(1, Math.round(thickness / 2));
+  const boxShadow = `0 0 ${glow}px ${beam.color}, 0 0 ${glow * 2}px ${beam.color}66`;
+
+  if (beam.horizontal) {
+    const startX = beam.reverse ? W + beamLen : -beamLen;
+    const endX = beam.reverse ? -beamLen : W + beamLen;
+    const x = startX + (endX - startX) * t;
+    const gradient = beam.reverse
+      ? `linear-gradient(270deg, rgba(0,0,0,0) 0%, ${beam.color} 40%, ${beam.color} 80%, #ffffff 100%)`
+      : `linear-gradient(90deg, rgba(0,0,0,0) 0%, ${beam.color} 40%, ${beam.color} 80%, #ffffff 100%)`;
+    const style: CSSProperties = {
+      position: 'absolute',
+      top: beam.pos - thickness / 2,
+      left: x,
+      width: beamLen,
+      height: thickness,
+      background: gradient,
+      borderRadius,
+      boxShadow,
+      opacity,
+      pointerEvents: 'none',
+    };
+    return <div style={style} />;
+  }
+
+  const startY = beam.reverse ? H + beamLen : -beamLen;
+  const endY = beam.reverse ? -beamLen : H + beamLen;
+  const y = startY + (endY - startY) * t;
+  const gradient = beam.reverse
+    ? `linear-gradient(0deg, rgba(0,0,0,0) 0%, ${beam.color} 40%, ${beam.color} 80%, #ffffff 100%)`
+    : `linear-gradient(180deg, rgba(0,0,0,0) 0%, ${beam.color} 40%, ${beam.color} 80%, #ffffff 100%)`;
+  const style: CSSProperties = {
+    position: 'absolute',
+    left: beam.pos - thickness / 2,
+    top: y,
+    width: thickness,
+    height: beamLen,
+    background: gradient,
+    borderRadius,
+    boxShadow,
+    opacity,
+    pointerEvents: 'none',
+  };
+  return <div style={style} />;
+}
+
+/** Props for the reduced-motion {@link ReducedMotionCrosshatch}. */
+interface ReducedMotionCrosshatchProps {
+  W: number;
+  H: number;
+  thickness: number;
+  glow: number;
+}
+
+/**
+ * Static rainbow `#` crosshatch shown instead of the animated beam loop when
+ * the user prefers reduced motion. Two horizontal and two vertical full-width
+ * / full-height segments sit at `S/4` and `3*S/4` on each axis; each segment
+ * takes a deterministic color from {@link SIGIL_PALETTE} so the same loader
+ * instance always renders the same pattern. Thickness, glow, and border
+ * radius match the animated path so the visual weight is consistent.
+ */
+function ReducedMotionCrosshatch({
+  W,
+  H,
+  thickness,
+  glow,
+}: ReducedMotionCrosshatchProps) {
+  const borderRadius = Math.max(1, Math.round(thickness / 2));
+
+  // Four deterministic colors — one per segment. Staying inside the first
+  // four palette entries keeps the crosshatch warm-side, echoing the sigil.
+  const segments: Array<{
+    horizontal: boolean;
+    pos: number;
+    color: string;
+  }> = [
+    { horizontal: true, pos: H / 4, color: SIGIL_PALETTE[0] },
+    { horizontal: true, pos: (3 * H) / 4, color: SIGIL_PALETTE[1] },
+    { horizontal: false, pos: W / 4, color: SIGIL_PALETTE[2] },
+    { horizontal: false, pos: (3 * W) / 4, color: SIGIL_PALETTE[3] },
+  ];
+
+  return (
+    <>
+      {segments.map((seg, i) => {
+        const boxShadow = `0 0 ${glow}px ${seg.color}, 0 0 ${glow * 2}px ${seg.color}66`;
+        const style: CSSProperties = seg.horizontal
+          ? {
+              position: 'absolute',
+              top: seg.pos - thickness / 2,
+              left: 0,
+              width: W,
+              height: thickness,
+              background: seg.color,
+              borderRadius,
+              boxShadow,
+              opacity: 1,
+              pointerEvents: 'none',
+            }
+          : {
+              position: 'absolute',
+              left: seg.pos - thickness / 2,
+              top: 0,
+              width: thickness,
+              height: H,
+              background: seg.color,
+              borderRadius,
+              boxShadow,
+              opacity: 1,
+              pointerEvents: 'none',
+            };
+        return <div key={i} style={style} />;
+      })}
+    </>
+  );
+}

--- a/apps/web/src/components/brand/sigil-palette.ts
+++ b/apps/web/src/components/brand/sigil-palette.ts
@@ -1,0 +1,25 @@
+/**
+ * Sunset → sea editorial palette shared by the Lightboard sigil, the login
+ * grid-backdrop, and the {@link LightboardLoader}.
+ *
+ * Duplicated verbatim from the `--sigil-1..10` CSS custom properties in
+ * `globals.css`. The duplication is deliberate: each animated trace needs its
+ * chosen color baked into a `linear-gradient(...)` and a `box-shadow` string
+ * at spawn time, and `var(--sigil-1)` inside those strings would pin every
+ * trace to the same runtime value instead of capturing the per-trace pick.
+ * If the tokens in `globals.css` change, update this array in lockstep.
+ */
+export const SIGIL_PALETTE = [
+  '#F4A261',
+  '#E76F51',
+  '#E9C46A',
+  '#D9A441',
+  '#8AB4B8',
+  '#5E8B95',
+  '#6A7BA2',
+  '#B08CA8',
+  '#D4846F',
+] as const;
+
+/** Exported type for the palette entries — a string-literal union of hex colors. */
+export type SigilPaletteColor = (typeof SIGIL_PALETTE)[number];

--- a/apps/web/src/components/data-sources/data-sources-page-client.tsx
+++ b/apps/web/src/components/data-sources/data-sources-page-client.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useState } from 'react';
+import { LightboardLoader } from '../brand';
 import { AddDataSourceForm } from './add-data-source-form';
 import { DataSourceList, type DataSourceRecord } from './data-source-list';
 import { SchemaBrowser } from './schema-browser';
@@ -9,6 +11,7 @@ type View = 'list' | 'add' | 'schema';
 
 /** Client-side Data Sources management page with API persistence. */
 export function DataSourcesPageClient() {
+  const t = useTranslations('dataSources');
   const [view, setView] = useState<View>('list');
   const [sources, setSources] = useState<DataSourceRecord[]>([]);
   const [browsingSourceId, setBrowsingSourceId] = useState<string | null>(null);
@@ -116,8 +119,9 @@ export function DataSourcesPageClient() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading...</p>
+      <div className="flex flex-col items-center justify-center gap-3 py-20">
+        <LightboardLoader size={48} />
+        <p className="text-sm text-muted-foreground">{t('loadingSources')}</p>
       </div>
     );
   }

--- a/apps/web/src/components/data-sources/schema-browser.tsx
+++ b/apps/web/src/components/data-sources/schema-browser.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
+import { LightboardLoader } from '../brand';
 
 /** Column info for schema browser. */
 interface ColumnInfo {
@@ -55,9 +56,10 @@ export function SchemaBrowser({ tables, onClose, sourceName, loading }: SchemaBr
       </div>
 
       {loading ? (
-        <p className="animate-pulse text-sm text-muted-foreground">
-          Loading schema...
-        </p>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <LightboardLoader size={14} />
+          <span>{t('loadingSchema')}</span>
+        </div>
       ) : tables.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           {t('noTables')}

--- a/apps/web/src/components/explore/schema-curation-panel.tsx
+++ b/apps/web/src/components/explore/schema-curation-panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
+import { LightboardLoader } from '../brand';
 
 /** Props for the SchemaCurationPanel component. */
 interface SchemaCurationPanelProps {
@@ -75,8 +76,10 @@ export function SchemaCurationPanel({
   if (phase === 'generating') {
     return (
       <div className="flex h-full items-center justify-center">
-        <div className="text-center">
-          <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" style={{ borderColor: 'var(--color-muted-foreground)', borderTopColor: 'transparent' }} />
+        <div className="flex flex-col items-center text-center">
+          <div className="mb-4">
+            <LightboardLoader size={48} />
+          </div>
           <p className="text-sm font-medium" style={{ color: 'var(--color-foreground)' }}>
             {t('schemaGenerating')}
           </p>

--- a/apps/web/src/components/view-renderer/html-view-renderer.tsx
+++ b/apps/web/src/components/view-renderer/html-view-renderer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRef, useEffect, useState } from 'react';
+import { LightboardLoader } from '../brand';
 
 /** An HTML view produced by the agent — rendered in a sandboxed iframe. */
 export interface HtmlView {
@@ -66,7 +67,7 @@ export function HtmlViewRenderer({ view, isLoading }: HtmlViewRendererProps) {
       <div className="relative flex-1 overflow-hidden">
         {isLoading && (
           <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/50">
-            <div className="h-8 w-8 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+            <LightboardLoader size={48} />
           </div>
         )}
         <iframe

--- a/apps/web/src/components/view-renderer/view-renderer.tsx
+++ b/apps/web/src/components/view-renderer/view-renderer.tsx
@@ -7,6 +7,7 @@ import {
 } from '@lightboard/viz-core';
 import { useTranslations } from 'next-intl';
 import { useCallback, useMemo, useState } from 'react';
+import { LightboardLoader } from '../brand';
 import { ControlBar } from './controls/control-bar';
 
 /** Props for the ViewRenderer component. */
@@ -104,10 +105,9 @@ export function ViewRenderer({
       {/* Chart area */}
       <div className="flex-1 relative">
         {isLoading && !data && (
-          <div className="absolute inset-0 flex items-center justify-center bg-muted/50">
-            <div className="animate-pulse text-sm text-muted-foreground">
-              {t('loading')}
-            </div>
+          <div className="absolute inset-0 flex items-center justify-center gap-2 bg-muted/50">
+            <LightboardLoader size={14} />
+            <span className="text-sm text-muted-foreground">{t('loading')}</span>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

One loader everywhere. Ports the login-page rainbow-beam visual language
(PR #93) into a general-purpose `<LightboardLoader>`, swaps every utility
loading surface in the app to it, and extracts the shared sigil palette
so both `grid-backdrop` and the loader read from one source module.

Before PR 10 the app carried 7 unrelated loading treatments — an auth
SVG spinner, two `animate-spin` border rings, two `animate-pulse` text
placeholders, and a plain "Loading…" paragraph — none of which matched
the brand motion already on `/login`. After: one component, five sizes,
every surface aligned.

## New files

- `apps/web/src/components/brand/lightboard-loader.tsx` — rAF beam
  loader. Auto-scales thickness / glow radius / beam count to the
  shorter axis. Props: `size` (default 48) or `width` / `height`,
  optional `beams`, `speed`, `style`, `className`, `ariaLabel`.
- `apps/web/src/components/brand/sigil-palette.ts` — shared
  `SIGIL_PALETTE` array. De-dup target for `grid-backdrop.tsx`'s
  previous local `TRACE_COLORS` copy. Palette is duplicated verbatim
  from `--sigil-1..10` tokens because `var()` inside a
  `linear-gradient(...)` pins every trace to the same runtime value
  instead of capturing the per-spawn pick.
- `apps/web/src/components/brand/__tests__/lightboard-loader.test.tsx`
  — 6 tests covering role/aria-label, size → width/height default,
  explicit width/height override, and reduced-motion skipping rAF.

## Swap matrix

| Surface | File | Size | Replaces |
|---|---|---|---|
| Login submit button | `auth/submit-button.tsx` | **12px** | `<SpinnerIcon />` (12px SVG, now removed) |
| View-renderer query fallback | `view-renderer/view-renderer.tsx` | **14px** + `t('loading')` | `animate-pulse` "Loading…" text |
| Schema browser | `data-sources/schema-browser.tsx` | **14px** + `t('loadingSchema')` | `animate-pulse` "Loading schema…" text |
| HTML iframe boot | `view-renderer/html-view-renderer.tsx` | **48px** | `h-8 w-8` `animate-spin` border ring |
| Schema curation generating | `explore/schema-curation-panel.tsx` | **48px** | `h-8 w-8` `animate-spin` border ring |
| Data-sources initial load | `data-sources/data-sources-page-client.tsx` | **48px** + `t('loadingSources')` | plain `"Loading..."` paragraph |

Removed alongside: the `SpinnerIcon` export from `auth/field-icons.tsx`,
the `.spinner` class + `lb-auth-spin` keyframe + reduced-motion
override in `auth-card.module.css`.

## Reduced-motion fallback

Skipping the rAF loop isn't enough — we still need a visual. Under
`prefers-reduced-motion: reduce` the loader renders a **static rainbow
`#` crosshatch**: two horizontal + two vertical beam segments at `S/4`
and `3*S/4` on each axis, one deterministic color each from
`SIGIL_PALETTE[0..3]`, same thickness / glow / border-radius math as
the animated path. Reads as a quiet "rainbow hash" that echoes both
the animated beams and the `#` glyph — the same "no rAF" approach
`SigilLoader` already takes.

## Preserved (intentionally)

- `brand/sigil-loader.tsx` + `/dev/sigil` showcase — an internal demo
  of the sigil itself, not a utility loading state.
- `explore/agent-message.tsx` streaming cursor — typing cursor, not a
  loader.
- `explore/composer.tsx` stop button — abort control, not a loader.

## Test plan

- [x] `pnpm typecheck` — clean across all 9 packages
- [x] `pnpm --filter @lightboard/web lint` — "No ESLint warnings or errors"
- [x] `pnpm test` — 123 web tests pass (includes 6 new loader tests);
      full monorepo 270+ tests pass
- [x] Browser-tested in a headless Chromium run on
      `http://localhost:3002`; screenshots saved to `.claude/`:
  - `pr10-loader-login-backdrop.png` — `/login` still animates
    (palette dedup is behavior-preserving)
  - `pr10-loader-submit-button.png` — 12px loader + "Signing in…" on
    the amber data-sent button
  - `pr10-loader-data-sources-initial.png` — 48px centered loader +
    "Loading data sources…"
  - `pr10-loader-schema-browser.png` — 14px inline loader + "Loading
    schema…" in the schema browser header
  - `pr10-loader-reduced-motion.png` — static rainbow `#` crosshatch
    rendered under `prefers-reduced-motion: reduce`
  - `pr10-loader-dev-sigil-untouched.png` — `/dev/sigil` showcase still
    renders the old `SigilLoader`, unchanged
- [x] Not runtime-verified but covered by code review: 48px loader in
      the HTML iframe boot + 48px in schema-curation generating (both
      use the same swap pattern as data-sources initial). The
      view-renderer 14px fallback is the same swap as schema-browser.
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)