### PR TITLE
fix(db): put migrations on proper drizzle-kit migrate footing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,3 +148,32 @@ docker compose -f docker-compose.prod.yml up  # Production single-node
 lightboard plugin pack <name>        # Create .tar.gz on connected machine
 # Copy to /plugins directory, restart or POST /api/admin/plugins/reload
 ```
+
+## Running migrations
+
+Schema changes ship as journaled migrations under `packages/db/drizzle/`.
+`pnpm --filter @lightboard/db db:migrate` is the one true way to evolve
+the schema — `drizzle-kit push` is only for ad-hoc local experimentation
+and must not be used for real schema changes.
+
+```bash
+# Fresh DB (no tables yet) — just migrate.
+pnpm --filter @lightboard/db db:migrate
+
+# Existing dev DB that was last seeded with `drizzle-kit push` (before the
+# journal existed): run bootstrap once to backfill drizzle's tracking
+# table, then migrate as usual.
+pnpm --filter @lightboard/db db:bootstrap
+pnpm --filter @lightboard/db db:migrate
+
+# Add a new migration after editing packages/db/src/schema/*.ts:
+pnpm --filter @lightboard/db db:generate  # produces next NNNN_*.sql + journal entry
+pnpm --filter @lightboard/db db:migrate
+```
+
+`db:bootstrap` is idempotent and safe to run even when not needed — it
+detects which migrations the live DB has already satisfied, closes any
+drizzle-kit-push gaps (missing `telemetry.telemetry_events`, missing
+`model_configs` / `agent_role_assignments`), and inserts matching rows
+into `drizzle.__drizzle_migrations` so the subsequent `db:migrate` call
+skips what's already applied.

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ docker compose up -d
 # Copy environment variables
 cp .env.example apps/web/.env.local
 
-# Push database schema
-pnpm --filter @lightboard/db db:push
+# Apply database migrations
+pnpm --filter @lightboard/db db:migrate
 
 # Seed demo data (optional)
 pnpm --filter @lightboard/db db:seed
@@ -92,11 +92,12 @@ pnpm format       # Auto-format all files
 ### Per-package commands
 
 ```bash
-pnpm --filter @lightboard/web dev         # Web app only
-pnpm --filter @lightboard/db db:push      # Push schema to DB
-pnpm --filter @lightboard/db db:generate  # Generate migrations
-pnpm --filter @lightboard/db db:seed      # Seed demo data
-pnpm --filter @lightboard/db db:studio    # Open Drizzle Studio
+pnpm --filter @lightboard/web dev            # Web app only
+pnpm --filter @lightboard/db db:migrate      # Apply pending migrations
+pnpm --filter @lightboard/db db:bootstrap    # Backfill tracking for DBs seeded by the old db:push flow
+pnpm --filter @lightboard/db db:generate     # Generate migration from schema changes
+pnpm --filter @lightboard/db db:seed         # Seed demo data
+pnpm --filter @lightboard/db db:studio       # Open Drizzle Studio
 ```
 
 ## Multi-tenancy

--- a/packages/db/drizzle/0000_initial_schema.sql
+++ b/packages/db/drizzle/0000_initial_schema.sql
@@ -1,0 +1,100 @@
+CREATE SCHEMA IF NOT EXISTS "telemetry";--> statement-breakpoint
+CREATE TYPE "public"."data_source_type" AS ENUM('postgres', 'mysql', 'clickhouse', 'rest', 'csv', 'prometheus', 'elasticsearch');--> statement-breakpoint
+CREATE TYPE "public"."user_role" AS ENUM('admin', 'editor', 'viewer');--> statement-breakpoint
+CREATE TYPE "public"."visibility" AS ENUM('private', 'org', 'public');--> statement-breakpoint
+CREATE TABLE "agent_role_assignments" (
+	"org_id" uuid NOT NULL,
+	"role" text NOT NULL,
+	"model_config_id" uuid NOT NULL,
+	CONSTRAINT "agent_role_assignments_org_id_role_pk" PRIMARY KEY("org_id","role")
+);
+--> statement-breakpoint
+CREATE TABLE "data_sources" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"type" "data_source_type" NOT NULL,
+	"config" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"credentials" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "model_configs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"provider" text NOT NULL,
+	"model" text NOT NULL,
+	"base_url" text,
+	"encrypted_api_key" text NOT NULL,
+	"temperature" numeric(3, 2),
+	"max_tokens" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "organizations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"settings" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"ai_credentials" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "organizations_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "sessions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" uuid NOT NULL,
+	"org_id" uuid NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "telemetry"."telemetry_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid,
+	"event_type" text NOT NULL,
+	"payload" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"email" text NOT NULL,
+	"name" text NOT NULL,
+	"password_hash" text NOT NULL,
+	"role" "user_role" DEFAULT 'viewer' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "users_org_email_unique" UNIQUE("org_id","email")
+);
+--> statement-breakpoint
+CREATE TABLE "views" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"created_by" uuid NOT NULL,
+	"name" text NOT NULL,
+	"spec" jsonb NOT NULL,
+	"version" integer DEFAULT 1 NOT NULL,
+	"visibility" "visibility" DEFAULT 'private' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "agent_role_assignments" ADD CONSTRAINT "agent_role_assignments_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "agent_role_assignments" ADD CONSTRAINT "agent_role_assignments_model_config_id_model_configs_id_fk" FOREIGN KEY ("model_config_id") REFERENCES "public"."model_configs"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "data_sources" ADD CONSTRAINT "data_sources_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "model_configs" ADD CONSTRAINT "model_configs_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "views" ADD CONSTRAINT "views_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "views" ADD CONSTRAINT "views_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "data_sources_org_id_idx" ON "data_sources" USING btree ("org_id");--> statement-breakpoint
+CREATE INDEX "model_configs_org_id_idx" ON "model_configs" USING btree ("org_id");--> statement-breakpoint
+CREATE INDEX "sessions_user_id_idx" ON "sessions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "telemetry_events_org_type_time_idx" ON "telemetry"."telemetry_events" USING btree ("org_id","event_type","created_at");--> statement-breakpoint
+CREATE INDEX "views_org_created_by_idx" ON "views" USING btree ("org_id","created_by");

--- a/packages/db/drizzle/0001_enable_rls.sql
+++ b/packages/db/drizzle/0001_enable_rls.sql
@@ -1,44 +1,49 @@
--- Enable Row Level Security on all tables with org_id
--- This migration must be run after the initial schema migration
+-- Enable Row Level Security on all tables with org_id.
+--
+-- RLS policies gate every row by the session variable `app.current_org_id`,
+-- which the API middleware sets on every request for the app-role pool. The
+-- admin-role pool (used by login/register/bootstrap) bypasses RLS because it
+-- does not match the `FORCE ROW LEVEL SECURITY` condition — ordinary table
+-- owners are not affected by policies.
 
 -- Organizations: filter on id (not org_id)
-ALTER TABLE organizations ENABLE ROW LEVEL SECURITY;
-CREATE POLICY organizations_tenant_isolation ON organizations
-  USING (id = current_setting('app.current_org_id', true)::uuid);
-CREATE POLICY organizations_tenant_insert ON organizations
-  FOR INSERT WITH CHECK (id = current_setting('app.current_org_id', true)::uuid);
+ALTER TABLE "organizations" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "organizations_tenant_isolation" ON "organizations"
+  USING (id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
+CREATE POLICY "organizations_tenant_insert" ON "organizations"
+  FOR INSERT WITH CHECK (id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
 
 -- Users
-ALTER TABLE users ENABLE ROW LEVEL SECURITY;
-CREATE POLICY users_tenant_isolation ON users
-  USING (org_id = current_setting('app.current_org_id', true)::uuid);
-CREATE POLICY users_tenant_insert ON users
-  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+ALTER TABLE "users" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "users_tenant_isolation" ON "users"
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
+CREATE POLICY "users_tenant_insert" ON "users"
+  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
 
 -- Sessions
-ALTER TABLE sessions ENABLE ROW LEVEL SECURITY;
-CREATE POLICY sessions_tenant_isolation ON sessions
-  USING (org_id = current_setting('app.current_org_id', true)::uuid);
-CREATE POLICY sessions_tenant_insert ON sessions
-  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+ALTER TABLE "sessions" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "sessions_tenant_isolation" ON "sessions"
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
+CREATE POLICY "sessions_tenant_insert" ON "sessions"
+  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
 
 -- Data Sources
-ALTER TABLE data_sources ENABLE ROW LEVEL SECURITY;
-CREATE POLICY data_sources_tenant_isolation ON data_sources
-  USING (org_id = current_setting('app.current_org_id', true)::uuid);
-CREATE POLICY data_sources_tenant_insert ON data_sources
-  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+ALTER TABLE "data_sources" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "data_sources_tenant_isolation" ON "data_sources"
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
+CREATE POLICY "data_sources_tenant_insert" ON "data_sources"
+  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
 
 -- Views
-ALTER TABLE views ENABLE ROW LEVEL SECURITY;
-CREATE POLICY views_tenant_isolation ON views
-  USING (org_id = current_setting('app.current_org_id', true)::uuid);
-CREATE POLICY views_tenant_insert ON views
-  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+ALTER TABLE "views" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "views_tenant_isolation" ON "views"
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
+CREATE POLICY "views_tenant_insert" ON "views"
+  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
 
 -- Telemetry Events (in telemetry schema)
-ALTER TABLE telemetry.telemetry_events ENABLE ROW LEVEL SECURITY;
-CREATE POLICY telemetry_events_tenant_isolation ON telemetry.telemetry_events
-  USING (org_id = current_setting('app.current_org_id', true)::uuid);
-CREATE POLICY telemetry_events_tenant_insert ON telemetry.telemetry_events
+ALTER TABLE "telemetry"."telemetry_events" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "telemetry_events_tenant_isolation" ON "telemetry"."telemetry_events"
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
+CREATE POLICY "telemetry_events_tenant_insert" ON "telemetry"."telemetry_events"
   FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);

--- a/packages/db/drizzle/0002_model_configs_rls_and_backfill.sql
+++ b/packages/db/drizzle/0002_model_configs_rls_and_backfill.sql
@@ -1,7 +1,6 @@
--- Multi-config LLM routing: model_configs + agent_role_assignments tables.
+-- Multi-config LLM routing: RLS + backfill for model_configs and
+-- agent_role_assignments (tables themselves are created in 0000).
 --
--- The tables themselves are created by `drizzle-kit push` from the schema
--- files under packages/db/src/schema/{model-configs,agent-role-assignments}.ts.
 -- This migration layers on the org-scoped RLS policies plus a one-time
 -- backfill that turns each org's pre-existing `organizations.ai_credentials`
 -- blob into a "Default" model config routed to all four agent roles.
@@ -10,17 +9,17 @@
 -- RLS — both new tables are org-scoped. Follow the pattern from 0001.
 -- ---------------------------------------------------------------------------
 
-ALTER TABLE model_configs ENABLE ROW LEVEL SECURITY;
-CREATE POLICY model_configs_tenant_isolation ON model_configs
-  USING (org_id = current_setting('app.current_org_id', true)::uuid);
-CREATE POLICY model_configs_tenant_insert ON model_configs
-  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+ALTER TABLE "model_configs" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "model_configs_tenant_isolation" ON "model_configs"
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
+CREATE POLICY "model_configs_tenant_insert" ON "model_configs"
+  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
 
-ALTER TABLE agent_role_assignments ENABLE ROW LEVEL SECURITY;
-CREATE POLICY agent_role_assignments_tenant_isolation ON agent_role_assignments
-  USING (org_id = current_setting('app.current_org_id', true)::uuid);
-CREATE POLICY agent_role_assignments_tenant_insert ON agent_role_assignments
-  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+ALTER TABLE "agent_role_assignments" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "agent_role_assignments_tenant_isolation" ON "agent_role_assignments"
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
+CREATE POLICY "agent_role_assignments_tenant_insert" ON "agent_role_assignments"
+  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
 
 -- ---------------------------------------------------------------------------
 -- Backfill — for every org with existing ai_credentials, create a Default

--- a/packages/db/drizzle/meta/0000_snapshot.json
+++ b/packages/db/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,757 @@
+{
+  "id": "4c0f26ea-13b0-4116-af7b-5b91c6f0298c",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_role_assignments": {
+      "name": "agent_role_assignments",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_config_id": {
+          "name": "model_config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_role_assignments_org_id_organizations_id_fk": {
+          "name": "agent_role_assignments_org_id_organizations_id_fk",
+          "tableFrom": "agent_role_assignments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_role_assignments_model_config_id_model_configs_id_fk": {
+          "name": "agent_role_assignments_model_config_id_model_configs_id_fk",
+          "tableFrom": "agent_role_assignments",
+          "tableTo": "model_configs",
+          "columnsFrom": [
+            "model_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_role_assignments_org_id_role_pk": {
+          "name": "agent_role_assignments_org_id_role_pk",
+          "columns": [
+            "org_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_sources": {
+      "name": "data_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "data_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_sources_org_id_idx": {
+          "name": "data_sources_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_sources_org_id_organizations_id_fk": {
+          "name": "data_sources_org_id_organizations_id_fk",
+          "tableFrom": "data_sources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_configs": {
+      "name": "model_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_configs_org_id_idx": {
+          "name": "model_configs_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_configs_org_id_organizations_id_fk": {
+          "name": "model_configs_org_id_organizations_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ai_credentials": {
+          "name": "ai_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_org_id_organizations_id_fk": {
+          "name": "sessions_org_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "telemetry.telemetry_events": {
+      "name": "telemetry_events",
+      "schema": "telemetry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telemetry_events_org_type_time_idx": {
+          "name": "telemetry_events_org_type_time_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_org_id_organizations_id_fk": {
+          "name": "users_org_id_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_org_email_unique": {
+          "name": "users_org_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.views": {
+      "name": "views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "views_org_created_by_idx": {
+          "name": "views_org_created_by_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "views_org_id_organizations_id_fk": {
+          "name": "views_org_id_organizations_id_fk",
+          "tableFrom": "views",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "views_created_by_users_id_fk": {
+          "name": "views_created_by_users_id_fk",
+          "tableFrom": "views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.data_source_type": {
+      "name": "data_source_type",
+      "schema": "public",
+      "values": [
+        "postgres",
+        "mysql",
+        "clickhouse",
+        "rest",
+        "csv",
+        "prometheus",
+        "elasticsearch"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "editor",
+        "viewer"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "org",
+        "public"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/0001_snapshot.json
+++ b/packages/db/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,757 @@
+{
+  "id": "c3be62d8-715e-4eb4-84df-65dfc7c6e9b1",
+  "prevId": "4c0f26ea-13b0-4116-af7b-5b91c6f0298c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_role_assignments": {
+      "name": "agent_role_assignments",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_config_id": {
+          "name": "model_config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_role_assignments_org_id_organizations_id_fk": {
+          "name": "agent_role_assignments_org_id_organizations_id_fk",
+          "tableFrom": "agent_role_assignments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_role_assignments_model_config_id_model_configs_id_fk": {
+          "name": "agent_role_assignments_model_config_id_model_configs_id_fk",
+          "tableFrom": "agent_role_assignments",
+          "tableTo": "model_configs",
+          "columnsFrom": [
+            "model_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_role_assignments_org_id_role_pk": {
+          "name": "agent_role_assignments_org_id_role_pk",
+          "columns": [
+            "org_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_sources": {
+      "name": "data_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "data_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_sources_org_id_idx": {
+          "name": "data_sources_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_sources_org_id_organizations_id_fk": {
+          "name": "data_sources_org_id_organizations_id_fk",
+          "tableFrom": "data_sources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_configs": {
+      "name": "model_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_configs_org_id_idx": {
+          "name": "model_configs_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_configs_org_id_organizations_id_fk": {
+          "name": "model_configs_org_id_organizations_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ai_credentials": {
+          "name": "ai_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_org_id_organizations_id_fk": {
+          "name": "sessions_org_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "telemetry.telemetry_events": {
+      "name": "telemetry_events",
+      "schema": "telemetry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telemetry_events_org_type_time_idx": {
+          "name": "telemetry_events_org_type_time_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_org_id_organizations_id_fk": {
+          "name": "users_org_id_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_org_email_unique": {
+          "name": "users_org_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.views": {
+      "name": "views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "views_org_created_by_idx": {
+          "name": "views_org_created_by_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "views_org_id_organizations_id_fk": {
+          "name": "views_org_id_organizations_id_fk",
+          "tableFrom": "views",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "views_created_by_users_id_fk": {
+          "name": "views_created_by_users_id_fk",
+          "tableFrom": "views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.data_source_type": {
+      "name": "data_source_type",
+      "schema": "public",
+      "values": [
+        "postgres",
+        "mysql",
+        "clickhouse",
+        "rest",
+        "csv",
+        "prometheus",
+        "elasticsearch"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "editor",
+        "viewer"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "org",
+        "public"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,757 @@
+{
+  "id": "f5be42c2-7a15-476f-a5ad-35ba40472561",
+  "prevId": "c3be62d8-715e-4eb4-84df-65dfc7c6e9b1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_role_assignments": {
+      "name": "agent_role_assignments",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_config_id": {
+          "name": "model_config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_role_assignments_org_id_organizations_id_fk": {
+          "name": "agent_role_assignments_org_id_organizations_id_fk",
+          "tableFrom": "agent_role_assignments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_role_assignments_model_config_id_model_configs_id_fk": {
+          "name": "agent_role_assignments_model_config_id_model_configs_id_fk",
+          "tableFrom": "agent_role_assignments",
+          "tableTo": "model_configs",
+          "columnsFrom": [
+            "model_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_role_assignments_org_id_role_pk": {
+          "name": "agent_role_assignments_org_id_role_pk",
+          "columns": [
+            "org_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_sources": {
+      "name": "data_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "data_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_sources_org_id_idx": {
+          "name": "data_sources_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_sources_org_id_organizations_id_fk": {
+          "name": "data_sources_org_id_organizations_id_fk",
+          "tableFrom": "data_sources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_configs": {
+      "name": "model_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_configs_org_id_idx": {
+          "name": "model_configs_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_configs_org_id_organizations_id_fk": {
+          "name": "model_configs_org_id_organizations_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ai_credentials": {
+          "name": "ai_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_org_id_organizations_id_fk": {
+          "name": "sessions_org_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "telemetry.telemetry_events": {
+      "name": "telemetry_events",
+      "schema": "telemetry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telemetry_events_org_type_time_idx": {
+          "name": "telemetry_events_org_type_time_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_org_id_organizations_id_fk": {
+          "name": "users_org_id_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_org_email_unique": {
+          "name": "users_org_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.views": {
+      "name": "views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "views_org_created_by_idx": {
+          "name": "views_org_created_by_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "views_org_id_organizations_id_fk": {
+          "name": "views_org_id_organizations_id_fk",
+          "tableFrom": "views",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "views_created_by_users_id_fk": {
+          "name": "views_created_by_users_id_fk",
+          "tableFrom": "views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.data_source_type": {
+      "name": "data_source_type",
+      "schema": "public",
+      "values": [
+        "postgres",
+        "mysql",
+        "clickhouse",
+        "rest",
+        "csv",
+        "prometheus",
+        "elasticsearch"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "editor",
+        "viewer"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "org",
+        "public"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1,0 +1,27 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1776500000000,
+      "tag": "0000_initial_schema",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776500001000,
+      "tag": "0001_enable_rls",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776500002000,
+      "tag": "0002_model_configs_rls_and_backfill",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "db:bootstrap": "tsx src/bootstrap-migrations.ts",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "db:seed": "tsx src/seed.ts",

--- a/packages/db/src/bootstrap-migrations.ts
+++ b/packages/db/src/bootstrap-migrations.ts
@@ -1,0 +1,353 @@
+import 'dotenv/config';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import pg from 'pg';
+
+/**
+ * Bootstraps drizzle-orm's migration tracking table for a database that was
+ * originally seeded with `drizzle-kit push` (no journal, no tracking rows).
+ *
+ * Historical context: before this fix, `packages/db/drizzle/` was a folder of
+ * hand-written SQL files with no `meta/_journal.json`. The real schema flow
+ * was `drizzle-kit push` + manually running RLS SQL via psql, so the live
+ * dev databases were never recorded in `drizzle.__drizzle_migrations`. With
+ * the journal now in place, running `db:migrate` against one of those
+ * databases would try to re-CREATE TABLE organizations and fail.
+ *
+ * This script introspects the live DB, decides which of the current
+ * migrations are logically already applied (based on the presence of the
+ * tables + RLS policies each migration introduces), runs small idempotent
+ * catch-up SQL to fill any gaps (e.g. a missing telemetry_events table when
+ * the rest of 0000 clearly ran), and then inserts matching rows into
+ * `drizzle.__drizzle_migrations` so that a subsequent `pnpm db:migrate`
+ * skips the ones we marked and only applies what's truly new.
+ *
+ * Fresh databases (no tables yet) should skip this script entirely and just
+ * run `pnpm db:migrate`. Running this against a fresh DB is safe — it just
+ * creates the tracking table and inserts no rows.
+ *
+ * Idempotent: running twice does nothing. Hashes are computed exactly the
+ * same way `drizzle-orm/node-postgres/migrator` computes them (sha256 of
+ * the raw migration file content), and `created_at` values match the
+ * `when` field in `meta/_journal.json` so the migrator's "is this applied"
+ * check (`lastDbMigration.created_at < migration.folderMillis`) works.
+ */
+
+type JournalEntry = {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+};
+
+type Journal = {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+};
+
+type MigrationFile = {
+  entry: JournalEntry;
+  hash: string;
+};
+
+const MIGRATIONS_SCHEMA = 'drizzle';
+const MIGRATIONS_TABLE = '__drizzle_migrations';
+
+const thisFile = fileURLToPath(import.meta.url);
+const pkgRoot = path.resolve(path.dirname(thisFile), '..');
+const migrationsDir = path.resolve(pkgRoot, 'drizzle');
+
+/** Reads the journal + each migration's file content and returns hashes. */
+function loadMigrations(): MigrationFile[] {
+  const journalPath = path.join(migrationsDir, 'meta', '_journal.json');
+  if (!fs.existsSync(journalPath)) {
+    throw new Error(`Journal not found at ${journalPath}`);
+  }
+  const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as Journal;
+  return journal.entries.map((entry) => {
+    const sqlPath = path.join(migrationsDir, `${entry.tag}.sql`);
+    const sql = fs.readFileSync(sqlPath, 'utf8');
+    const hash = crypto.createHash('sha256').update(sql).digest('hex');
+    return { entry, hash };
+  });
+}
+
+/**
+ * Returns true if a fully-qualified table exists.
+ * Used as a proxy for whether migrations have (partially) been applied.
+ */
+async function tableExists(
+  client: pg.PoolClient,
+  schema: string,
+  name: string,
+): Promise<boolean> {
+  const result = await client.query(
+    `SELECT to_regclass($1) AS oid`,
+    [`${schema}.${name}`],
+  );
+  return result.rows[0]?.oid !== null;
+}
+
+/**
+ * Returns true if the named RLS policy exists on the named table.
+ * Used as a proxy for whether migrations 0001 / 0002 have been applied.
+ */
+async function policyExists(
+  client: pg.PoolClient,
+  schema: string,
+  table: string,
+  policy: string,
+): Promise<boolean> {
+  const result = await client.query(
+    `SELECT 1
+       FROM pg_policies
+      WHERE schemaname = $1
+        AND tablename = $2
+        AND policyname = $3
+      LIMIT 1`,
+    [schema, table, policy],
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+
+/** Ensures the drizzle tracking schema + table exist. Safe to run repeatedly. */
+async function ensureTrackingTable(client: pg.PoolClient): Promise<void> {
+  await client.query(`CREATE SCHEMA IF NOT EXISTS "${MIGRATIONS_SCHEMA}"`);
+  await client.query(
+    `CREATE TABLE IF NOT EXISTS "${MIGRATIONS_SCHEMA}"."${MIGRATIONS_TABLE}" (
+       id SERIAL PRIMARY KEY,
+       hash text NOT NULL,
+       created_at bigint
+     )`,
+  );
+}
+
+/**
+ * Backfills any pieces of 0000 that past `db:push` runs may have skipped.
+ *
+ * Three known gaps:
+ * 1. The `telemetry` schema is never created by `drizzle-kit push`, so on
+ *    dev DBs bootstrapped without the docker-compose init.sql,
+ *    `telemetry.telemetry_events` is missing. 0001 would then fail at
+ *    `ALTER TABLE telemetry.telemetry_events ENABLE ROW LEVEL SECURITY`.
+ * 2. `model_configs` and `agent_role_assignments` are missing on any DB
+ *    that was last pushed before PR #96. 0002's RLS + backfill assumes
+ *    they exist, so we must create them before marking 0000 applied.
+ *
+ * Everything here uses IF NOT EXISTS and matches the generated 0000 SQL
+ * exactly so it's safe to re-run on a DB that already has all tables.
+ *
+ * Only runs when 0000 is considered applied (organizations exists).
+ * Idempotent.
+ */
+async function reconcile0000Gaps(client: pg.PoolClient): Promise<void> {
+  await client.query(`CREATE SCHEMA IF NOT EXISTS "telemetry"`);
+  if (!(await tableExists(client, 'telemetry', 'telemetry_events'))) {
+    console.log('    reconciling: creating missing telemetry.telemetry_events');
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS "telemetry"."telemetry_events" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+        "org_id" uuid,
+        "event_type" text NOT NULL,
+        "payload" jsonb DEFAULT '{}'::jsonb NOT NULL,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL
+      )
+    `);
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS "telemetry_events_org_type_time_idx"
+        ON "telemetry"."telemetry_events" USING btree ("org_id","event_type","created_at")
+    `);
+  }
+  if (!(await tableExists(client, 'public', 'model_configs'))) {
+    console.log('    reconciling: creating missing public.model_configs');
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS "model_configs" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+        "org_id" uuid NOT NULL,
+        "name" text NOT NULL,
+        "provider" text NOT NULL,
+        "model" text NOT NULL,
+        "base_url" text,
+        "encrypted_api_key" text NOT NULL,
+        "temperature" numeric(3, 2),
+        "max_tokens" integer,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+      )
+    `);
+    await client.query(`
+      ALTER TABLE "model_configs"
+        DROP CONSTRAINT IF EXISTS "model_configs_org_id_organizations_id_fk"
+    `);
+    await client.query(`
+      ALTER TABLE "model_configs"
+        ADD CONSTRAINT "model_configs_org_id_organizations_id_fk"
+        FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id")
+        ON DELETE cascade ON UPDATE no action
+    `);
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS "model_configs_org_id_idx"
+        ON "model_configs" USING btree ("org_id")
+    `);
+  }
+  if (!(await tableExists(client, 'public', 'agent_role_assignments'))) {
+    console.log('    reconciling: creating missing public.agent_role_assignments');
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS "agent_role_assignments" (
+        "org_id" uuid NOT NULL,
+        "role" text NOT NULL,
+        "model_config_id" uuid NOT NULL,
+        CONSTRAINT "agent_role_assignments_org_id_role_pk" PRIMARY KEY("org_id","role")
+      )
+    `);
+    await client.query(`
+      ALTER TABLE "agent_role_assignments"
+        DROP CONSTRAINT IF EXISTS "agent_role_assignments_org_id_organizations_id_fk"
+    `);
+    await client.query(`
+      ALTER TABLE "agent_role_assignments"
+        ADD CONSTRAINT "agent_role_assignments_org_id_organizations_id_fk"
+        FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id")
+        ON DELETE cascade ON UPDATE no action
+    `);
+    await client.query(`
+      ALTER TABLE "agent_role_assignments"
+        DROP CONSTRAINT IF EXISTS "agent_role_assignments_model_config_id_model_configs_id_fk"
+    `);
+    await client.query(`
+      ALTER TABLE "agent_role_assignments"
+        ADD CONSTRAINT "agent_role_assignments_model_config_id_model_configs_id_fk"
+        FOREIGN KEY ("model_config_id") REFERENCES "public"."model_configs"("id")
+        ON DELETE restrict ON UPDATE no action
+    `);
+  }
+}
+
+/**
+ * Inserts a tracking row for a migration if one does not already exist for
+ * the given `created_at` timestamp. Idempotent.
+ */
+async function markApplied(
+  client: pg.PoolClient,
+  migration: MigrationFile,
+): Promise<'inserted' | 'already-present'> {
+  const existing = await client.query(
+    `SELECT id FROM "${MIGRATIONS_SCHEMA}"."${MIGRATIONS_TABLE}" WHERE created_at = $1 LIMIT 1`,
+    [migration.entry.when],
+  );
+  if ((existing.rowCount ?? 0) > 0) {
+    return 'already-present';
+  }
+  await client.query(
+    `INSERT INTO "${MIGRATIONS_SCHEMA}"."${MIGRATIONS_TABLE}" (hash, created_at) VALUES ($1, $2)`,
+    [migration.hash, migration.entry.when],
+  );
+  return 'inserted';
+}
+
+/**
+ * Decides whether a migration should be considered already applied on this DB.
+ * The check is tag-based rather than positional because the introspection
+ * signal is specific to what each migration creates.
+ *
+ * Note: 0001 (RLS) is only marked applied when a canonical policy exists.
+ * Many dev DBs that ran `db:push` never ran the hand-written RLS SQL, so
+ * bootstrap correctly lets db:migrate run 0001 for them.
+ */
+async function shouldMarkApplied(
+  client: pg.PoolClient,
+  tag: string,
+): Promise<boolean> {
+  switch (tag) {
+    case '0000_initial_schema':
+      // The initial schema created organizations among other things;
+      // organizations is the cleanest single signal.
+      return await tableExists(client, 'public', 'organizations');
+    case '0001_enable_rls': {
+      // RLS migration's signature is the organizations_tenant_isolation
+      // policy. If absent, let db:migrate apply the migration itself.
+      return await policyExists(
+        client,
+        'public',
+        'organizations',
+        'organizations_tenant_isolation',
+      );
+    }
+    case '0002_model_configs_rls_and_backfill':
+      // Mark applied only if BOTH the table exists AND its RLS policy is
+      // in place. Otherwise let db:migrate run it — its RLS + backfill
+      // block are safe on an empty table.
+      if (!(await tableExists(client, 'public', 'model_configs'))) return false;
+      return await policyExists(
+        client,
+        'public',
+        'model_configs',
+        'model_configs_tenant_isolation',
+      );
+    default:
+      return false;
+  }
+}
+
+/** Runs bootstrap end-to-end. */
+async function main(): Promise<void> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error('DATABASE_URL is not set');
+  }
+
+  const migrations = loadMigrations();
+  console.log(`Loaded ${migrations.length} migrations from ${migrationsDir}`);
+
+  const pool = new pg.Pool({ connectionString });
+  const client = await pool.connect();
+  try {
+    await ensureTrackingTable(client);
+
+    let insertedCount = 0;
+    let skippedCount = 0;
+    let notApplicableCount = 0;
+
+    for (const migration of migrations) {
+      const { tag } = migration.entry;
+      const applied = await shouldMarkApplied(client, tag);
+      if (!applied) {
+        console.log(`  [ ] ${tag} — not applied to this DB; db:migrate will run it`);
+        notApplicableCount++;
+        continue;
+      }
+      // When marking 0000 as applied, first close any gaps that `db:push`
+      // leaves behind so subsequent migrations don't trip over a missing
+      // telemetry.telemetry_events.
+      if (tag === '0000_initial_schema') {
+        await reconcile0000Gaps(client);
+      }
+      const result = await markApplied(client, migration);
+      if (result === 'inserted') {
+        console.log(`  [✓] ${tag} — marked as applied (hash ${migration.hash.slice(0, 12)}…)`);
+        insertedCount++;
+      } else {
+        console.log(`  [·] ${tag} — already tracked, leaving as-is`);
+        skippedCount++;
+      }
+    }
+
+    console.log(
+      `\nBootstrap complete: ${insertedCount} inserted, ${skippedCount} already tracked, ${notApplicableCount} to apply.`,
+    );
+    console.log('Next step: pnpm --filter @lightboard/db db:migrate');
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Bootstrap failed:', err);
+  process.exit(1);
+});

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,9 @@
     },
     "db:migrate": {
       "cache": false
+    },
+    "db:bootstrap": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## Why this PR

PR #96 (settings v2, merged as `eb980e6`) added `model_configs` and `agent_role_assignments` to the schema and shipped a hand-written `0002_model_configs.sql` that expected `drizzle-kit push` to create the tables first. Any dev who merged the PR without running `db:push` is now hitting `relation "model_configs" does not exist` — which is *also* the state I'm looking at on my own dev DB.

The deeper issue: `packages/db/drizzle/` has only been a folder of hand-written SQL with no `meta/_journal.json`, so `drizzle-kit migrate` (which is what `packages/db/src/migrate.ts` calls) has never worked. The repo's real flow was always `drizzle-kit push` + `psql` the RLS by hand. Time to make `db:migrate` the one true way.

## What's in here

- **Regenerate migrations via `drizzle-kit generate`.** The new `0000_initial_schema.sql` is drizzle-kit's output from the current schema TS files, carrying every `CREATE TABLE` / `CREATE INDEX` / FK. A `CREATE SCHEMA IF NOT EXISTS "telemetry"` is prepended so fresh DBs (without docker's init.sql) still get the telemetry schema. A proper `meta/_journal.json` + `meta/0000_snapshot.json` are now tracked.
- **Keep 0001 (RLS) and 0002 (RLS + ai_credentials backfill) as hand-written follow-on migrations** with matching journal entries + snapshot files. The SQL now uses `--> statement-breakpoint` markers so drizzle's migrator executes each statement individually.
- **New `packages/db/src/bootstrap-migrations.ts` (wired as `pnpm db:bootstrap`).** On a DB already seeded by the old `db:push` flow, it introspects the live state, marks already-applied migrations in `drizzle.__drizzle_migrations`, and — crucially — closes push-leaves-behind gaps before marking 0000 applied (creates missing `telemetry.telemetry_events`, `model_configs`, `agent_role_assignments` with their FKs and indexes using `IF NOT EXISTS`). Fully idempotent. Safe on fresh DBs.
- **Docs updated.** `CLAUDE.md` has a new "Running migrations" section; `README.md` replaces `db:push` with `db:migrate`. The `db:push` script is kept for ad-hoc local experimentation but is no longer the blessed flow.
- **`turbo.json`** registers `db:bootstrap`.

Closes the "relation model_configs does not exist" breakage from PR #96.

## What existing devs need to run

**Read this carefully — this is the whole point of the PR:**

```bash
pnpm --filter @lightboard/db db:bootstrap
pnpm --filter @lightboard/db db:migrate
```

Bootstrap detects that your base tables + policies already exist, inserts tracking rows for 0000 (and 0001 if you have the RLS policies), creates `model_configs` + `agent_role_assignments` + `telemetry.telemetry_events` if they're missing, and then `db:migrate` runs only what you're actually missing (0001 RLS and/or 0002 RLS + backfill). You'll get a `Default` model_config row + 4 agent_role_assignments for every org that had `ai_credentials` set, matching the PR #96 design.

On a fresh DB (no tables), just run `db:migrate` — bootstrap is a no-op.

## Migrations in this PR

| Tag | Type | Notes |
|---|---|---|
| `0000_initial_schema` | CREATE TABLE + CREATE TYPE + FK + INDEX | Generated by `drizzle-kit generate` from the current schema TS. Prepended with `CREATE SCHEMA IF NOT EXISTS "telemetry"`. |
| `0001_enable_rls` | RLS (ENABLE + CREATE POLICY) | Hand-written. Content preserved from the previous `0001_enable_rls.sql` with proper statement breakpoints + quoted identifiers. |
| `0002_model_configs_rls_and_backfill` | RLS + one-time backfill | Hand-written. Content preserved from the previous `0002_model_configs.sql`. Renamed for clarity. |

## Test plan

End-to-end tested against throwaway `postgres:16-alpine` containers on three distinct starting states:

- [x] **Fresh DB** (no tables at all) + `db:migrate` → all 7 public tables + `telemetry.telemetry_events` + 16 RLS policies + 3 rows in `drizzle.__drizzle_migrations`
- [x] **User's simulated state** (5 base tables from `db:push`, no telemetry schema, no RLS, no `model_configs`, 1 org with `ai_credentials`) + `db:bootstrap` + `db:migrate` → bootstrap reconciles the missing tables/schema and marks 0000 applied, migrate runs 0001 (RLS) and 0002 (RLS + backfill), end state has 16 policies and a `Default` model_config routed to all 4 agent roles
- [x] **Idempotency:** re-running `db:bootstrap` and `db:migrate` is a no-op in both cases; row counts are stable
- [x] `pnpm --filter @lightboard/db test` — 8 tests pass
- [x] `pnpm typecheck` — 9 packages clean
- [x] `pnpm --filter @lightboard/web lint` — no warnings or errors
- [x] `pnpm test` — all 134 web + 8 db + agent/viz-core (cached) tests pass

## What NOT in this PR

- The user's own dev DB is not touched from inside this PR. They run `db:bootstrap && db:migrate` themselves after merge.
- No rename/removal of tables, columns, or schemas. The generated 0000 matches the live schema exactly — diffed and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)