### PR TITLE
Tighten agent harness: H3 schema docs, conversation logs, token budgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ docker/cricket-analytics/
 
 # One-off prompt scratch file used during development
 sample_prompt.txt
+
+# Passive conversation-log drop (dev artifact; see packages/agent/src/logging/)
+.agent-logs/

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -196,6 +196,8 @@
       "addDatasource": "+ Add datasource",
       "loading": "Loading data sources…",
       "empty": "No data sources configured yet.",
+      "deleteFailed": "Couldn't delete that data source: {message}",
+      "dismiss": "Dismiss",
       "list": {
         "source": "Source",
         "schemaDoc": "Schema doc",
@@ -253,6 +255,21 @@
         "startBlank": "Start blank",
         "tablesDetected": "{count, plural, =0 {No tables detected} =1 {1 table detected} other {# tables detected}}",
         "guidedDuration": "~15 min guided"
+      },
+      "schemaEditor": {
+        "title": "Schema doc",
+        "description": "Markdown briefing the agent reads before every query against this source. Edit directly or generate a first draft with AI.",
+        "generate": "Generate with AI",
+        "regenerate": "Regenerate with AI",
+        "generating": "Generating…",
+        "save": "Save",
+        "saving": "Saving…",
+        "saved": "Saved",
+        "reset": "Reset",
+        "unsavedChanges": "Unsaved changes",
+        "charCount": "{count, plural, =0 {empty} =1 {1 char} other {# chars}}",
+        "placeholder": "# Your datasource name\n\nOne-paragraph description.\n\n### Tables\n…\n\nClick Generate with AI to draft this automatically.",
+        "confirmRegenerate": "Regenerating will overwrite your current schema doc. Continue?"
       },
       "drawer": {
         "newTitle": "Add datasource",

--- a/apps/web/src/app/api/agent/chat/route.ts
+++ b/apps/web/src/app/api/agent/chat/route.ts
@@ -15,6 +15,9 @@ import {
   ScratchpadManager,
   LLMError,
   generateSchemaContext,
+  ConversationLog,
+  wrapToolContext,
+  defaultLogDir,
   type AgentDataSource,
   type AgentEvent,
   type Message,
@@ -108,8 +111,8 @@ export const POST = withAuth(async (req, { db, orgId }) => {
   }
 
   // Resolve per-role AI providers from org settings or env var fallback
-  const providers = await resolveAIProviders(db, orgId);
-  if (!providers) {
+  const resolved = await resolveAIProviders(db, orgId);
+  if (!resolved) {
     return NextResponse.json(
       {
         error: 'AI agent is not configured. Add a model under Settings → LLM providers or set the ANTHROPIC_API_KEY environment variable.',
@@ -117,6 +120,7 @@ export const POST = withAuth(async (req, { db, orgId }) => {
       { status: 503 },
     );
   }
+  const { providers, maxTokens: maxTokensPerRole } = resolved;
 
   // Load org's data sources with cached schemas
   const orgSources = await db
@@ -195,6 +199,20 @@ export const POST = withAuth(async (req, { db, orgId }) => {
   // Generate or reuse conversation/session ID
   const sessionId = conversationId ?? `conv_${Date.now()}_${crypto.randomUUID().slice(0, 8)}`;
 
+  // Passive conversation log — one JSONL per turn. Advisory; failures never
+  // block the response. Consumed later (eval / past-mistakes curation).
+  const convLog = new ConversationLog({
+    sessionId,
+    orgId,
+    userMessage: message,
+    dataSources: agentDataSources.map((d) => ({ id: d.id, name: d.name, type: d.type })),
+  });
+  convLog.snapshotSchemaDocs(agentDataSources);
+  convLog.push({ t: 'user_message', text: message });
+
+  // Wrap the tool context so SQL + schema calls are recorded with inputs.
+  const loggedToolContext = wrapToolContext(toolContext, convLog);
+
   // Reuse existing LeaderAgent for this session, or create a new one.
   // Leaders persist across turns to keep conversation state in-memory.
   let leader: LeaderAgent;
@@ -202,14 +220,18 @@ export const POST = withAuth(async (req, { db, orgId }) => {
   if (cached) {
     leader = cached.leader;
     cached.lastAccess = Date.now();
+    // Rebind the tool context so this turn's conversation log captures
+    // SQL + schema calls made by the cached leader.
+    leader.setToolContext(loggedToolContext);
   } else {
     leader = new LeaderAgent({
       providers,
-      toolContext,
+      toolContext: loggedToolContext,
       dataSources: agentDataSources,
       scratchpadManager,
       maxToolRounds: 25,
       subAgentMaxRounds: 15,
+      maxTokensPerRole,
     });
 
     // Load conversation history from Redis for cold-start recovery
@@ -229,10 +251,10 @@ export const POST = withAuth(async (req, { db, orgId }) => {
 
   console.log(`[Chat] Mode: ${wantsStream ? 'SSE streaming' : 'JSON'}, session=${sessionId}`);
   if (wantsStream) {
-    return handleStreaming(leader, message, orgId, sessionId, sourcesNeedingBootstrap, adminDb, agentDataSources);
+    return handleStreaming(leader, message, orgId, sessionId, sourcesNeedingBootstrap, adminDb, agentDataSources, convLog);
   }
 
-  return handleNonStreaming(leader, message, orgId, sessionId);
+  return handleNonStreaming(leader, message, orgId, sessionId, convLog);
 });
 
 /**
@@ -243,7 +265,9 @@ async function handleNonStreaming(
   message: string,
   orgId: string,
   sessionId: string,
+  convLog: ConversationLog,
 ): Promise<NextResponse> {
+  let stopReason = 'unknown';
   try {
     // Process with timeout
     const events = await collectWithTimeout(leader.chat(message, sessionId), AGENT_TIMEOUT_MS);
@@ -255,6 +279,7 @@ async function handleNonStreaming(
     let queryResult: Record<string, unknown> | null = null;
 
     for (const event of events) {
+      mirrorAgentEventToLog(event, convLog);
       switch (event.type) {
         case 'text':
           text += event.text;
@@ -296,6 +321,9 @@ async function handleNonStreaming(
           }
           break;
         }
+        case 'done':
+          stopReason = event.stopReason;
+          break;
       }
     }
 
@@ -315,26 +343,44 @@ async function handleNonStreaming(
     });
   } catch (err) {
     if (err instanceof LLMError) {
-      if (err.statusCode === 401) {
+      if (err.reason === 'output_tokens_exceeded') {
         return NextResponse.json(
-          { error: 'Invalid API key. Check your AI model configuration in Settings.' },
+          {
+            error: 'Model hit its output-token ceiling. Raise max_tokens for the affected agent role in Settings → LLM providers.',
+            reason: err.reason,
+          },
+          { status: 400 },
+        );
+      }
+      if (err.reason === 'context_length_exceeded') {
+        return NextResponse.json(
+          {
+            error: 'The request is larger than the model can read. Try a shorter question or trim the schema doc.',
+            reason: err.reason,
+          },
+          { status: 400 },
+        );
+      }
+      if (err.statusCode === 401 || err.reason === 'auth') {
+        return NextResponse.json(
+          { error: 'Invalid API key. Check your AI model configuration in Settings.', reason: err.reason },
           { status: 401 },
         );
       }
-      if (err.statusCode === 429) {
+      if (err.statusCode === 429 || err.reason === 'rate_limited') {
         return NextResponse.json(
-          { error: 'AI service is busy, please retry in a moment.' },
+          { error: 'AI service is busy, please retry in a moment.', reason: err.reason },
           { status: 429 },
         );
       }
-      if (err.statusCode && err.statusCode >= 500) {
+      if ((err.statusCode && err.statusCode >= 500) || err.reason === 'server_error') {
         return NextResponse.json(
-          { error: 'AI service is temporarily unavailable.' },
+          { error: 'AI service is temporarily unavailable.', reason: err.reason },
           { status: 502 },
         );
       }
       return NextResponse.json(
-        { error: `AI provider error: ${err.message}` },
+        { error: `AI provider error: ${err.message}`, reason: err.reason },
         { status: err.statusCode ?? 500 },
       );
     }
@@ -357,6 +403,61 @@ async function handleNonStreaming(
       { error: `Agent error: ${err instanceof Error ? err.message : String(err)}` },
       { status: 500 },
     );
+  } finally {
+    // Fire-and-forget flush so slow disk I/O can't delay the response.
+    void convLog.flush(defaultLogDir(), stopReason);
+  }
+}
+
+/**
+ * Mirror an agent event into the conversation log. Side-by-side with the SSE
+ * wire emission — the log captures what we'd need to debug, not what the UI
+ * renders.
+ */
+function mirrorAgentEventToLog(event: AgentEvent, log: ConversationLog): void {
+  switch (event.type) {
+    case 'text':
+      // Accumulate a short preview per chunk; avoids flooding the log with
+      // per-token events but still shows what the model emitted.
+      log.push({
+        t: 'agent_text',
+        preview: event.text.slice(0, 200),
+        chars: event.text.length,
+      });
+      break;
+    case 'thinking':
+      log.push({ t: 'thinking', text: event.text.slice(0, 500) });
+      break;
+    case 'agent_start':
+      log.push({ t: 'agent_turn_start', agent: event.agent, task: event.task });
+      break;
+    case 'agent_end':
+      log.push({ t: 'agent_turn_end', agent: event.agent, summary: event.summary });
+      break;
+    case 'task_dispatched':
+      log.push({
+        t: 'task_dispatched',
+        task_id: event.taskId,
+        agent: event.agent,
+        instruction: event.instruction,
+      });
+      break;
+    case 'task_complete':
+      log.push({
+        t: 'task_complete',
+        task_id: event.taskId,
+        agent: event.agent,
+        summary: event.summary,
+        is_error: event.isError,
+      });
+      break;
+    case 'task_cancelled':
+      log.push({ t: 'task_cancelled', task_id: event.taskId });
+      break;
+    // tool_start/tool_end already captured by wrapToolContext at execution
+    // boundary; skip here to avoid duplicates.
+    default:
+      break;
   }
 }
 
@@ -371,12 +472,14 @@ function handleStreaming(
   sourcesNeedingBootstrap: Array<{ id: string; name: string; config: unknown }>,
   adminDb: ReturnType<typeof getAdminDb>,
   agentDataSources: AgentDataSource[],
+  convLog: ConversationLog,
 ): Response {
   const encoder = new TextEncoder();
   const abort = new AbortController();
 
   const stream = new ReadableStream({
     async start(controller) {
+      let streamStopReason = 'unknown';
       const enqueue = (event: string, data: Record<string, unknown>) => {
         if (abort.signal.aborted) return;
         try {
@@ -452,6 +555,7 @@ function handleStreaming(
               console.log('[Chat] Agent processing aborted — client disconnected');
               return;
             }
+            mirrorAgentEventToLog(event, convLog);
             switch (event.type) {
               case 'text':
                 enqueue('text', { text: event.text });
@@ -542,6 +646,7 @@ function handleStreaming(
                 const history = leader.getHistory();
                 await saveConversation(orgId, sessionId, history);
                 enqueue('done', { stopReason: event.stopReason, conversationId: sessionId });
+                streamStopReason = event.stopReason;
                 break;
               }
             }
@@ -554,16 +659,43 @@ function handleStreaming(
         await Promise.race([processStream(), abortPromise]);
       } catch (err) {
         if (!abort.signal.aborted) {
-          const errorMessage = err instanceof LLMError
-            ? (err.statusCode === 429 ? 'AI service is busy, please retry.' : 'AI service error.')
-            : (err instanceof Error ? err.message : String(err));
-          enqueue('error', { error: errorMessage });
+          let errorMessage: string;
+          let errorReason: string | undefined;
+          if (err instanceof LLMError) {
+            errorReason = err.reason;
+            switch (err.reason) {
+              case 'output_tokens_exceeded':
+                errorMessage = 'Model hit its output-token ceiling. Raise max_tokens for the affected agent role in Settings → LLM providers.';
+                break;
+              case 'context_length_exceeded':
+                errorMessage = 'The request is larger than the model can read. Try a shorter question or trim the schema doc.';
+                break;
+              case 'auth':
+                errorMessage = 'Invalid API key. Check your AI model configuration in Settings.';
+                break;
+              case 'rate_limited':
+                errorMessage = 'AI service is busy, please retry.';
+                break;
+              case 'server_error':
+                errorMessage = 'AI service is temporarily unavailable.';
+                break;
+              default:
+                errorMessage = err.message || 'AI service error.';
+            }
+          } else {
+            errorMessage = err instanceof Error ? err.message : String(err);
+          }
+          enqueue('error', errorReason ? { error: errorMessage, reason: errorReason } : { error: errorMessage });
+          streamStopReason = errorReason ? `error:${errorReason}` : 'error';
         } else {
           console.log(`[Chat] Stream ended — client disconnected (session=${sessionId})`);
+          streamStopReason = 'client_disconnect';
         }
       } finally {
         clearInterval(heartbeat);
         try { controller.close(); } catch { /* already closed */ }
+        // Fire-and-forget log flush.
+        void convLog.flush(defaultLogDir(), streamStopReason);
       }
     },
     cancel() {

--- a/apps/web/src/app/api/data-sources/[id]/route.ts
+++ b/apps/web/src/app/api/data-sources/[id]/route.ts
@@ -3,9 +3,15 @@ import { eq, and } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth';
 
+/** Extract the `[id]` segment from `/api/data-sources/[id]`. */
+function extractId(req: Request): string | null {
+  const segments = new URL(req.url).pathname.split('/').filter(Boolean);
+  return segments[segments.length - 1] ?? null;
+}
+
 /** DELETE /api/data-sources/[id] — Delete a data source. */
 export const DELETE = withAuth(async (req, { db, orgId }) => {
-  const id = req.nextUrl.pathname.split('/').pop();
+  const id = extractId(req);
   if (!id) {
     return NextResponse.json({ error: 'ID is required' }, { status: 400 });
   }

--- a/apps/web/src/app/api/data-sources/[id]/schema/generate/annotation-prompt.test.ts
+++ b/apps/web/src/app/api/data-sources/[id]/schema/generate/annotation-prompt.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The annotator prompt must instruct the LLM to emit every H3 briefing
+ * section in a fixed order. Downstream tooling (query-hints checker, past-
+ * mistakes injection) depends on these headers being present verbatim.
+ *
+ * We assert the prompt text directly rather than running the LLM — the goal
+ * is to catch accidental regressions in the prompt contract.
+ */
+
+const EXPECTED_HEADERS = [
+  '### Tables',
+  '### Key Join Patterns',
+  '### Useful Enumerations',
+  '### Derived Metrics',
+  '### Semantic Dictionary',
+  '### Implicit Filters',
+  '### Gotchas',
+  '### Example Queries',
+  '### Past Mistakes',
+] as const;
+
+describe('schema annotator prompt contract', () => {
+  it('contains every required H3 section in order', async () => {
+    const mod = await import('./route');
+    // The prompt is a private const; re-read the source to avoid exporting
+    // it just for tests.
+    const { readFile } = await import('node:fs/promises');
+    const src = await readFile(new URL('./route.ts', import.meta.url), 'utf8');
+    const promptMatch = src.match(/const ANNOTATION_PROMPT = `([\s\S]*?)`;/);
+    const prompt = promptMatch?.[1];
+    expect(prompt, 'ANNOTATION_PROMPT template literal not found').toBeTruthy();
+
+    let cursor = 0;
+    for (const header of EXPECTED_HEADERS) {
+      const idx = prompt!.indexOf(header, cursor);
+      expect(idx, `missing or out-of-order header ${header}`).toBeGreaterThan(-1);
+      cursor = idx + header.length;
+    }
+
+    // Exercise the import so lint doesn't flag `mod` as dead weight and we
+    // fail fast on syntax errors in the route file.
+    expect(mod).toBeDefined();
+  });
+
+  it('pins the Past Mistakes placeholder to "(none yet)"', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const src = await readFile(new URL('./route.ts', import.meta.url), 'utf8');
+    expect(src).toContain('_(none yet)_');
+  });
+
+  it('forbids inventing columns in the prompt instructions', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const src = await readFile(new URL('./route.ts', import.meta.url), 'utf8');
+    expect(src.toLowerCase()).toContain('do not invent');
+  });
+});

--- a/apps/web/src/app/api/data-sources/[id]/schema/generate/route.ts
+++ b/apps/web/src/app/api/data-sources/[id]/schema/generate/route.ts
@@ -4,18 +4,76 @@ import { getDataSourceConnection, DataSourceError } from '@/lib/data-source-serv
 import { resolveAIProviders } from '@/lib/ai-provider';
 import { generateSchemaContext, renderSchemaContext } from '@lightboard/agent';
 
-/** Annotation system prompt for the LLM. */
-const ANNOTATION_PROMPT = `You are a database documentation expert. Below is auto-generated schema documentation for a PostgreSQL database. Annotate it to create a concise, high-quality reference that will help an AI agent write correct SQL queries on the first attempt.
+/**
+ * Annotation system prompt.
+ *
+ * Produces a briefing document with a stable set of H3 sections so downstream
+ * tooling (the query-hints checker, past-mistakes injection) can parse the
+ * output. Prose-first — the section headers are the only machine-readable
+ * surface. Total output must stay under ~5500 chars to leave headroom under
+ * the 6000 ceiling the caller truncates at.
+ */
+const ANNOTATION_PROMPT = `You are a database documentation expert. You will be given auto-generated PostgreSQL introspection output. Turn it into a concise briefing document that an AI SQL agent reads before every query.
 
-Your output should be a single markdown document that includes:
-1. Plain-English description for each table (one line)
-2. Notes on important columns — what they mean, not just their type
-3. Key join patterns with example SQL fragments
-4. Data quality gotchas (naming quirks, NULL patterns, enum values to know about)
-5. 3-5 example queries that answer typical questions about this data
+Output a single markdown document with EXACTLY these H3 sections, in this order, using these exact headers:
 
-Keep it concise — under 6000 characters. The AI agent will read this as context before every query.
-Do NOT wrap the output in a code block. Output raw markdown only.`;
+### Tables
+### Key Join Patterns
+### Useful Enumerations
+### Derived Metrics
+### Semantic Dictionary
+### Implicit Filters
+### Gotchas
+### Example Queries
+### Past Mistakes
+
+Begin the document with a level-1 title (\`# <Data Source Name>\`) and a single-paragraph description (domain, grain, time coverage). No summary section beyond that paragraph. Do NOT wrap the output in a code block.
+
+Section guidance (approximate budgets — redistribute if a section has little to say, but keep every header present):
+
+**Tables (~1500 chars)** — One block per meaningful table. Include: table name, grain in plain words (one row per what?), approximate row count if available, and only the semantically notable columns. Skip routine columns like \`id\`, \`created_at\` — they are self-explanatory. Example shape:
+
+  **batting_derived** — Per-match batting scorecard (338K rows)
+  - match_id, player_object_id -> players.object_id
+  - runs, balls, strike_rate (numeric), is_not_out (bool)
+
+**Key Join Patterns (~500 chars)** — Named join paths for the most-used table pairs. Eliminates which-key-to-use hesitation. Example:
+  - Player from deliveries: \`players.object_id = deliveries.batsman_object_id\`
+
+**Useful Enumerations (~500 chars)** — Low-cardinality text columns with the observed values. Lift these from the sample values in the introspection output; do not invent values.
+
+**Derived Metrics (~800 chars)** — Named metrics with formulas and qualifiers. One block per metric, required fields formula + qualifier, optional interpretation. NULLIF guards belong in the formula. Example:
+
+  strike_rate (batting):
+    formula: SUM(runs) * 100.0 / NULLIF(SUM(balls), 0)
+    qualifier: HAVING SUM(balls) >= 100
+    interpretation: higher = faster scoring
+
+Only include metrics whose columns ACTUALLY appear in the introspection input. If you cannot justify a metric from the schema, omit it.
+
+**Semantic Dictionary (~500 chars)** — User-vocabulary -> schema-entity mappings with disambiguation. Focus on phrases that silently produce wrong answers if mis-resolved. Example:
+  - "best batsman" — ambiguous. Default: strike_rate DESC with min 500 balls. Flag if user means consistency (batting_average) or volume (SUM runs).
+
+**Implicit Filters (~600 chars)** — Filters applied by default unless explicitly overridden. Each entry must include a "when to skip" clause so the agent can justify omission. Format:
+
+  name: one-sentence description
+    predicate: SQL fragment
+    when to apply: scope (tables or query shapes)
+    when to skip: user intent that overrides this default
+
+**Gotchas (~500 chars)** — Named traps that silently produce wrong answers. One block per gotcha: what goes wrong, how to avoid, how to detect.
+
+**Example Queries (~800 chars)** — Two worked SELECT examples as raw SQL, each exercising at least one derived metric and one implicit filter.
+
+**Past Mistakes** — Output EXACTLY this placeholder and nothing else:
+
+  _(none yet)_
+
+Hard rules:
+- Do NOT invent columns, tables, or enum values that are absent from the introspection input. Omit a proposed metric or dictionary entry rather than hallucinate.
+- Keep total output under 5500 characters.
+- Every H3 header above must appear exactly once, in the order listed, even if a section is sparse.
+- Output raw markdown only. No code fences around the whole document.`;
 
 /**
  * POST /api/data-sources/[id]/schema/generate
@@ -49,11 +107,12 @@ export const POST = withAuth(async (req, { db, orgId }) => {
 
   // Step 2: Annotate with LLM (if a provider is available)
   // Schema annotation is a leader-class task, so use the leader-routed provider.
-  const providers = await resolveAIProviders(db, orgId);
-  if (!providers) {
+  const resolved = await resolveAIProviders(db, orgId);
+  if (!resolved) {
     // No LLM configured — return raw markdown for manual editing
     return NextResponse.json({ rawMarkdown, annotatedMarkdown: rawMarkdown });
   }
+  const { providers, maxTokens } = resolved;
 
   try {
     // Cap schema size to avoid sending massive prompts (38 tables can produce 30K+ chars)
@@ -66,7 +125,7 @@ export const POST = withAuth(async (req, { db, orgId }) => {
     const stream = providers.leader.chat(
       [{ role: 'user', content: schemaForLLM }],
       [], // no tools
-      { system: ANNOTATION_PROMPT },
+      { system: ANNOTATION_PROMPT, maxTokens: maxTokens.leader },
     );
 
     for await (const event of stream) {

--- a/apps/web/src/components/explore/explore-page-client.tsx
+++ b/apps/web/src/components/explore/explore-page-client.tsx
@@ -108,21 +108,26 @@ export function ExplorePageClient() {
     queryFn: async () => {
       const res = await fetch('/api/data-sources');
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      return (await res.json()) as {
-        dataSources: {
+      const body = (await res.json()) as {
+        dataSources?: {
           id: string;
           name: string;
           type: string;
           config?: Record<string, unknown>;
         }[];
       };
+      // Normalize to a flat array — shared cache key with `useDataSources`,
+      // whose queryFn also returns the unwrapped shape. Divergent shapes
+      // under the same key cause `.map is not a function` when one page's
+      // cache is read by the other.
+      return body.dataSources ?? [];
     },
     staleTime: 5 * 60 * 1000,
   });
 
   const dataSources: DataSourceOption[] = useMemo(() => {
     return (
-      dataSourcesQuery.data?.dataSources.map((ds) => ({
+      dataSourcesQuery.data?.map((ds) => ({
         id: ds.id,
         name: ds.name,
         type: ds.type,

--- a/apps/web/src/components/settings/data-sources/data-source-detail.tsx
+++ b/apps/web/src/components/settings/data-sources/data-source-detail.tsx
@@ -5,7 +5,6 @@ import { useTranslations } from 'next-intl';
 import { useMemo, useState } from 'react';
 
 import { LightboardLoader } from '@/components/brand';
-import { SchemaBrowser } from '@/components/data-sources/schema-browser';
 import { queryKeys } from '@/lib/query-keys';
 
 import { PrimaryButton, SecondaryButton, SettingsPage } from '../primitives';
@@ -13,8 +12,7 @@ import { ConnectionTab } from './connection-tab';
 import { DetailTabs, type DetailTabId } from './detail-tabs';
 import { KindGlyph } from './kind-glyph';
 import { getKindMeta } from './kind-meta';
-import { deriveSchemaDocStatus } from './schema-doc-chip';
-import { SchemaDocEmpty } from './schema-doc-empty';
+import { SchemaDocEditor } from './schema-doc-editor';
 import type { DataSourceRow } from './use-data-sources';
 
 /** Props for {@link DataSourceDetail}. */
@@ -23,31 +21,19 @@ export interface DataSourceDetailProps {
   id: string;
 }
 
-/** Schema payload returned by `/api/data-sources/[id]/schema`. */
-interface SchemaPayload {
-  tables: {
-    name: string;
-    schema: string;
-    columns: { name: string; type: string; nullable: boolean; primaryKey: boolean }[];
-  }[];
-}
-
 /** 5 minutes — schema docs rarely change mid-session. */
 const METADATA_STALE_TIME = 5 * 60 * 1000;
 
-/** Fetch all data sources (used by the detail page until we have a single-source GET). */
+/**
+ * Fetch all data sources (used by the detail page until we have a single-source GET).
+ * Unwraps the API envelope so the shape matches the shared `['data-sources']`
+ * cache key — see `use-data-sources.ts` for the matching invariant.
+ */
 async function fetchDataSources(): Promise<DataSourceRow[]> {
   const res = await fetch('/api/data-sources');
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const data = (await res.json()) as { dataSources: DataSourceRow[] };
+  const data = (await res.json()) as { dataSources?: DataSourceRow[] };
   return data.dataSources ?? [];
-}
-
-/** Fetch the schema payload for a specific data source id. */
-async function fetchSchema(id: string): Promise<SchemaPayload> {
-  const res = await fetch(`/api/data-sources/${id}/schema`);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return (await res.json()) as SchemaPayload;
 }
 
 /**
@@ -71,18 +57,6 @@ export function DataSourceDetail({ id }: DataSourceDetailProps) {
     [sourcesQuery.data, id],
   );
 
-  const schemaStatus = source ? deriveSchemaDocStatus(source.config) : null;
-
-  // Only fetch the schema when the Schema tab is active AND the source
-  // actually has a documented schema to surface. `enabled` lets react-query
-  // gate the fetch without forcing a wrapping `useEffect`.
-  const schemaQuery = useQuery({
-    queryKey: queryKeys.dataSourceSchema(id),
-    queryFn: () => fetchSchema(id),
-    staleTime: METADATA_STALE_TIME,
-    enabled: tab === 'schema' && !!source && schemaStatus?.status !== 'empty',
-  });
-
   if (sourcesQuery.isPending || !source) {
     return (
       <div className="flex flex-col items-center justify-center gap-3 py-20">
@@ -99,7 +73,6 @@ export function DataSourceDetail({ id }: DataSourceDetailProps) {
   const host = (config.host as string | undefined) ?? '';
   const database = (config.database as string | undefined) ?? '';
   const description = [host, database].filter(Boolean).join(' · ');
-  const schemaLoading = schemaQuery.isPending && schemaQuery.fetchStatus === 'fetching';
 
   return (
     <SettingsPage
@@ -121,25 +94,7 @@ export function DataSourceDetail({ id }: DataSourceDetailProps) {
     >
       <DetailTabs tab={tab} setTab={setTab} />
       <div className="mt-6">
-        {tab === 'schema' && (
-          <>
-            {schemaStatus?.status === 'empty' ? (
-              <SchemaDocEmpty sourceName={source.name} tableCount={0} />
-            ) : schemaLoading ? (
-              <div className="flex flex-col items-center justify-center gap-3 py-16">
-                <LightboardLoader size={32} />
-                <p className="text-sm text-[var(--ink-3)]">{t('schemaLoading')}</p>
-              </div>
-            ) : (
-              <SchemaBrowser
-                tables={schemaQuery.data?.tables ?? []}
-                sourceName={source.name}
-                loading={false}
-                onClose={() => { /* detail keeps the tab */ }}
-              />
-            )}
-          </>
-        )}
+        {tab === 'schema' && <SchemaDocEditor source={source} />}
         {tab === 'connection' && <ConnectionTab ds={source} />}
         {tab === 'access' && <AccessPlaceholder />}
       </div>

--- a/apps/web/src/components/settings/data-sources/data-sources-section.tsx
+++ b/apps/web/src/components/settings/data-sources/data-sources-section.tsx
@@ -17,7 +17,7 @@ import { useDataSources } from './use-data-sources';
  */
 export function DataSourcesSection() {
   const t = useTranslations('settings.dataSources');
-  const { sources, loading, deletingId, refetch, remove } = useDataSources();
+  const { sources, loading, deletingId, deleteError, clearDeleteError, refetch, remove } = useDataSources();
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   function handleCreated() {
@@ -50,7 +50,26 @@ export function DataSourcesSection() {
             </div>
           </div>
         ) : (
-          <DataSourcesList sources={sources} deletingId={deletingId} onDelete={remove} />
+          <>
+            {deleteError && (
+              <div
+                role="alert"
+                className="mb-4 flex items-start justify-between gap-4 rounded-[8px] border border-[var(--danger-border)] bg-[var(--danger-bg)] px-3.5 py-2.5 text-[12.5px] text-[var(--danger-ink)]"
+                style={{ fontFamily: 'var(--font-body)' }}
+              >
+                <span>{t('deleteFailed', { message: deleteError.message })}</span>
+                <button
+                  type="button"
+                  onClick={clearDeleteError}
+                  className="text-[11px] uppercase tracking-[0.1em] text-[var(--danger-ink)] opacity-70 hover:opacity-100"
+                  style={{ fontFamily: 'var(--font-mono)' }}
+                >
+                  {t('dismiss')}
+                </button>
+              </div>
+            )}
+            <DataSourcesList sources={sources} deletingId={deletingId} onDelete={remove} />
+          </>
         )}
       </SettingsPage>
       {drawerOpen && (

--- a/apps/web/src/components/settings/data-sources/schema-doc-editor.tsx
+++ b/apps/web/src/components/settings/data-sources/schema-doc-editor.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
+
+import { LightboardLoader } from '@/components/brand';
+import { queryKeys } from '@/lib/query-keys';
+
+import { GhostButton, PrimaryButton, SecondaryButton } from '../primitives';
+import type { DataSourceRow } from './use-data-sources';
+
+/** Props for {@link SchemaDocEditor}. */
+export interface SchemaDocEditorProps {
+  /** The data source row whose schema doc we're editing. */
+  source: DataSourceRow;
+}
+
+/** Shape of `POST /api/data-sources/[id]/schema/generate`. */
+interface GenerateResponse {
+  rawMarkdown: string;
+  annotatedMarkdown: string;
+}
+
+/**
+ * Markdown editor for a data source's curated `schemaDoc`.
+ *
+ * Shows the current persisted doc (from `source.config.schemaDoc`) in a plain
+ * textarea. Provides:
+ *   - "Generate with AI" — POSTs to `/schema/generate` and replaces the
+ *     textarea with the H3-sectioned briefing the annotator returns. If a
+ *     doc already exists, the user must confirm the overwrite.
+ *   - "Save" — PUTs to `/schema` and invalidates the data-sources cache.
+ *   - "Reset" — reloads the textarea from the currently-saved doc,
+ *     discarding unsaved changes.
+ *
+ * The editor is intentionally dumb (no rich editing, no preview pane). The
+ * output is consumed verbatim by the agent's system prompt — what the human
+ * sees here is exactly what the LLM will read.
+ */
+export function SchemaDocEditor({ source }: SchemaDocEditorProps) {
+  const t = useTranslations('settings.dataSources.schemaEditor');
+  const queryClient = useQueryClient();
+
+  const savedDoc = (source.config?.schemaDoc as string | undefined) ?? '';
+  const [draft, setDraft] = useState(savedDoc);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Keep the draft in sync when the caller swaps the source (e.g. after a
+  // route change) and when react-query refetches a fresher row.
+  useEffect(() => {
+    setDraft(savedDoc);
+  }, [savedDoc, source.id]);
+
+  const generateMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch(`/api/data-sources/${source.id}/schema/generate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      return (await res.json()) as GenerateResponse;
+    },
+    onSuccess: (data) => {
+      setDraft(data.annotatedMarkdown);
+      setErrorMsg(null);
+    },
+    onError: (err) => {
+      setErrorMsg(err instanceof Error ? err.message : String(err));
+    },
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: async (schemaDoc: string) => {
+      const res = await fetch(`/api/data-sources/${source.id}/schema`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ schemaDoc }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      setErrorMsg(null);
+      void queryClient.invalidateQueries({ queryKey: queryKeys.dataSources() });
+    },
+    onError: (err) => {
+      setErrorMsg(err instanceof Error ? err.message : String(err));
+    },
+  });
+
+  const generating = generateMutation.isPending;
+  const saving = saveMutation.isPending;
+  const dirty = draft !== savedDoc;
+
+  function handleGenerate() {
+    // Guard an explicit overwrite so a user doesn't lose hand-edits by
+    // clicking AI Generate on a populated doc.
+    if (savedDoc && !window.confirm(t('confirmRegenerate'))) return;
+    generateMutation.mutate();
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start justify-between gap-6 border-b border-[var(--line-1)] pb-3">
+        <div className="min-w-0">
+          <h2
+            className="mb-1 text-[15px] font-medium text-[var(--ink-1)]"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            {t('title')}
+          </h2>
+          <p
+            className="text-[12.5px] leading-[1.55] text-[var(--ink-3)]"
+            style={{ fontFamily: 'var(--font-body)' }}
+          >
+            {t('description')}
+          </p>
+        </div>
+        <div className="flex flex-shrink-0 items-center gap-2">
+          <SecondaryButton onClick={handleGenerate} disabled={generating || saving}>
+            {generating && <LightboardLoader size={12} ariaLabel="" />}
+            <SparkleIcon />
+            <span>{generating ? t('generating') : savedDoc ? t('regenerate') : t('generate')}</span>
+          </SecondaryButton>
+          <GhostButton
+            onClick={() => setDraft(savedDoc)}
+            disabled={!dirty || generating || saving}
+          >
+            {t('reset')}
+          </GhostButton>
+          <PrimaryButton
+            onClick={() => saveMutation.mutate(draft)}
+            disabled={!dirty || generating || saving}
+          >
+            {saving && <LightboardLoader size={12} ariaLabel="" />}
+            <span>{saving ? t('saving') : t('save')}</span>
+          </PrimaryButton>
+        </div>
+      </div>
+
+      {errorMsg && (
+        <div
+          role="alert"
+          className="rounded-[8px] border border-[var(--danger-border)] bg-[var(--danger-bg)] px-3.5 py-2.5 text-[12.5px] text-[var(--danger-ink)]"
+          style={{ fontFamily: 'var(--font-body)' }}
+        >
+          {errorMsg}
+        </div>
+      )}
+
+      <textarea
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        spellCheck={false}
+        placeholder={t('placeholder')}
+        className="min-h-[520px] w-full resize-y rounded-[10px] border border-[var(--line-1)] bg-[var(--bg-2)] p-4 text-[13px] text-[var(--ink-1)] outline-none focus:border-[var(--accent-border)] focus:shadow-[var(--glow-accent-soft)]"
+        style={{
+          fontFamily: 'var(--font-mono)',
+          lineHeight: 1.6,
+          tabSize: 2,
+        }}
+      />
+
+      <div
+        className="flex items-center justify-between text-[11px] uppercase tracking-[0.1em] text-[var(--ink-4)]"
+        style={{ fontFamily: 'var(--font-mono)' }}
+      >
+        <span>{t('charCount', { count: draft.length })}</span>
+        <span>{dirty ? t('unsavedChanges') : t('saved')}</span>
+      </div>
+    </div>
+  );
+}
+
+/** Small sparkle glyph matching SchemaDocEmpty. */
+function SparkleIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
+      <path
+        d="M6 1.5l0.9 2.6L9.5 5l-2.6 0.9L6 8.5 5.1 5.9 2.5 5l2.6-0.9L6 1.5zM9.5 7.5l0.4 1.1 1.1 0.4-1.1 0.4-0.4 1.1-0.4-1.1L8 9l1.1-0.4 0.4-1.1z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/components/settings/data-sources/use-data-sources.ts
+++ b/apps/web/src/components/settings/data-sources/use-data-sources.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 import { queryKeys } from '@/lib/query-keys';
 
@@ -17,11 +17,17 @@ export interface DataSourceRow {
 /** 5 minutes — data sources are metadata, they rarely change mid-session. */
 const METADATA_STALE_TIME = 5 * 60 * 1000;
 
-/** Fetch all data sources for the current org. Shared queryFn. */
+/**
+ * Fetch all data sources for the current org. Shared queryFn.
+ *
+ * Unwraps the API's `{ dataSources }` envelope to a flat array. Other callers
+ * sharing this query key (e.g. the explore page) must return the same shape
+ * or react-query will hand one consumer the other's cached result.
+ */
 async function fetchDataSources(): Promise<DataSourceRow[]> {
   const res = await fetch('/api/data-sources');
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const data = (await res.json()) as { dataSources: DataSourceRow[] };
+  const data = (await res.json()) as { dataSources?: DataSourceRow[] };
   return data.dataSources ?? [];
 }
 
@@ -29,8 +35,17 @@ async function fetchDataSources(): Promise<DataSourceRow[]> {
 export interface DataSourcesState {
   sources: DataSourceRow[];
   loading: boolean;
+  /** Error from the list fetch (not the delete mutation). */
   error: string | null;
   deletingId: string | null;
+  /**
+   * Error from the most recent delete attempt, if any. Stays set until the
+   * next delete is kicked off, so the UI has time to render a toast / inline
+   * banner explaining why the row reappeared after the optimistic removal.
+   */
+  deleteError: { id: string; message: string } | null;
+  /** Clear the last `deleteError`. */
+  clearDeleteError: () => void;
   refetch: () => Promise<void>;
   /** Optimistically remove by id and fire the DELETE request. */
   remove: (id: string) => Promise<void>;
@@ -49,6 +64,7 @@ export interface DataSourcesState {
  */
 export function useDataSources(): DataSourcesState {
   const queryClient = useQueryClient();
+  const [deleteError, setDeleteError] = useState<{ id: string; message: string } | null>(null);
 
   const query = useQuery({
     queryKey: queryKeys.dataSources(),
@@ -59,9 +75,20 @@ export function useDataSources(): DataSourcesState {
   const deleteMutation = useMutation<void, Error, string, { previous?: DataSourceRow[] }>({
     mutationFn: async (id) => {
       const res = await fetch(`/api/data-sources/${id}`, { method: 'DELETE' });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      if (!res.ok) {
+        // Try to lift the server's error message; fall back to the status code.
+        let serverMsg: string | undefined;
+        try {
+          const body = (await res.json()) as { error?: string };
+          serverMsg = body?.error;
+        } catch {
+          /* non-JSON body */
+        }
+        throw new Error(serverMsg ?? `HTTP ${res.status}`);
+      }
     },
     onMutate: async (id) => {
+      setDeleteError(null);
       await queryClient.cancelQueries({ queryKey: queryKeys.dataSources() });
       const previous = queryClient.getQueryData<DataSourceRow[]>(queryKeys.dataSources());
       if (previous) {
@@ -72,10 +99,11 @@ export function useDataSources(): DataSourcesState {
       }
       return { previous };
     },
-    onError: (_err, _id, context) => {
+    onError: (err, id, context) => {
       if (context?.previous) {
         queryClient.setQueryData(queryKeys.dataSources(), context.previous);
       }
+      setDeleteError({ id, message: err instanceof Error ? err.message : String(err) });
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.dataSources() });
@@ -91,19 +119,22 @@ export function useDataSources(): DataSourcesState {
       try {
         await deleteMutation.mutateAsync(id);
       } catch {
-        // The mutation has already rolled back via `onError`; swallow so the
-        // caller isn't forced to handle it. Errors surface through
-        // `state.error` instead.
+        // The failure is already on `deleteError`; swallow so callers don't
+        // have to guard against rejection.
       }
     },
     [deleteMutation],
   );
+
+  const clearDeleteError = useCallback(() => setDeleteError(null), []);
 
   return {
     sources: query.data ?? [],
     loading: query.isPending,
     error: query.error instanceof Error ? query.error.message : null,
     deletingId: deleteMutation.isPending ? (deleteMutation.variables ?? null) : null,
+    deleteError,
+    clearDeleteError,
     refetch,
     remove,
   };

--- a/apps/web/src/lib/ai-provider.ts
+++ b/apps/web/src/lib/ai-provider.ts
@@ -17,6 +17,21 @@ export const AGENT_ROLES: readonly AgentRole[] = ['leader', 'query', 'view', 'in
 /** Mapping from each agent role to a concrete provider instance. */
 export type ProviderMap = Record<AgentRole, LLMProvider>;
 
+/**
+ * Per-role output-token ceiling lifted from `model_configs.max_tokens`. Values
+ * default to `undefined` when a role's model config has no configured max; the
+ * agent then falls through to the provider's stored default
+ * (`DEFAULT_MAX_OUTPUT_TOKENS`). This map is threaded into LeaderAgent so the
+ * user-configured value is applied explicitly at the chat() call site.
+ */
+export type MaxTokensMap = Partial<Record<AgentRole, number>>;
+
+/** Combined resolution result — providers + per-role token ceilings. */
+export interface ResolvedAIProviders {
+  providers: ProviderMap;
+  maxTokens: MaxTokensMap;
+}
+
 /** Provider keys that have a real implementation wired up in this release. */
 export const IMPLEMENTED_PROVIDERS = new Set([
   'anthropic',
@@ -96,7 +111,7 @@ function instantiateProvider(row: ResolvedConfigRow, apiKey: string): LLMProvide
 export async function resolveAIProviders(
   db: Database,
   orgId: string,
-): Promise<ProviderMap | null> {
+): Promise<ResolvedAIProviders | null> {
   const masterKey = process.env.ENCRYPTION_MASTER_KEY;
 
   // 1. Routing rows + configs (preferred path).
@@ -116,6 +131,7 @@ export async function resolveAIProviders(
 
   if (rows.length > 0 && masterKey) {
     const partial: Partial<ProviderMap> = {};
+    const maxTokensPartial: MaxTokensMap = {};
     for (const row of rows) {
       const role = row.role as AgentRole;
       if (!AGENT_ROLES.includes(role)) continue;
@@ -128,6 +144,9 @@ export async function resolveAIProviders(
           },
           apiKey,
         );
+        if (typeof row.maxTokens === 'number') {
+          maxTokensPartial[role] = row.maxTokens;
+        }
       } catch {
         // Decryption or instantiation failed — leave this role unmapped
         // so the fallbacks below still get a chance to fill it.
@@ -139,18 +158,32 @@ export async function resolveAIProviders(
     if (partial.leader) {
       for (const role of AGENT_ROLES) {
         if (!partial[role]) partial[role] = partial.leader;
+        if (maxTokensPartial[role] === undefined && maxTokensPartial.leader !== undefined) {
+          maxTokensPartial[role] = maxTokensPartial.leader;
+        }
       }
-      return partial as ProviderMap;
+      return { providers: partial as ProviderMap, maxTokens: maxTokensPartial };
     }
 
     // Missing leader but some other role set — still usable: pick any.
     const anyConcrete = AGENT_ROLES.map((r) => partial[r]).find((p): p is LLMProvider => !!p);
     if (anyConcrete) {
+      const anyMaxTokens = AGENT_ROLES.map((r) => maxTokensPartial[r]).find(
+        (v): v is number => typeof v === 'number',
+      );
       return {
-        leader: anyConcrete,
-        query: partial.query ?? anyConcrete,
-        view: partial.view ?? anyConcrete,
-        insights: partial.insights ?? anyConcrete,
+        providers: {
+          leader: anyConcrete,
+          query: partial.query ?? anyConcrete,
+          view: partial.view ?? anyConcrete,
+          insights: partial.insights ?? anyConcrete,
+        },
+        maxTokens: {
+          leader: maxTokensPartial.leader ?? anyMaxTokens,
+          query: maxTokensPartial.query ?? anyMaxTokens,
+          view: maxTokensPartial.view ?? anyMaxTokens,
+          insights: maxTokensPartial.insights ?? anyMaxTokens,
+        },
       };
     }
   }
@@ -181,7 +214,10 @@ export async function resolveAIProviders(
               apiKey,
               model: aiConfig?.model ?? 'gpt-4o',
             });
-      return { leader: single, query: single, view: single, insights: single };
+      return {
+        providers: { leader: single, query: single, view: single, insights: single },
+        maxTokens: {},
+      };
     } catch {
       // Fall through to env-var fallback.
     }
@@ -191,7 +227,10 @@ export async function resolveAIProviders(
   const envKey = process.env.ANTHROPIC_API_KEY;
   if (envKey) {
     const single = new ClaudeProvider({ apiKey: envKey });
-    return { leader: single, query: single, view: single, insights: single };
+    return {
+      providers: { leader: single, query: single, view: single, insights: single },
+      maxTokens: {},
+    };
   }
 
   return null;

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -1,7 +1,12 @@
 export { QueryAgent } from './query-agent';
 export { ViewAgent } from './view-agent';
 export { InsightsAgent } from './insights-agent';
-export { LeaderAgent, type LeaderAgentConfig, type LeaderProviderMap } from './leader';
+export {
+  LeaderAgent,
+  type LeaderAgentConfig,
+  type LeaderProviderMap,
+  type LeaderMaxTokensMap,
+} from './leader';
 export type {
   SubAgent,
   SubAgentConfig,

--- a/packages/agent/src/agents/insights-agent.ts
+++ b/packages/agent/src/agents/insights-agent.ts
@@ -43,7 +43,7 @@ export class InsightsAgent implements SubAgent {
       const stream = this.config.provider.chat(
         messages,
         this.tools,
-        { system: systemPrompt },
+        { system: systemPrompt, maxTokens: this.config.maxTokens },
       );
 
       for await (const event of stream) {

--- a/packages/agent/src/agents/leader.ts
+++ b/packages/agent/src/agents/leader.ts
@@ -28,6 +28,18 @@ export type LeaderProviderMap = {
   insights: LLMProvider;
 };
 
+/**
+ * Per-role output-token ceiling. Keyed by role name, each value is the
+ * `maxTokens` that role's LLM call will pass in `ChatOptions.maxTokens`. When
+ * a role is missing from this map, the provider's stored default is used.
+ */
+export type LeaderMaxTokensMap = Partial<{
+  leader: number;
+  query: number;
+  view: number;
+  insights: number;
+}>;
+
 /** Configuration for creating a LeaderAgent. */
 export interface LeaderAgentConfig {
   /**
@@ -53,6 +65,12 @@ export interface LeaderAgentConfig {
   subAgentMaxRounds?: number;
   /** Grace timeout (ms) for draining in-flight tasks at turn end. */
   drainTimeoutMs?: number;
+  /**
+   * Per-role output-token ceilings. Threaded into each agent's LLM call so
+   * the user-configured `model_configs.max_tokens` is honored explicitly
+   * instead of relying on the provider's stored default.
+   */
+  maxTokensPerRole?: LeaderMaxTokensMap;
 }
 
 /** Maximum number of sample rows to include in summaries sent to the LLM. */
@@ -113,6 +131,7 @@ export class LeaderAgent {
   private maxToolRounds: number;
   private subAgentMaxRounds: number;
   private drainTimeoutMs: number;
+  private maxTokensPerRole: LeaderMaxTokensMap;
   /** Counter for auto-naming scratchpad tables. */
   private queryCounter = 0;
   /** Per-turn task pool for async dispatch. Reset at the start of each chat() call. */
@@ -137,6 +156,7 @@ export class LeaderAgent {
     this.maxToolRounds = config.maxToolRounds ?? 10;
     this.subAgentMaxRounds = config.subAgentMaxRounds ?? 5;
     this.drainTimeoutMs = config.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
+    this.maxTokensPerRole = config.maxTokensPerRole ?? {};
   }
 
   /**
@@ -146,6 +166,15 @@ export class LeaderAgent {
    */
   get provider(): LLMProvider {
     return this.providers.leader;
+  }
+
+  /**
+   * Swap the tool context for subsequent turns. Used when callers wrap the
+   * context per-turn (e.g., with a turn-scoped conversation logger) but keep
+   * the LeaderAgent alive across turns via a cache.
+   */
+  setToolContext(ctx: ToolContext): void {
+    this.toolContext = ctx;
   }
 
   /**
@@ -182,7 +211,7 @@ export class LeaderAgent {
       const stream = this.providers.leader.chat(
         this.conversation.getMessages(),
         leaderTools,
-        { system: systemPrompt },
+        { system: systemPrompt, maxTokens: this.maxTokensPerRole.leader },
       );
 
       for await (const event of stream) {
@@ -511,6 +540,7 @@ export class LeaderAgent {
         provider: this.providers.query,
         toolRouter: queryRouter,
         maxToolRounds: this.subAgentMaxRounds,
+        maxTokens: this.maxTokensPerRole.query,
         onStatus,
       });
 
@@ -544,6 +574,7 @@ export class LeaderAgent {
         provider: this.providers.view,
         toolRouter: viewRouter,
         maxToolRounds: this.subAgentMaxRounds,
+        maxTokens: this.maxTokensPerRole.view,
         onStatus,
       });
 
@@ -571,6 +602,7 @@ export class LeaderAgent {
       provider: this.providers.insights,
       toolRouter: insightsRouter,
       maxToolRounds: this.subAgentMaxRounds,
+      maxTokens: this.maxTokensPerRole.insights,
       onStatus,
     });
 

--- a/packages/agent/src/agents/maxtokens-threading.test.ts
+++ b/packages/agent/src/agents/maxtokens-threading.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { QueryAgent } from './query-agent';
+import { ViewAgent } from './view-agent';
+import { InsightsAgent } from './insights-agent';
+import { LeaderAgent } from './leader';
+import { ToolRouter, type ToolContext } from '../tools/router';
+import type { ChatOptions, LLMProvider, StreamEvent, ToolDefinition } from '../provider/types';
+
+/**
+ * Each agent must pass `maxTokens` from its config into `ChatOptions` so the
+ * user-configured `model_configs.max_tokens` is honored explicitly at the
+ * call site — not left to the provider's stored default. The test captures
+ * the options a mock provider received and asserts the expected value.
+ */
+
+function makeCapturingProvider(): {
+  provider: LLMProvider;
+  captured: ChatOptions[];
+} {
+  const captured: ChatOptions[] = [];
+  const provider: LLMProvider = {
+    name: 'mock',
+    async *chat(_msgs, _tools, options?: ChatOptions): AsyncIterable<StreamEvent> {
+      captured.push(options ?? {});
+      yield { type: 'text_delta', text: 'ok' };
+      yield { type: 'message_end', stopReason: 'end_turn' };
+    },
+  };
+  return { provider, captured };
+}
+
+function mockToolContext(): ToolContext {
+  return {
+    getSchema: vi.fn().mockResolvedValue({ tables: [] }),
+    runSQL: vi.fn().mockResolvedValue({ rows: [], rowCount: 0, columns: [] }),
+    describeTable: vi.fn().mockResolvedValue({ columns: [] }),
+    analyzeData: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+  };
+}
+
+describe('SubAgents thread maxTokens into ChatOptions', () => {
+  it('QueryAgent passes config.maxTokens', async () => {
+    const { provider, captured } = makeCapturingProvider();
+    const agent = new QueryAgent({
+      provider,
+      toolRouter: new ToolRouter(mockToolContext()),
+      maxToolRounds: 1,
+      maxTokens: 1234,
+    });
+    await agent.run({ id: 't1', instruction: 'hi', context: {} });
+    expect(captured[0]?.maxTokens).toBe(1234);
+  });
+
+  it('ViewAgent passes config.maxTokens', async () => {
+    const { provider, captured } = makeCapturingProvider();
+    const agent = new ViewAgent({
+      provider,
+      toolRouter: new ToolRouter(mockToolContext()),
+      maxToolRounds: 1,
+      maxTokens: 8888,
+    });
+    await agent.run({ id: 't1', instruction: 'draw', context: { dataSummary: { columns: [], rowCount: 0, sampleRows: [] } } });
+    expect(captured[0]?.maxTokens).toBe(8888);
+  });
+
+  it('InsightsAgent passes config.maxTokens', async () => {
+    const { provider, captured } = makeCapturingProvider();
+    const agent = new InsightsAgent({
+      provider,
+      toolRouter: new ToolRouter(mockToolContext()),
+      maxToolRounds: 1,
+      maxTokens: 7,
+    });
+    await agent.run({ id: 't1', instruction: 'summarize', context: { tableName: 'query_1' } });
+    expect(captured[0]?.maxTokens).toBe(7);
+  });
+
+  it('leaves maxTokens undefined when config omits it', async () => {
+    const { provider, captured } = makeCapturingProvider();
+    const agent = new QueryAgent({
+      provider,
+      toolRouter: new ToolRouter(mockToolContext()),
+      maxToolRounds: 1,
+    });
+    await agent.run({ id: 't1', instruction: 'hi', context: {} });
+    expect(captured[0]?.maxTokens).toBeUndefined();
+  });
+});
+
+describe('LeaderAgent threads maxTokensPerRole to its own chat() call', () => {
+  it('passes maxTokensPerRole.leader to the leader provider', async () => {
+    const { provider: leaderProvider, captured } = makeCapturingProvider();
+    const stubTool: ToolDefinition = {
+      name: 'noop',
+      description: '',
+      inputSchema: { type: 'object', properties: {} },
+    };
+    void stubTool;
+
+    const leader = new LeaderAgent({
+      providers: {
+        leader: leaderProvider,
+        query: leaderProvider,
+        view: leaderProvider,
+        insights: leaderProvider,
+      },
+      toolContext: mockToolContext(),
+      dataSources: [],
+      maxToolRounds: 1,
+      maxTokensPerRole: { leader: 5555, query: 1111, view: 2222, insights: 3333 },
+    });
+
+    // Drain the first turn — leader calls provider.chat once and then emits 'done'.
+    for await (const _ of leader.chat('ping', 'sess_1')) { void _; }
+
+    expect(captured[0]?.maxTokens).toBe(5555);
+  });
+});

--- a/packages/agent/src/agents/query-agent.ts
+++ b/packages/agent/src/agents/query-agent.ts
@@ -48,6 +48,7 @@ export class QueryAgent implements SubAgent {
 
       const stream = this.config.provider.chat(messages, this.tools, {
         system: systemPrompt,
+        maxTokens: this.config.maxTokens,
       });
 
       for await (const event of stream) {

--- a/packages/agent/src/agents/types.ts
+++ b/packages/agent/src/agents/types.ts
@@ -60,6 +60,13 @@ export interface SubAgentConfig {
   /** Maximum tool call rounds before giving up (default varies by agent). */
   maxToolRounds?: number;
   /**
+   * Output-token ceiling for this agent's LLM calls. When set, the agent
+   * passes it explicitly in `ChatOptions.maxTokens` on every turn. When unset,
+   * the provider's stored default is used. Prefer setting explicitly so the
+   * per-role routing in `agent_role_assignments` actually takes effect.
+   */
+  maxTokens?: number;
+  /**
    * Optional progress callback. Sub-agents invoke this with short, human-
    * readable status strings ("Running query: SELECT ...", "Got 1250 rows")
    * so the leader can surface task_progress events to the UI during long

--- a/packages/agent/src/agents/view-agent.ts
+++ b/packages/agent/src/agents/view-agent.ts
@@ -43,7 +43,7 @@ export class ViewAgent implements SubAgent {
       const stream = this.config.provider.chat(
         messages,
         this.tools,
-        { system: systemPrompt },
+        { system: systemPrompt, maxTokens: this.config.maxTokens },
       );
 
       for await (const event of stream) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,6 +6,7 @@ export {
   LeaderAgent,
   type LeaderAgentConfig,
   type LeaderProviderMap,
+  type LeaderMaxTokensMap,
   type SubAgent,
   type SubAgentConfig,
   type SubAgentRole,
@@ -16,7 +17,9 @@ export { ConversationManager } from './conversation';
 export {
   ClaudeProvider,
   type ClaudeProviderConfig,
+  DEFAULT_MAX_OUTPUT_TOKENS,
   LLMError,
+  type LLMErrorReason,
   type LLMProvider,
   type Message,
   OpenAICompatibleProvider,
@@ -38,3 +41,10 @@ export {
   type ToolContext,
   type ToolExecutionResult,
 } from './tools';
+export {
+  ConversationLog,
+  wrapToolContext,
+  defaultLogDir,
+  type ConversationLogEvent,
+  type ConversationLogMeta,
+} from './logging';

--- a/packages/agent/src/logging/conversation-log.test.ts
+++ b/packages/agent/src/logging/conversation-log.test.ts
@@ -1,0 +1,157 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ConversationLog,
+  defaultLogDir,
+  wrapToolContext,
+} from './conversation-log';
+import type { ToolContext } from '../tools/router';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'convlog-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('ConversationLog', () => {
+  it('seeds with a session_start event', () => {
+    const log = new ConversationLog({
+      sessionId: 'sess_1',
+      orgId: 'org_1',
+      userMessage: 'hello',
+      dataSources: [{ id: 'ds_1', name: 'cricket', type: 'postgres' }],
+    });
+    const events = log.getEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      t: 'session_start',
+      session_id: 'sess_1',
+      org_id: 'org_1',
+      user_message: 'hello',
+    });
+  });
+
+  it('snapshotSchemaDocs picks the first non-empty tier and reports chars', () => {
+    const log = new ConversationLog({
+      sessionId: 's',
+      orgId: 'o',
+      userMessage: '',
+      dataSources: [],
+    });
+    log.snapshotSchemaDocs([
+      { id: 'a', name: 'A', schemaDoc: '# doc' },
+      { id: 'b', name: 'B', schemaContext: { tables: [] } },
+      { id: 'c', name: 'C', cachedSchema: { tables: [] } },
+      { id: 'd', name: 'D' },
+    ]);
+    const snaps = log.getEvents().filter((e) => e.t === 'schema_doc_snapshot');
+    expect(snaps).toHaveLength(4);
+    expect(snaps[0]).toMatchObject({ source: 'schemaDoc', chars: 5 });
+    expect(snaps[1]).toMatchObject({ source: 'schemaContext' });
+    expect(snaps[2]).toMatchObject({ source: 'cachedSchema' });
+    expect(snaps[3]).toMatchObject({ source: 'none', chars: 0, doc: null });
+  });
+
+  it('flush writes a JSONL file with session_end appended', async () => {
+    const log = new ConversationLog({
+      sessionId: 'sess_flush',
+      orgId: 'o',
+      userMessage: 'q',
+      dataSources: [],
+    });
+    log.push({ t: 'user_message', text: 'q' });
+
+    const written = await log.flush(tmpDir, 'end_turn');
+    expect(written).not.toBeNull();
+
+    const body = await fs.readFile(written!, 'utf8');
+    const lines = body.trim().split('\n').map((l) => JSON.parse(l));
+    expect(lines[0].t).toBe('session_start');
+    expect(lines.at(-1)?.t).toBe('session_end');
+    expect(lines.at(-1)?.stop_reason).toBe('end_turn');
+  });
+
+  it('flush returns null and does not throw when the dir is unwritable', async () => {
+    const log = new ConversationLog({
+      sessionId: 's',
+      orgId: 'o',
+      userMessage: '',
+      dataSources: [],
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Use a path that will fail the mkdir (null byte is invalid on every OS).
+    const result = await log.flush('\0/invalid', undefined);
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('wrapToolContext', () => {
+  function createCtx(overrides?: Partial<ToolContext>): ToolContext {
+    return {
+      getSchema: vi.fn().mockResolvedValue({ tables: [] }),
+      runSQL: vi.fn().mockResolvedValue({ columns: ['a'], rows: [{ a: 1 }], rowCount: 1 }),
+      describeTable: vi.fn().mockResolvedValue({ columns: [] }),
+      ...overrides,
+    };
+  }
+
+  it('records runSQL calls with the SQL input and a row_count on success', async () => {
+    const log = new ConversationLog({
+      sessionId: 's',
+      orgId: 'o',
+      userMessage: '',
+      dataSources: [],
+    });
+    const wrapped = wrapToolContext(createCtx(), log);
+    await wrapped.runSQL!('ds_1', 'SELECT 1');
+    const events = log.getEvents();
+    expect(events.some((e) => e.t === 'tool_call' && e.tool === 'run_sql' && e.input.sql === 'SELECT 1')).toBe(true);
+    const result = events.find((e) => e.t === 'tool_result' && e.tool === 'run_sql');
+    expect(result).toMatchObject({ status: 'ok', row_count: 1, column_count: 1 });
+  });
+
+  it('records runSQL errors without throwing past the wrapper', async () => {
+    const log = new ConversationLog({
+      sessionId: 's',
+      orgId: 'o',
+      userMessage: '',
+      dataSources: [],
+    });
+    const boom = new Error('bad sql');
+    const wrapped = wrapToolContext(createCtx({ runSQL: vi.fn().mockRejectedValue(boom) }), log);
+    await expect(wrapped.runSQL!('ds_1', 'SELECT oops')).rejects.toThrow('bad sql');
+    const result = log.getEvents().find((e) => e.t === 'tool_result' && e.tool === 'run_sql');
+    expect(result).toMatchObject({ status: 'error', error: 'bad sql' });
+  });
+
+  it('omits runSQL / describeTable when the original context lacks them', () => {
+    const log = new ConversationLog({
+      sessionId: 's',
+      orgId: 'o',
+      userMessage: '',
+      dataSources: [],
+    });
+    const minimal: ToolContext = { getSchema: vi.fn().mockResolvedValue({}) };
+    const wrapped = wrapToolContext(minimal, log);
+    expect(wrapped.runSQL).toBeUndefined();
+    expect(wrapped.describeTable).toBeUndefined();
+  });
+});
+
+describe('defaultLogDir', () => {
+  it('resolves to an absolute path under the cwd', () => {
+    const dir = defaultLogDir();
+    expect(path.isAbsolute(dir)).toBe(true);
+    expect(dir.endsWith('.agent-logs')).toBe(true);
+  });
+});

--- a/packages/agent/src/logging/conversation-log.ts
+++ b/packages/agent/src/logging/conversation-log.ts
@@ -1,0 +1,286 @@
+import { existsSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import type { ToolContext } from '../tools/router';
+
+/**
+ * Events captured in the conversation log. Line-oriented JSON.
+ *
+ * The log is a passive capture for later eval / past-mistakes curation. It is
+ * NOT consumed by the running agent. Keep events cheap to serialize; exclude
+ * raw result rows, credentials, and chain-of-thought beyond what the tool
+ * trace already reveals.
+ */
+export type ConversationLogEvent =
+  | {
+      t: 'session_start';
+      ts: string;
+      session_id: string;
+      org_id: string;
+      user_message: string;
+      data_sources: Array<{ id: string; name: string; type: string }>;
+    }
+  | {
+      t: 'schema_doc_snapshot';
+      data_source_id: string;
+      data_source_name: string;
+      source: 'schemaDoc' | 'schemaContext' | 'cachedSchema' | 'none';
+      chars: number;
+      doc: string | null;
+    }
+  | { t: 'user_message'; text: string }
+  | { t: 'agent_turn_start'; agent: string; task?: string }
+  | { t: 'agent_turn_end'; agent: string; summary?: string }
+  | { t: 'thinking'; text: string }
+  | { t: 'agent_text'; preview: string; chars: number }
+  | {
+      t: 'tool_call';
+      tool: string;
+      call_id?: string;
+      input: Record<string, unknown>;
+    }
+  | {
+      t: 'tool_result';
+      tool: string;
+      call_id?: string;
+      status: 'ok' | 'error';
+      row_count?: number;
+      column_count?: number;
+      result_chars?: number;
+      error?: string;
+      duration_ms?: number;
+    }
+  | { t: 'task_dispatched'; task_id: string; agent: string; instruction: string }
+  | { t: 'task_complete'; task_id: string; agent: string; summary: string; is_error: boolean }
+  | { t: 'task_cancelled'; task_id: string }
+  | { t: 'session_end'; ts: string; duration_ms: number; stop_reason?: string };
+
+/** Metadata fixed at session start. */
+export interface ConversationLogMeta {
+  sessionId: string;
+  orgId: string;
+  userMessage: string;
+  dataSources: Array<{ id: string; name: string; type: string }>;
+}
+
+/**
+ * Buffers conversation events in memory and writes a single JSONL file on
+ * flush. Failure to write the log never propagates — the agent response must
+ * never be blocked by logging.
+ */
+export class ConversationLog {
+  private events: ConversationLogEvent[] = [];
+  private meta: ConversationLogMeta;
+  private startedAt: number;
+  private filename: string;
+
+  constructor(meta: ConversationLogMeta) {
+    this.meta = meta;
+    this.startedAt = Date.now();
+    const ts = new Date(this.startedAt).toISOString().replace(/[:.]/g, '-');
+    this.filename = `${ts}_${meta.sessionId}.jsonl`;
+
+    this.push({
+      t: 'session_start',
+      ts: new Date(this.startedAt).toISOString(),
+      session_id: meta.sessionId,
+      org_id: meta.orgId,
+      user_message: meta.userMessage,
+      data_sources: meta.dataSources,
+    });
+  }
+
+  /** Append an event. */
+  push(event: ConversationLogEvent): void {
+    this.events.push(event);
+  }
+
+  /**
+   * Record a schema-doc snapshot for each data source that has one, so we can
+   * later correlate doc quality with query quality.
+   */
+  snapshotSchemaDocs(
+    sources: Array<{
+      id: string;
+      name: string;
+      schemaDoc?: string | null;
+      schemaContext?: Record<string, unknown> | null;
+      cachedSchema?: Record<string, unknown> | null;
+    }>,
+  ): void {
+    for (const s of sources) {
+      let source: 'schemaDoc' | 'schemaContext' | 'cachedSchema' | 'none' = 'none';
+      let doc: string | null = null;
+      if (s.schemaDoc) {
+        source = 'schemaDoc';
+        doc = s.schemaDoc;
+      } else if (s.schemaContext) {
+        source = 'schemaContext';
+        doc = JSON.stringify(s.schemaContext);
+      } else if (s.cachedSchema) {
+        source = 'cachedSchema';
+        doc = JSON.stringify(s.cachedSchema);
+      }
+      this.push({
+        t: 'schema_doc_snapshot',
+        data_source_id: s.id,
+        data_source_name: s.name,
+        source,
+        chars: doc?.length ?? 0,
+        doc,
+      });
+    }
+  }
+
+  /**
+   * Close the log with a session_end event and write to disk. Swallows write
+   * errors — the log is advisory. Returns the written path (or null on error)
+   * for tests.
+   */
+  async flush(dir: string, stopReason?: string): Promise<string | null> {
+    this.push({
+      t: 'session_end',
+      ts: new Date().toISOString(),
+      duration_ms: Date.now() - this.startedAt,
+      stop_reason: stopReason,
+    });
+
+    try {
+      await fs.mkdir(dir, { recursive: true });
+      const fullPath = path.join(dir, this.filename);
+      const body = this.events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+      await fs.writeFile(fullPath, body, 'utf8');
+      return fullPath;
+    } catch (err) {
+      console.warn('[ConversationLog] Failed to flush log:', err instanceof Error ? err.message : err);
+      return null;
+    }
+  }
+
+  /** Accessor for tests — returns a shallow copy. */
+  getEvents(): ConversationLogEvent[] {
+    return [...this.events];
+  }
+}
+
+/**
+ * Wraps a ToolContext so every SQL execution and schema call is recorded with
+ * its input and a sanitized summary of the output. Rows are stripped; only
+ * column count and row count survive.
+ */
+export function wrapToolContext(ctx: ToolContext, log: ConversationLog): ToolContext {
+  return {
+    ...ctx,
+    getSchema: async (sourceId) => {
+      const start = Date.now();
+      log.push({ t: 'tool_call', tool: 'get_schema', input: { source_id: sourceId } });
+      try {
+        const result = await ctx.getSchema(sourceId);
+        log.push({
+          t: 'tool_result',
+          tool: 'get_schema',
+          status: 'ok',
+          duration_ms: Date.now() - start,
+          result_chars: JSON.stringify(result).length,
+        });
+        return result;
+      } catch (err) {
+        log.push({
+          t: 'tool_result',
+          tool: 'get_schema',
+          status: 'error',
+          duration_ms: Date.now() - start,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      }
+    },
+    runSQL: ctx.runSQL
+      ? async (sourceId, sql) => {
+          const start = Date.now();
+          log.push({ t: 'tool_call', tool: 'run_sql', input: { source_id: sourceId, sql } });
+          try {
+            const result = await ctx.runSQL!(sourceId, sql);
+            const cols = (result as { columns?: unknown[] }).columns;
+            const rows = (result as { rows?: unknown[]; rowCount?: number }).rows;
+            log.push({
+              t: 'tool_result',
+              tool: 'run_sql',
+              status: 'ok',
+              duration_ms: Date.now() - start,
+              row_count: (result as { rowCount?: number }).rowCount ?? rows?.length ?? 0,
+              column_count: Array.isArray(cols) ? cols.length : undefined,
+            });
+            return result;
+          } catch (err) {
+            log.push({
+              t: 'tool_result',
+              tool: 'run_sql',
+              status: 'error',
+              duration_ms: Date.now() - start,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            throw err;
+          }
+        }
+      : undefined,
+    describeTable: ctx.describeTable
+      ? async (sourceId, tableName) => {
+          const start = Date.now();
+          log.push({
+            t: 'tool_call',
+            tool: 'describe_table',
+            input: { source_id: sourceId, table_name: tableName },
+          });
+          try {
+            const result = await ctx.describeTable!(sourceId, tableName);
+            log.push({
+              t: 'tool_result',
+              tool: 'describe_table',
+              status: 'ok',
+              duration_ms: Date.now() - start,
+              result_chars: JSON.stringify(result).length,
+            });
+            return result;
+          } catch (err) {
+            log.push({
+              t: 'tool_result',
+              tool: 'describe_table',
+              status: 'error',
+              duration_ms: Date.now() - start,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            throw err;
+          }
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Default log directory: `<repo-root>/.agent-logs/`.
+ *
+ * Walks up from `process.cwd()` looking for a workspace marker
+ * (`pnpm-workspace.yaml`, `.git`) so logs land at the repo root even when
+ * the caller is a monorepo app with `cwd = apps/web` (as Next.js does in
+ * `next dev`). Falls back to cwd if no marker is found.
+ */
+export function defaultLogDir(): string {
+  return path.join(resolveRepoRoot(), '.agent-logs');
+}
+
+/** Internal: find the nearest ancestor containing a workspace marker. */
+function resolveRepoRoot(start: string = process.cwd()): string {
+  const markers = ['pnpm-workspace.yaml', '.git'];
+  let dir = start;
+  for (let i = 0; i < 10; i++) {
+    for (const m of markers) {
+      if (existsSync(path.join(dir, m))) return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return start;
+}

--- a/packages/agent/src/logging/index.ts
+++ b/packages/agent/src/logging/index.ts
@@ -1,0 +1,7 @@
+export {
+  ConversationLog,
+  wrapToolContext,
+  defaultLogDir,
+  type ConversationLogEvent,
+  type ConversationLogMeta,
+} from './conversation-log';

--- a/packages/agent/src/provider/claude.ts
+++ b/packages/agent/src/provider/claude.ts
@@ -1,6 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk';
-import type { ChatOptions, LLMProvider, Message, StreamEvent, ToolDefinition } from './types';
+import type { ChatOptions, LLMErrorReason, LLMProvider, Message, StreamEvent, ToolDefinition } from './types';
 import { LLMError } from './types';
+import { DEFAULT_MAX_OUTPUT_TOKENS } from './constants';
 
 /** Configuration for the Claude provider. */
 export interface ClaudeProviderConfig {
@@ -22,7 +23,7 @@ export class ClaudeProvider implements LLMProvider {
   constructor(config: ClaudeProviderConfig) {
     this.client = new Anthropic({ apiKey: config.apiKey });
     this.defaultModel = config.model ?? 'claude-sonnet-4-20250514';
-    this.defaultMaxTokens = config.maxTokens ?? 4096;
+    this.defaultMaxTokens = config.maxTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
   }
 
   /** Stream a chat response from Claude with tool use. */
@@ -56,6 +57,9 @@ export class ClaudeProvider implements LLMProvider {
       let activeToolId = '';
       let activeToolName = '';
       let activeToolInput = '';
+      // stop_reason arrives on `message_delta`, not `message_stop`; hold it
+      // so we can surface it in the final message_end event.
+      let finalStopReason = 'end_turn';
 
       for await (const event of stream) {
         switch (event.type) {
@@ -105,18 +109,39 @@ export class ClaudeProvider implements LLMProvider {
             }
             break;
 
+          case 'message_delta':
+            if (event.delta?.stop_reason) {
+              finalStopReason = event.delta.stop_reason;
+            }
+            break;
+
           case 'message_stop':
-            yield { type: 'message_end' as const, stopReason: 'end_turn' };
+            if (finalStopReason === 'max_tokens') {
+              // Surface truncated output as a structured error so callers
+              // (chat route, UI) can render an actionable message. The
+              // stream has already delivered the (partial) text/tool data,
+              // so this fires only after content has been yielded.
+              throw new LLMError(
+                `Output truncated at max_tokens=${options?.maxTokens ?? this.defaultMaxTokens}. Raise the model's max_tokens setting for this agent role.`,
+                'claude',
+                undefined,
+                false,
+                'output_tokens_exceeded',
+              );
+            }
+            yield { type: 'message_end' as const, stopReason: finalStopReason };
             break;
         }
       }
     } catch (err) {
+      if (err instanceof LLMError) throw err;
       if (err instanceof Anthropic.APIError) {
         throw new LLMError(
           err.message,
           'claude',
           err.status,
           err.status === 429 || err.status >= 500,
+          classifyClaudeError(err),
         );
       }
       throw err;
@@ -167,4 +192,22 @@ export class ClaudeProvider implements LLMProvider {
     return result;
   }
 
+}
+
+/**
+ * Map an Anthropic SDK error to a structured {@link LLMErrorReason}. Keeps
+ * pattern-matching in one place so the provider class stays readable.
+ */
+function classifyClaudeError(err: InstanceType<typeof Anthropic.APIError>): LLMErrorReason {
+  const msg = (err.message ?? '').toLowerCase();
+  if (err.status === 401 || err.status === 403) return 'auth';
+  if (err.status === 429) return 'rate_limited';
+  if (typeof err.status === 'number' && err.status >= 500) return 'server_error';
+  if (msg.includes('max_tokens') || msg.includes('output tokens')) return 'output_tokens_exceeded';
+  if (msg.includes('context') && (msg.includes('length') || msg.includes('window'))) {
+    return 'context_length_exceeded';
+  }
+  if (msg.includes('prompt is too long')) return 'context_length_exceeded';
+  if (err.status === 400) return 'invalid_request';
+  return 'unknown';
 }

--- a/packages/agent/src/provider/constants.ts
+++ b/packages/agent/src/provider/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Provider-level defaults shared by every concrete LLM provider.
+ *
+ * We keep these as named constants (not inline numbers) because the user-
+ * configured `model_configs.max_tokens` is the source of truth; this value
+ * only kicks in when the caller *explicitly* built a provider without a
+ * max-token setting. Any test or dev-bootstrap code path that lands here
+ * should be auditable from one grep.
+ */
+
+/**
+ * Fallback ceiling on output tokens when neither the ChatOptions call nor
+ * the provider constructor supplied a value. Chosen to match the UI slider
+ * default so a user who accepts all defaults gets the same ceiling
+ * regardless of which code path instantiated their provider.
+ *
+ * When this fires in practice, view-agent outputs (which generate full HTML
+ * documents) may hit `stop_reason: max_tokens` — that is the structured
+ * error the providers surface as `LLMError.reason = 'output_tokens_exceeded'`.
+ */
+export const DEFAULT_MAX_OUTPUT_TOKENS = 4096;

--- a/packages/agent/src/provider/index.ts
+++ b/packages/agent/src/provider/index.ts
@@ -1,5 +1,6 @@
 export { ClaudeProvider, type ClaudeProviderConfig } from './claude';
 export { OpenAICompatibleProvider, type OpenAICompatibleConfig } from './openai-compatible';
+export { DEFAULT_MAX_OUTPUT_TOKENS } from './constants';
 export type {
   ChatOptions,
   LLMProvider,
@@ -9,4 +10,4 @@ export type {
   ToolDefinition,
   ToolResult,
 } from './types';
-export { LLMError } from './types';
+export { LLMError, type LLMErrorReason } from './types';

--- a/packages/agent/src/provider/openai-compatible.ts
+++ b/packages/agent/src/provider/openai-compatible.ts
@@ -1,5 +1,6 @@
-import type { ChatOptions, LLMProvider, Message, StreamEvent, ToolDefinition } from './types';
+import type { ChatOptions, LLMErrorReason, LLMProvider, Message, StreamEvent, ToolDefinition } from './types';
 import { LLMError } from './types';
+import { DEFAULT_MAX_OUTPUT_TOKENS } from './constants';
 
 /** Configuration for OpenAI-compatible providers (Ollama, vLLM, etc.). */
 export interface OpenAICompatibleConfig {
@@ -27,7 +28,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
     this.baseUrl = url;
     this.apiKey = config.apiKey ?? '';
     this.defaultModel = config.model;
-    this.defaultMaxTokens = config.maxTokens ?? 4096;
+    this.defaultMaxTokens = config.maxTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
   }
 
   /** Stream a chat response from an OpenAI-compatible endpoint. */
@@ -89,6 +90,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
         'openai-compatible',
         response.status,
         response.status === 429 || response.status >= 500,
+        classifyOpenAIError(response.status, errorDetail),
       );
     }
 
@@ -170,6 +172,19 @@ export class OpenAICompatibleProvider implements LLMProvider {
             yield { type: 'message_end', stopReason: 'end_turn' };
             return;
           }
+          if (finishReason === 'length') {
+            // OpenAI's signal for output-token ceiling hit. Surface as a
+            // structured error so the UI can tell the user which knob to
+            // turn. Emit any pending tool calls first so nothing is lost.
+            yield* flushToolCalls();
+            throw new LLMError(
+              `Output truncated at max_tokens=${options?.maxTokens ?? this.defaultMaxTokens}. Raise the model's max_tokens setting for this agent role.`,
+              'openai-compatible',
+              undefined,
+              false,
+              'output_tokens_exceeded',
+            );
+          }
         } catch {
           // Skip malformed SSE lines
         }
@@ -216,4 +231,27 @@ export class OpenAICompatibleProvider implements LLMProvider {
 
     return result;
   }
+}
+
+/**
+ * Classify an HTTP error from an OpenAI-compatible endpoint into a structured
+ * {@link LLMErrorReason}. Pattern-matches the error body because providers
+ * differ on status codes for token-limit issues (some use 400, others 413).
+ */
+function classifyOpenAIError(status: number, body: string): LLMErrorReason {
+  const msg = body.toLowerCase();
+  if (status === 401 || status === 403) return 'auth';
+  if (status === 429) return 'rate_limited';
+  if (status >= 500) return 'server_error';
+  if (msg.includes('max_tokens') || msg.includes('max tokens') || msg.includes('output token')) {
+    return 'output_tokens_exceeded';
+  }
+  if (msg.includes('context') && (msg.includes('length') || msg.includes('window'))) {
+    return 'context_length_exceeded';
+  }
+  if (msg.includes('maximum context') || msg.includes('too many tokens')) {
+    return 'context_length_exceeded';
+  }
+  if (status === 400) return 'invalid_request';
+  return 'unknown';
 }

--- a/packages/agent/src/provider/types.ts
+++ b/packages/agent/src/provider/types.ts
@@ -43,6 +43,29 @@ export interface ChatOptions {
   system?: string;
 }
 
+/**
+ * Structured reason for an LLM error. Helps callers render actionable messages
+ * instead of a generic "AI provider error" when the root cause is a knob the
+ * user can turn (e.g., `maxTokens` too small).
+ *
+ * - `output_tokens_exceeded`: the model produced a response at the `maxTokens`
+ *   ceiling — view output may be truncated.
+ * - `context_length_exceeded`: total input (messages + tools + system) is
+ *   larger than the model's context window.
+ * - `invalid_request`: provider rejected the request shape; usually a caller bug.
+ * - `auth`: API key missing or rejected.
+ * - `rate_limited`: 429 from the provider.
+ * - `server_error`: 5xx from the provider.
+ */
+export type LLMErrorReason =
+  | 'output_tokens_exceeded'
+  | 'context_length_exceeded'
+  | 'invalid_request'
+  | 'auth'
+  | 'rate_limited'
+  | 'server_error'
+  | 'unknown';
+
 /** Normalized error from any LLM provider. */
 export class LLMError extends Error {
   constructor(
@@ -50,6 +73,7 @@ export class LLMError extends Error {
     public readonly provider: string,
     public readonly statusCode?: number,
     public readonly retryable: boolean = false,
+    public readonly reason: LLMErrorReason = 'unknown',
   ) {
     super(message);
     this.name = 'LLMError';


### PR DESCRIPTION
## Summary

Three related improvements to how the agent reasons about data sources, plus settings-UI polish that fell out of exercising them end-to-end.

### 1. Schema doc format contract
Annotator prompt now produces a stable H3-sectioned briefing: **Tables**, **Key Join Patterns**, **Useful Enumerations**, **Derived Metrics**, **Semantic Dictionary**, **Implicit Filters**, **Gotchas**, **Example Queries**, **Past Mistakes** placeholder. Parseable with a 10-line regex, which is what unlocks the query-hints checker later. Hard rule in the prompt forbids inventing columns.

### 2. Conversation log drop
New passive recorder at `packages/agent/src/logging/conversation-log.ts`. One JSONL file per chat turn under `.agent-logs/` (gitignored), capturing session metadata, schema-doc snapshots, tool calls with full SQL, and sanitized results (row/col counts only — no raw rows). Advisory only; flush failures never block the response. Wired into the `/api/agent/chat` route via a `ToolContext` wrapper plus event mirroring.

### 3. Token budget threading
`maxTokens` now flows explicitly: `model_configs.max_tokens` → `resolveAIProviders` → `LeaderAgent.maxTokensPerRole` → every agent's `ChatOptions`. The inline `?? 4096` fallbacks in `ClaudeProvider` and `OpenAICompatibleProvider` collapse into a single named constant (`DEFAULT_MAX_OUTPUT_TOKENS`). `LLMError.reason` surfaces `output_tokens_exceeded` / `context_length_exceeded` / `auth` / `rate_limited` / `server_error` / `invalid_request` / `unknown`, and the chat route renders actionable messages per reason instead of a generic "AI provider error".

### 4. Settings polish (fell out of testing)
- **Schema doc editor** on `/settings/data-sources/[id]`: replaces the read-only schema browser with a markdown editor preloaded from `config.schemaDoc`, with Generate-with-AI / Reset / Save actions wired to the existing endpoints.
- **Cross-page cache fix**: `/explore` and `/settings/data-sources` both read the `['data-sources']` query key but returned different shapes (envelope vs flat array). Navigating between the pages blew up `.map is not a function`. Both now return `DataSourceRow[]`.
- **Delete error surface**: the mutation now parses the server's JSON error body, and `DataSourcesSection` renders a dismissable banner so the user knows why a row reappeared after optimistic removal. Previously the error was swallowed silently.

## Test plan

- [x] `pnpm --filter @lightboard/agent typecheck` clean
- [x] `pnpm --filter @lightboard/web lint` clean (`next lint && tsc --noEmit`)
- [x] `pnpm --filter @lightboard/agent test` — 124/124 pass (13 new across 3 files)
- [x] `pnpm --filter @lightboard/web test` — 137/137 pass
- [x] Manual chat session against cricket DB — JSONL appears under `.agent-logs/` with expected event shape, no raw rows leaked
- [x] Regenerate cricket schema doc via `POST /api/data-sources/.../schema/generate` — all 9 H3 headers present in order, Past Mistakes pinned to `_(none yet)_`
- [x] Schema tab editor loads saved doc, type → save roundtrips, status flips to Saved
- [x] Delete flow: throwaway data source removed end-to-end; injected 500 shows the error banner and restores the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)