### PR TITLE
feat(agent): enrich AgentEvent tool events + sub-agent bubble-up

### DIFF
--- a/apps/web/src/app/api/agent/chat/route.ts
+++ b/apps/web/src/app/api/agent/chat/route.ts
@@ -561,13 +561,24 @@ function handleStreaming(
                 enqueue('text', { text: event.text });
                 break;
               case 'tool_start':
-                enqueue('tool_start', { name: event.name, id: event.id });
+                enqueue('tool_start', {
+                  name: event.name,
+                  id: event.id,
+                  ...(event.kind !== undefined ? { kind: event.kind } : {}),
+                  ...(event.label !== undefined ? { label: event.label } : {}),
+                  ...(event.parentAgent !== undefined ? { parentAgent: event.parentAgent } : {}),
+                });
                 break;
               case 'tool_end': {
                 enqueue('tool_end', {
                   name: event.name,
                   result: event.result,
                   isError: event.isError,
+                  ...(event.kind !== undefined ? { kind: event.kind } : {}),
+                  ...(event.label !== undefined ? { label: event.label } : {}),
+                  ...(event.resultSummary !== undefined ? { resultSummary: event.resultSummary } : {}),
+                  ...(event.durationMs !== undefined ? { durationMs: event.durationMs } : {}),
+                  ...(event.parentAgent !== undefined ? { parentAgent: event.parentAgent } : {}),
                 });
 
                 // Emit view_created for view-related tool results

--- a/apps/web/src/components/explore/chat-message.tsx
+++ b/apps/web/src/components/explore/chat-message.tsx
@@ -31,6 +31,16 @@ export type MessagePart =
       result?: string;
       durationMs?: number;
       parentAgent?: string;
+      /**
+       * Backend-supplied semantic kind (uppercase: 'SCHEMA' | 'QUERY' | ...).
+       * When present the editorial trace prefers this over its local
+       * `kindFor` name-based fallback.
+       */
+      toolKind?: string;
+      /** Backend-supplied compact label like `sql(SELECT batter, SUM(runs)…)`. */
+      label?: string;
+      /** Backend-supplied terminal suffix like `→ 412 rows`. */
+      resultSummary?: string;
     }
   | {
       kind: 'agent_delegation';

--- a/apps/web/src/components/explore/sse-reducer.ts
+++ b/apps/web/src/components/explore/sse-reducer.ts
@@ -36,13 +36,28 @@ export type SSEEventShape =
   | { type: 'thinking'; text: string }
   | { type: 'text'; text: string }
   | { type: 'status'; text: string }
-  | { type: 'tool_start'; name: string; input?: unknown }
+  | {
+      type: 'tool_start';
+      name: string;
+      input?: unknown;
+      /** Backend-supplied `ToolKind` (uppercase string) used for coloring. */
+      kind?: string;
+      /** Backend-supplied compact display label. */
+      label?: string;
+      /** Role of the parent sub-agent, if this tool ran inside one. */
+      parentAgent?: string;
+    }
   | {
       type: 'tool_end';
       name: string;
       result?: string;
       durationMs?: number;
       isError?: boolean;
+      kind?: string;
+      label?: string;
+      /** Terminal suffix like `→ 412 rows`. */
+      resultSummary?: string;
+      parentAgent?: string;
     }
   | { type: 'agent_start'; agent: string; task?: string }
   | { type: 'agent_end'; agent: string; summary?: string }
@@ -155,7 +170,11 @@ export function reduceParts(
     }
 
     case 'tool_start': {
+      // Prefer the backend's explicit parentAgent (sub-agent bubble-up)
+      // over the locally-tracked active-agent stack. The stack only moves
+      // on agent_start/agent_end which don't fire in dispatch mode.
       const parentAgent =
+        event.parentAgent ??
         ctx.activeAgentStack[ctx.activeAgentStack.length - 1];
       const part: MessagePart = {
         kind: 'tool_call',
@@ -163,6 +182,8 @@ export function reduceParts(
         status: 'running',
         ...(event.input !== undefined ? { input: event.input } : {}),
         ...(parentAgent ? { parentAgent } : {}),
+        ...(event.kind !== undefined ? { toolKind: event.kind } : {}),
+        ...(event.label !== undefined ? { label: event.label } : {}),
       };
       const nextCtx: ReducerContext = {
         ...ctx,
@@ -237,6 +258,12 @@ export function reduceParts(
         ...(derivedDuration !== undefined
           ? { durationMs: derivedDuration }
           : {}),
+        // Backend-supplied fields win over whatever was stamped at tool_start
+        // (tool_start only ever has `kind`; label/resultSummary land here).
+        ...(event.kind !== undefined ? { toolKind: event.kind } : {}),
+        ...(event.label !== undefined ? { label: event.label } : {}),
+        ...(event.resultSummary !== undefined ? { resultSummary: event.resultSummary } : {}),
+        ...(event.parentAgent !== undefined ? { parentAgent: event.parentAgent } : {}),
       };
       const nextParts = [
         ...basePartsForNonStatus.slice(0, matchIndex),
@@ -415,6 +442,9 @@ export function parseSSEJson(
         type: 'tool_start',
         name: data.name,
         ...(data.input !== undefined ? { input: data.input } : {}),
+        ...(typeof data.kind === 'string' ? { kind: data.kind } : {}),
+        ...(typeof data.label === 'string' ? { label: data.label } : {}),
+        ...(typeof data.parentAgent === 'string' ? { parentAgent: data.parentAgent } : {}),
       };
     case 'tool_end':
       if (typeof data.name !== 'string') return null;
@@ -426,6 +456,10 @@ export function parseSSEJson(
           ? { durationMs: data.durationMs }
           : {}),
         ...(typeof data.isError === 'boolean' ? { isError: data.isError } : {}),
+        ...(typeof data.kind === 'string' ? { kind: data.kind } : {}),
+        ...(typeof data.label === 'string' ? { label: data.label } : {}),
+        ...(typeof data.resultSummary === 'string' ? { resultSummary: data.resultSummary } : {}),
+        ...(typeof data.parentAgent === 'string' ? { parentAgent: data.parentAgent } : {}),
       };
     case 'agent_start':
       if (typeof data.agent !== 'string') return null;

--- a/apps/web/src/components/explore/trace/tool-call-row.tsx
+++ b/apps/web/src/components/explore/trace/tool-call-row.tsx
@@ -23,6 +23,10 @@ const KIND_COLOR: Record<string, string> = {
  * Map a tool name to a semantic kind for coloring. Keep this pure/local —
  * no runtime data-source lookups. New tools can be added here as the
  * backend grows.
+ *
+ * This remains the fallback path. When the backend supplies `part.toolKind`,
+ * the renderer prefers it (the backend's classifier is the source of truth;
+ * this function exists so stale bundles still color rows sensibly).
  */
 function kindFor(name: string): keyof typeof KIND_COLOR {
   if (name === 'get_schema' || name === 'describe_table' || name === 'introspect_schema') {
@@ -31,8 +35,22 @@ function kindFor(name: string): keyof typeof KIND_COLOR {
   if (name === 'run_sql' || name === 'execute_query') return 'query';
   if (name === 'create_view' || name === 'modify_view') return 'viz';
   if (name === 'apply_filter') return 'filter';
-  if (name === 'summarize' || name === 'caveat') return 'narrate';
+  if (name === 'summarize' || name === 'caveat' || name === 'narrate_summary') {
+    return 'narrate';
+  }
   return 'compute';
+}
+
+/**
+ * Normalize a `ToolKind` (uppercase, from the backend) to the lowercase key
+ * the `KIND_COLOR` map expects. Tolerates unknown values by returning
+ * `null` so the caller can fall back to the name-based classifier.
+ */
+function kindFromBackend(kind: string | undefined): keyof typeof KIND_COLOR | null {
+  if (!kind) return null;
+  const k = kind.toLowerCase();
+  if (k in KIND_COLOR) return k as keyof typeof KIND_COLOR;
+  return null;
 }
 
 /**
@@ -91,6 +109,23 @@ function formatDuration(ms: number): string {
 }
 
 /**
+ * Split a backend-supplied label like `sql(SELECT batter, SUM(runs)…)`
+ * into `{ name: 'sql', args: 'SELECT batter, SUM(runs)…' }`. Preserves the
+ * existing two-tone rendering (name in ink-1, parens in ink-5). Returns
+ * null when the label doesn't match the expected shape.
+ */
+function parseToolLabel(label: string): { name: string; args: string } | null {
+  // Find the first `(` and match its closing `)` at the very end.
+  const openIdx = label.indexOf('(');
+  if (openIdx <= 0) return null;
+  if (!label.endsWith(')')) return null;
+  return {
+    name: label.slice(0, openIdx),
+    args: label.slice(openIdx + 1, -1),
+  };
+}
+
+/**
  * Props for {@link ToolCallRow}.
  */
 interface ToolCallRowProps {
@@ -114,19 +149,37 @@ interface ToolCallRowProps {
  * visually.
  */
 export function ToolCallRow({ part }: ToolCallRowProps) {
-  const kind = kindFor(part.name);
+  // Prefer the backend-supplied kind; fall back to the name-based map so
+  // stale bundles still render sensibly. Lower-cased because CSS tokens
+  // are keyed in lowercase while the backend emits uppercase `ToolKind`.
+  const kind = kindFromBackend(part.toolKind) ?? kindFor(part.name);
   const kindColor = KIND_COLOR[kind];
   const isRunning = part.status === 'running';
   const isError = part.status === 'error';
   const isAborted = part.status === 'aborted';
   const isNested = !!part.parentAgent;
 
-  // Derive display parts. Long SQL (>100 chars) renders in an expandable
-  // details block so single-line rows stay readable.
+  // Derive display parts. If the backend supplied a compact `label` use
+  // that; otherwise reconstruct from the tool name + args. Long SQL (>100
+  // chars) renders in an expandable details block so single-line rows stay
+  // readable.
   const raw = displayInput(part.input);
   const isLong = raw.length > 100;
   const inlineArgs = isLong ? truncateArgs(raw) : raw;
-  const rows = rowsFromResult(part.result);
+  // Parse the backend-supplied `tool(args)` label into its components so we
+  // can keep the existing two-tone rendering (`name` in ink-1, parens in
+  // ink-5, args in default) without changing the DOM shape.
+  const parsedLabel = part.label ? parseToolLabel(part.label) : null;
+  const displayName = parsedLabel?.name ?? part.name;
+  const displayArgs = parsedLabel?.args ?? inlineArgs;
+
+  // Result-summary precedence:
+  //   1) backend-supplied `part.resultSummary` (`→ 412 rows`, `→ view created`)
+  //   2) locally-derived `→ N rows` from a parseable run_sql result
+  //   3) null — no suffix rendered
+  const localRows = rowsFromResult(part.result);
+  const summary = part.resultSummary
+    ?? (localRows != null ? `→ ${localRows} rows` : null);
 
   const dotBackground = isRunning ? 'var(--bg-0)' : 'var(--bg-0)';
   const dotBorderColor = isError
@@ -196,7 +249,7 @@ export function ToolCallRow({ part }: ToolCallRowProps) {
       >
         {kind}
       </div>
-      {/* Middle: tool(args) → rows */}
+      {/* Middle: tool(args) → summary */}
       <div
         style={{
           fontFamily: 'var(--font-mono), JetBrains Mono, ui-monospace, monospace',
@@ -213,14 +266,14 @@ export function ToolCallRow({ part }: ToolCallRowProps) {
             textDecoration: isAborted ? 'line-through' : 'none',
           }}
         >
-          {part.name}
+          {displayName}
         </span>
         <span style={{ color: 'var(--ink-5)' }}>(</span>
-        <span>{inlineArgs}</span>
+        <span>{displayArgs}</span>
         <span style={{ color: 'var(--ink-5)' }}>)</span>
-        {rows != null && (
+        {summary && (
           <span style={{ color: 'var(--ink-4)', marginLeft: 8 }}>
-            → {rows} rows
+            {summary}
           </span>
         )}
       </div>

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,4 +1,5 @@
 import { ConversationManager } from './conversation/manager';
+import { classifyTool, formatEnd, formatStart, type ToolKind } from './events/tool-event-formatter';
 import type { LLMProvider, Message, StreamEvent, ToolCallResult } from './provider/types';
 import { buildSystemPrompt } from './prompt/system';
 import { agentTools } from './tools/definitions';
@@ -7,8 +8,30 @@ import { ToolRouter, type ToolContext } from './tools/router';
 /** Events emitted by the agent during a conversation turn. */
 export type AgentEvent =
   | { type: 'text'; text: string }
-  | { type: 'tool_start'; name: string; id: string }
-  | { type: 'tool_end'; name: string; result: string; isError: boolean }
+  | {
+      type: 'tool_start';
+      name: string;
+      id: string;
+      /** Semantic bucket used by the UI to color-code the row. */
+      kind?: ToolKind;
+      /** Compact single-line label for the editorial trace. */
+      label?: string;
+      /** When a sub-agent ran this tool, the role of that sub-agent. */
+      parentAgent?: string;
+    }
+  | {
+      type: 'tool_end';
+      name: string;
+      result: string;
+      isError: boolean;
+      kind?: ToolKind;
+      label?: string;
+      /** Terminal suffix like `→ 412 rows`. */
+      resultSummary?: string;
+      /** Wall-clock execution duration, measured around the tool router call. */
+      durationMs?: number;
+      parentAgent?: string;
+    }
   | { type: 'agent_start'; agent: string; task: string }
   | { type: 'agent_end'; agent: string; summary: string }
   | { type: 'thinking'; text: string }
@@ -112,9 +135,18 @@ export class Agent {
           case 'tool_call_start':
             hasToolCalls = true;
             toolInputBuffers.set(event.id, '');
-            yield { type: 'tool_start', name: event.name, id: event.id };
-            // Store the tool name for later
+            // Store the tool name for later so we can enrich tool_start once
+            // the input has finished streaming.
             toolCalls.push({ id: event.id, name: event.name, input: {} });
+            // Emit the start event now (with kind only — label comes once
+            // the input is complete at tool_end boundary). A minimally-enriched
+            // start lets the UI still color the row while args are streaming.
+            yield {
+              type: 'tool_start',
+              name: event.name,
+              id: event.id,
+              kind: classifyTool(event.name),
+            };
             break;
 
           case 'tool_call_delta':
@@ -161,14 +193,27 @@ export class Agent {
       const toolResults = [];
       let allFailed = true;
       for (const tc of toolCalls) {
+        const { kind, label } = formatStart(tc.name, tc.input);
+        const startMs = performance.now();
         const result = await this.toolRouter.execute(tc.name, tc.input);
+        const durationMs = Math.max(0, Math.round(performance.now() - startMs));
+        const { resultSummary } = formatEnd(tc.name, result.content, result.isError, durationMs);
         toolResults.push({
           toolCallId: tc.id,
           content: result.content,
           isError: result.isError,
         });
         if (!result.isError) allFailed = false;
-        yield { type: 'tool_end', name: tc.name, result: result.content, isError: result.isError };
+        yield {
+          type: 'tool_end',
+          name: tc.name,
+          result: result.content,
+          isError: result.isError,
+          kind,
+          label,
+          durationMs,
+          ...(resultSummary !== undefined ? { resultSummary } : {}),
+        };
       }
 
       // Circuit breaker: stop if tools keep failing

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -10,6 +10,7 @@ export {
 export type {
   SubAgent,
   SubAgentConfig,
+  SubAgentEventCallback,
   SubAgentRole,
   AgentTask,
   SubAgentResult,

--- a/packages/agent/src/agents/insights-agent.test.ts
+++ b/packages/agent/src/agents/insights-agent.test.ts
@@ -185,6 +185,51 @@ describe('InsightsAgent', () => {
     expect(results[0]!.success).toBe(true);
   });
 
+  it('fires onEvent with enriched tool_start and tool_end events', async () => {
+    const ctx = mockToolContext();
+    const captured: Array<{ type: string; name: string; kind?: string; label?: string; resultSummary?: string }> = [];
+
+    const agent = new InsightsAgent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'analyze_data' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'analyze_data',
+            input: { sql: 'SELECT AVG(sales) FROM sales_data', description: 'Average sales' },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'Analyzed.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolRouter: new ToolRouter(ctx, insightsTools),
+      onEvent: (event) => {
+        captured.push({
+          type: event.type,
+          name: event.name,
+          ...('kind' in event ? { kind: event.kind } : {}),
+          ...('label' in event ? { label: event.label } : {}),
+          ...('resultSummary' in event ? { resultSummary: event.resultSummary } : {}),
+        });
+      },
+    });
+
+    await agent.run(createInsightsTask());
+
+    const startEvent = captured.find((e) => e.type === 'tool_start');
+    const endEvent = captured.find((e) => e.type === 'tool_end');
+
+    expect(startEvent?.kind).toBe('COMPUTE');
+    expect(endEvent?.kind).toBe('COMPUTE');
+    expect(endEvent?.label).toBe('analyze_data(Average sales)');
+    // Default mock returns { rows: [...], rowCount: 2 } → → 2 rows
+    expect(endEvent?.resultSummary).toBe('→ 2 rows');
+  });
+
   it('returns failure when max rounds exceeded without final text', async () => {
     // Provider always makes tool calls, never returns text
     const infiniteToolProvider: LLMProvider = {

--- a/packages/agent/src/agents/insights-agent.ts
+++ b/packages/agent/src/agents/insights-agent.ts
@@ -1,3 +1,4 @@
+import { classifyTool, formatEnd, formatStart } from '../events/tool-event-formatter';
 import type { Message, ToolCallResult } from '../provider/types';
 import { buildInsightsPrompt } from '../prompt/insights-prompt';
 import { insightsTools } from '../tools/insights-tools';
@@ -55,6 +56,12 @@ export class InsightsAgent implements SubAgent {
             hasToolCalls = true;
             toolInputBuffers.set(event.id, '');
             toolCalls.push({ id: event.id, name: event.name, input: {} });
+            this.config.onEvent?.({
+              type: 'tool_start',
+              name: event.name,
+              id: event.id,
+              kind: classifyTool(event.name),
+            });
             break;
           case 'tool_call_delta':
             toolInputBuffers.set(event.id, (toolInputBuffers.get(event.id) ?? '') + event.input);
@@ -103,11 +110,26 @@ export class InsightsAgent implements SubAgent {
           this.config.onStatus?.(desc ? `Analyzing: ${String(desc)}` : 'Running statistical analysis…');
         }
 
+        const { kind, label } = formatStart(tc.name, tc.input);
+        const startMs = performance.now();
         const result = await this.config.toolRouter.execute(tc.name, tc.input);
+        const durationMs = Math.max(0, Math.round(performance.now() - startMs));
+        const { resultSummary } = formatEnd(tc.name, result.content, result.isError, durationMs);
         toolResults.push({
           toolCallId: tc.id,
           content: result.content,
           isError: result.isError,
+        });
+
+        this.config.onEvent?.({
+          type: 'tool_end',
+          name: tc.name,
+          result: result.content,
+          isError: result.isError,
+          kind,
+          label,
+          durationMs,
+          ...(resultSummary !== undefined ? { resultSummary } : {}),
         });
 
         // Capture analysis results

--- a/packages/agent/src/agents/leader.test.ts
+++ b/packages/agent/src/agents/leader.test.ts
@@ -445,6 +445,125 @@ describe('LeaderAgent', () => {
     await scratchpadManager.destroyAll();
   });
 
+  it('enriches tool_end events with kind, label and durationMs', async () => {
+    const scratchpadManager = new ScratchpadManager({ cleanupIntervalMs: 0 });
+    const leader = new LeaderAgent({
+      provider: mockProvider([
+        // Leader calls list_scratchpads — handled synchronously inside the
+        // leader so it's the simplest path to assert enrichment on.
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'list_scratchpads' },
+          { type: 'tool_call_end', id: 'tc_1', name: 'list_scratchpads', input: {} },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'Done.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [],
+      scratchpadManager,
+    });
+
+    const events = await collectEvents(leader, 'What tables do I have?');
+
+    const start = events.find(
+      (e) => e.type === 'tool_start' && e.name === 'list_scratchpads',
+    ) as Extract<AgentEvent, { type: 'tool_start' }> | undefined;
+    expect(start).toBeDefined();
+    // tool_start carries the kind immediately so the UI can color the row
+    // while inputs are still streaming.
+    expect(start?.kind).toBe('COMPUTE');
+
+    const end = events.find(
+      (e) => e.type === 'tool_end' && e.name === 'list_scratchpads',
+    ) as Extract<AgentEvent, { type: 'tool_end' }> | undefined;
+    expect(end).toBeDefined();
+    expect(end?.kind).toBe('COMPUTE');
+    expect(end?.label).toBe('list_scratchpads()');
+    expect(typeof end?.durationMs).toBe('number');
+    expect((end?.durationMs as number) >= 0).toBe(true);
+
+    await scratchpadManager.destroyAll();
+  });
+
+  it('bubbles sub-agent tool events up with parentAgent stamped', async () => {
+    // Leader synchronously delegates to QueryAgent. The sub-agent runs
+    // run_sql internally; we expect those tool_start/tool_end events to
+    // surface on the outer stream tagged with parentAgent='query'.
+    const leader = new LeaderAgent({
+      provider: mockProvider([
+        // Round 1: leader calls delegate_query
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'delegate_query' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'delegate_query',
+            input: { instruction: 'Count rows', source_id: 'pg-main' },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Sub-agent round 1: run_sql
+        [
+          { type: 'tool_call_start', id: 'sub_1', name: 'run_sql' },
+          {
+            type: 'tool_call_end',
+            id: 'sub_1',
+            name: 'run_sql',
+            input: { source_id: 'pg-main', sql: 'SELECT COUNT(*) FROM orders' },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        // Sub-agent round 2: text only
+        [
+          { type: 'text_delta', text: 'Got it.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+        // Leader round 2: final text
+        [
+          { type: 'text_delta', text: 'Found the rows.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolContext: mockToolContext(),
+      dataSources: [{ id: 'pg-main', name: 'Main DB', type: 'postgres' }],
+    });
+
+    const events = await collectEvents(leader, 'Count orders');
+
+    const bubbledStart = events.find(
+      (e) => e.type === 'tool_start' && e.name === 'run_sql',
+    ) as Extract<AgentEvent, { type: 'tool_start' }> | undefined;
+    expect(bubbledStart).toBeDefined();
+    expect(bubbledStart?.parentAgent).toBe('query');
+    expect(bubbledStart?.kind).toBe('QUERY');
+
+    const bubbledEnd = events.find(
+      (e) => e.type === 'tool_end' && e.name === 'run_sql',
+    ) as Extract<AgentEvent, { type: 'tool_end' }> | undefined;
+    expect(bubbledEnd).toBeDefined();
+    expect(bubbledEnd?.parentAgent).toBe('query');
+    expect(bubbledEnd?.kind).toBe('QUERY');
+    // Label pulled from formatStart — should summarize the SQL body.
+    expect(bubbledEnd?.label).toMatch(/^sql\(SELECT COUNT/);
+    expect(typeof bubbledEnd?.durationMs).toBe('number');
+    // The mocked runSQL returns { rows: [...], rowCount: 1 } → "→ 1 rows".
+    expect(bubbledEnd?.resultSummary).toBe('→ 1 rows');
+
+    // The parent delegate_query tool_end is emitted after the bubble-up
+    // events so the trace renders children before their parent's `done`.
+    const startIdx = events.findIndex((e) => e.type === 'tool_start' && e.name === 'run_sql');
+    const endIdx = events.findIndex((e) => e.type === 'tool_end' && e.name === 'run_sql');
+    const parentEndIdx = events.findIndex(
+      (e) => e.type === 'tool_end' && e.name === 'delegate_query',
+    );
+    expect(startIdx).toBeGreaterThan(-1);
+    expect(endIdx).toBeGreaterThan(startIdx);
+    expect(parentEndIdx).toBeGreaterThan(endIdx);
+  });
+
   it('resets conversation', async () => {
     const leader = new LeaderAgent({
       provider: mockProvider([

--- a/packages/agent/src/agents/leader.ts
+++ b/packages/agent/src/agents/leader.ts
@@ -1,5 +1,6 @@
 import type { AgentDataSource, AgentEvent } from '../agent';
 import { ConversationManager } from '../conversation/manager';
+import { classifyTool, formatEnd, formatStart } from '../events/tool-event-formatter';
 import { buildLeaderPrompt } from '../prompt/leader-prompt';
 import type { LLMProvider, Message, ToolCallResult } from '../provider/types';
 import { ScratchpadManager } from '../scratchpad/manager';
@@ -224,7 +225,15 @@ export class LeaderAgent {
             hasToolCalls = true;
             toolInputBuffers.set(event.id, '');
             toolCalls.push({ id: event.id, name: event.name, input: {} });
-            yield { type: 'tool_start', name: event.name, id: event.id };
+            // Emit start with kind immediately so the UI can color the row
+            // while args are still streaming. Label + resultSummary arrive on
+            // tool_end once inputs and outputs are final.
+            yield {
+              type: 'tool_start',
+              name: event.name,
+              id: event.id,
+              kind: classifyTool(event.name),
+            };
             break;
           case 'tool_call_delta': {
             const buf = toolInputBuffers.get(event.id) ?? '';
@@ -273,6 +282,9 @@ export class LeaderAgent {
       for (const tc of toolCalls) {
         let result: { content: string; isError: boolean };
 
+        const { kind, label } = formatStart(tc.name, tc.input);
+        const startMs = performance.now();
+
         if (tc.name.startsWith('dispatch_')) {
           result = yield* this.handleDispatch(tc, conversationId);
         } else if (tc.name === 'await_tasks') {
@@ -293,14 +305,36 @@ export class LeaderAgent {
           result = { content: `Unknown tool: ${tc.name}`, isError: true };
         }
 
+        const durationMs = Math.max(0, Math.round(performance.now() - startMs));
+        const { resultSummary } = formatEnd(tc.name, result.content, result.isError, durationMs);
+
+        // Flush any sub-agent tool events queued during this tool's execution
+        // BEFORE the parent tool_end lands. That way the trace renders:
+        //   delegate_query (running)
+        //     → SCHEMA get_schema (done)
+        //     → QUERY sql(...) (done)
+        //   delegate_query (done)
+        // instead of ending the delegate row before its nested children.
+        yield* this.flushPending();
+
         toolResults.push({
           toolCallId: tc.id,
           content: result.content,
           isError: result.isError,
         });
-        yield { type: 'tool_end', name: tc.name, result: result.content, isError: result.isError };
+        yield {
+          type: 'tool_end',
+          name: tc.name,
+          result: result.content,
+          isError: result.isError,
+          kind,
+          label,
+          durationMs,
+          ...(resultSummary !== undefined ? { resultSummary } : {}),
+        };
 
-        // Flush any async events that fired during this tool call.
+        // Catch anything that landed between the flush above and tool_end
+        // (vanishingly rare, but cheap insurance).
         yield* this.flushPending();
       }
 
@@ -531,6 +565,13 @@ export class LeaderAgent {
       || this.getLastUserMessage()
       || 'Explore the available data';
 
+    // Bubble sub-agent tool events up to the outer stream. Stamps `parentAgent`
+    // onto the event so the trace UI renders the row as a nested child of the
+    // surrounding dispatch_* / delegate_* call.
+    const onEvent = (event: Extract<AgentEvent, { type: 'tool_start' } | { type: 'tool_end' }>): void => {
+      this.pendingEvents.push({ ...event, parentAgent: role });
+    };
+
     if (role === 'query') {
       const sourceId = (input.source_id as string) ?? this.dataSources[0]?.id ?? '';
       const ds = this.dataSources.find((d) => d.id === sourceId);
@@ -542,6 +583,7 @@ export class LeaderAgent {
         maxToolRounds: this.subAgentMaxRounds,
         maxTokens: this.maxTokensPerRole.query,
         onStatus,
+        onEvent,
       });
 
       const task: AgentTask = {
@@ -576,6 +618,7 @@ export class LeaderAgent {
         maxToolRounds: this.subAgentMaxRounds,
         maxTokens: this.maxTokensPerRole.view,
         onStatus,
+        onEvent,
       });
 
       let dataSummary = input.data_summary as Record<string, unknown> | undefined;
@@ -604,6 +647,7 @@ export class LeaderAgent {
       maxToolRounds: this.subAgentMaxRounds,
       maxTokens: this.maxTokensPerRole.insights,
       onStatus,
+      onEvent,
     });
 
     const task: AgentTask = {

--- a/packages/agent/src/agents/query-agent.test.ts
+++ b/packages/agent/src/agents/query-agent.test.ts
@@ -291,6 +291,56 @@ describe('QueryAgent', () => {
     expect(capturedSystem).toContain('pg-main');
   });
 
+  it('fires onEvent with enriched tool_start and tool_end events', async () => {
+    const ctx = mockToolContext();
+    const captured: Array<{ type: string; name: string; kind?: string; label?: string; resultSummary?: string; durationMs?: number }> = [];
+
+    const agent = new QueryAgent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'run_sql' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'run_sql',
+            input: { source_id: 'pg-main', sql: 'SELECT region FROM orders' },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'Done.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolRouter: new ToolRouter(ctx),
+      onEvent: (event) => {
+        captured.push({
+          type: event.type,
+          name: event.name,
+          ...('kind' in event ? { kind: event.kind } : {}),
+          ...('label' in event ? { label: event.label } : {}),
+          ...('resultSummary' in event ? { resultSummary: event.resultSummary } : {}),
+          ...('durationMs' in event ? { durationMs: event.durationMs } : {}),
+        });
+      },
+    });
+
+    await agent.run(makeTask('Get region data'));
+
+    const startEvent = captured.find((e) => e.type === 'tool_start');
+    const endEvent = captured.find((e) => e.type === 'tool_end');
+
+    expect(startEvent).toBeDefined();
+    expect(startEvent?.kind).toBe('QUERY');
+
+    expect(endEvent).toBeDefined();
+    expect(endEvent?.kind).toBe('QUERY');
+    expect(endEvent?.label).toMatch(/^sql\(SELECT region/);
+    expect(typeof endEvent?.durationMs).toBe('number');
+    // Mocked runSQL returns 2 rows in the default context.
+    expect(endEvent?.resultSummary).toBe('→ 2 rows');
+  });
+
   it('only passes query tools to the LLM', async () => {
     let capturedTools: unknown;
 

--- a/packages/agent/src/agents/query-agent.ts
+++ b/packages/agent/src/agents/query-agent.ts
@@ -1,3 +1,4 @@
+import { classifyTool, formatEnd, formatStart } from '../events/tool-event-formatter';
 import type { Message, ToolCallResult } from '../provider/types';
 import { buildQueryPrompt } from '../prompt/query-prompt';
 import { queryTools } from '../tools/query-tools';
@@ -60,6 +61,15 @@ export class QueryAgent implements SubAgent {
             hasToolCalls = true;
             toolInputBuffers.set(event.id, '');
             toolCalls.push({ id: event.id, name: event.name, input: {} });
+            // Bubble a minimally-enriched tool_start up to the leader so
+            // the trace UI can render this row with the right color while
+            // args are still streaming. Label arrives on tool_end.
+            this.config.onEvent?.({
+              type: 'tool_start',
+              name: event.name,
+              id: event.id,
+              kind: classifyTool(event.name),
+            });
             break;
           case 'tool_call_delta':
             toolInputBuffers.set(event.id, (toolInputBuffers.get(event.id) ?? '') + event.input);
@@ -103,11 +113,28 @@ export class QueryAgent implements SubAgent {
       const toolResults = [];
       for (const tc of toolCalls) {
         this.emitStatus(describeQueryToolCall(tc.name, tc.input));
+        const { kind, label } = formatStart(tc.name, tc.input);
+        const startMs = performance.now();
         const result = await this.config.toolRouter.execute(tc.name, tc.input);
+        const durationMs = Math.max(0, Math.round(performance.now() - startMs));
+        const { resultSummary } = formatEnd(tc.name, result.content, result.isError, durationMs);
         toolResults.push({
           toolCallId: tc.id,
           content: result.content,
           isError: result.isError,
+        });
+
+        // Bubble the structured tool_end up so the leader's stream can render
+        // the sub-agent's tool calls as nested rows in the trace.
+        this.config.onEvent?.({
+          type: 'tool_end',
+          name: tc.name,
+          result: result.content,
+          isError: result.isError,
+          kind,
+          label,
+          durationMs,
+          ...(resultSummary !== undefined ? { resultSummary } : {}),
         });
 
         if (result.isError) {

--- a/packages/agent/src/agents/types.ts
+++ b/packages/agent/src/agents/types.ts
@@ -1,8 +1,24 @@
+import type { AgentEvent } from '../agent';
 import type { LLMProvider, ToolDefinition } from '../provider/types';
 import type { ToolRouter } from '../tools/router';
 
 /** Roles that sub-agents can take in the multi-agent orchestration. */
 export type SubAgentRole = 'query' | 'view' | 'insights';
+
+/**
+ * Typed event callback fed to sub-agents so their tool calls can bubble up
+ * to the leader's outer stream. The leader passes one in that re-yields
+ * the event after stamping `parentAgent` onto it — letting the editorial
+ * trace render nested `SCHEMA introspect_schema(...)` and
+ * `QUERY sql(...)` rows under a `dispatch_query` parent.
+ *
+ * Kept narrow (tool_start/tool_end only today) because the sub-agents do
+ * not drive text or delegate further themselves — if that ever changes we
+ * can widen this without rewriting callers.
+ */
+export type SubAgentEventCallback = (
+  event: Extract<AgentEvent, { type: 'tool_start' } | { type: 'tool_end' }>,
+) => void;
 
 /**
  * A task assigned by the leader to a sub-agent.
@@ -73,4 +89,11 @@ export interface SubAgentConfig {
    * tool calls. Safe to omit.
    */
   onStatus?: (message: string) => void;
+  /**
+   * Optional typed event callback for bubbling structured tool events
+   * (tool_start / tool_end) up to the leader's outer stream. The leader
+   * re-yields these with `parentAgent: 'query' | 'view' | 'insights'`
+   * stamped on so the trace UI can render nested rows.
+   */
+  onEvent?: SubAgentEventCallback;
 }

--- a/packages/agent/src/agents/view-agent.test.ts
+++ b/packages/agent/src/agents/view-agent.test.ts
@@ -229,6 +229,53 @@ describe('ViewAgent', () => {
     expect(results[0]!.success).toBe(true);
   });
 
+  it('fires onEvent with enriched tool_start and tool_end events', async () => {
+    const captured: Array<{ type: string; name: string; kind?: string; label?: string; resultSummary?: string }> = [];
+
+    const agent = new ViewAgent({
+      provider: mockProvider([
+        [
+          { type: 'tool_call_start', id: 'tc_1', name: 'create_view' },
+          {
+            type: 'tool_call_end',
+            id: 'tc_1',
+            name: 'create_view',
+            input: {
+              title: 'Sales by Region',
+              sql: 'SELECT region, SUM(amount) FROM orders GROUP BY region',
+              html: '<html><body>chart</body></html>',
+            },
+          },
+          { type: 'message_end', stopReason: 'tool_use' },
+        ],
+        [
+          { type: 'text_delta', text: 'View ready.' },
+          { type: 'message_end', stopReason: 'end_turn' },
+        ],
+      ]),
+      toolRouter: new ToolRouter(mockToolContext()),
+      onEvent: (event) => {
+        captured.push({
+          type: event.type,
+          name: event.name,
+          ...('kind' in event ? { kind: event.kind } : {}),
+          ...('label' in event ? { label: event.label } : {}),
+          ...('resultSummary' in event ? { resultSummary: event.resultSummary } : {}),
+        });
+      },
+    });
+
+    await agent.run(createViewTask());
+
+    const startEvent = captured.find((e) => e.type === 'tool_start');
+    const endEvent = captured.find((e) => e.type === 'tool_end');
+
+    expect(startEvent?.kind).toBe('VIZ');
+    expect(endEvent?.kind).toBe('VIZ');
+    expect(endEvent?.label).toBe('create_view(Sales by Region)');
+    expect(endEvent?.resultSummary).toBe('→ view created');
+  });
+
   it('extracts JSON from code blocks in text response', async () => {
     const agent = new ViewAgent({
       provider: mockProvider([

--- a/packages/agent/src/agents/view-agent.ts
+++ b/packages/agent/src/agents/view-agent.ts
@@ -1,3 +1,4 @@
+import { classifyTool, formatEnd, formatStart } from '../events/tool-event-formatter';
 import type { Message, ToolCallResult } from '../provider/types';
 import { buildViewPrompt } from '../prompt/view-prompt';
 import { viewTools } from '../tools/view-tools';
@@ -55,6 +56,12 @@ export class ViewAgent implements SubAgent {
             hasToolCalls = true;
             toolInputBuffers.set(event.id, '');
             toolCalls.push({ id: event.id, name: event.name, input: {} });
+            this.config.onEvent?.({
+              type: 'tool_start',
+              name: event.name,
+              id: event.id,
+              kind: classifyTool(event.name),
+            });
             break;
           case 'tool_call_delta':
             toolInputBuffers.set(event.id, (toolInputBuffers.get(event.id) ?? '') + event.input);
@@ -107,11 +114,26 @@ export class ViewAgent implements SubAgent {
           );
         }
 
+        const { kind, label } = formatStart(tc.name, tc.input);
+        const startMs = performance.now();
         const result = await this.config.toolRouter.execute(tc.name, tc.input);
+        const durationMs = Math.max(0, Math.round(performance.now() - startMs));
+        const { resultSummary } = formatEnd(tc.name, result.content, result.isError, durationMs);
         toolResults.push({
           toolCallId: tc.id,
           content: result.content,
           isError: result.isError,
+        });
+
+        this.config.onEvent?.({
+          type: 'tool_end',
+          name: tc.name,
+          result: result.content,
+          isError: result.isError,
+          kind,
+          label,
+          durationMs,
+          ...(resultSummary !== undefined ? { resultSummary } : {}),
         });
 
         // Capture the view data from create_view or modify_view results

--- a/packages/agent/src/events/tool-event-formatter.test.ts
+++ b/packages/agent/src/events/tool-event-formatter.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyTool, formatEnd, formatStart } from './tool-event-formatter';
+
+describe('classifyTool', () => {
+  it.each([
+    ['get_schema', 'SCHEMA'],
+    ['describe_table', 'SCHEMA'],
+    ['introspect_schema', 'SCHEMA'],
+    ['propose_schema_doc', 'SCHEMA'],
+    ['run_sql', 'QUERY'],
+    ['execute_query', 'QUERY'],
+    ['check_query_hints', 'FILTER'],
+    ['apply_filter', 'FILTER'],
+    ['create_view', 'VIZ'],
+    ['modify_view', 'VIZ'],
+    ['analyze_data', 'COMPUTE'],
+    ['list_scratchpads', 'COMPUTE'],
+    ['load_scratchpad', 'COMPUTE'],
+    ['narrate_summary', 'NARRATE'],
+    ['dispatch_query', 'COMPUTE'],
+    ['dispatch_view', 'COMPUTE'],
+    ['dispatch_insights', 'COMPUTE'],
+    ['delegate_query', 'COMPUTE'],
+    ['await_tasks', 'COMPUTE'],
+    ['cancel_task', 'COMPUTE'],
+    ['totally_unknown_tool', 'COMPUTE'],
+  ])('classifies %s as %s', (name, expected) => {
+    expect(classifyTool(name)).toBe(expected);
+  });
+});
+
+describe('formatStart', () => {
+  it('formats get_schema with an empty body', () => {
+    const { kind, label } = formatStart('get_schema', {});
+    expect(kind).toBe('SCHEMA');
+    expect(label).toBe('get_schema()');
+  });
+
+  it('pulls source.table out of describe_table input', () => {
+    const out = formatStart('describe_table', {
+      source_id: 'cricket',
+      table_name: 'ball_by_ball',
+    });
+    expect(out.kind).toBe('SCHEMA');
+    expect(out.label).toBe('describe_table(cricket.ball_by_ball)');
+  });
+
+  it('falls back to the bare table name when source_id missing', () => {
+    const out = formatStart('describe_table', { table_name: 'ball_by_ball' });
+    expect(out.label).toBe('describe_table(ball_by_ball)');
+  });
+
+  it('summarizes short SQL verbatim', () => {
+    const out = formatStart('run_sql', { sql: 'SELECT 1' });
+    expect(out.kind).toBe('QUERY');
+    expect(out.label).toBe('sql(SELECT 1)');
+  });
+
+  it('truncates SQL at the FROM clause', () => {
+    const sql = 'SELECT batter, SUM(runs) FROM cricket.ball_by_ball WHERE over < 20';
+    const out = formatStart('run_sql', { sql });
+    expect(out.label).toBe('sql(SELECT batter, SUM(runs))');
+  });
+
+  it('collapses multi-line SQL whitespace', () => {
+    const sql = `SELECT
+        batter,
+        SUM(runs)
+      FROM cricket.ball_by_ball`;
+    const out = formatStart('run_sql', { sql });
+    expect(out.label).toBe('sql(SELECT batter, SUM(runs))');
+  });
+
+  it('truncates SQL with no FROM clause at the 60-char ceiling', () => {
+    const sql = 'SELECT ' + 'a, '.repeat(50);
+    const out = formatStart('run_sql', { sql });
+    // Should start with `sql(SELECT ` and end with the ellipsis truncation
+    expect(out.label.startsWith('sql(SELECT ')).toBe(true);
+    // The label body (inside the parens) is truncated to 60 chars.
+    const inner = out.label.slice('sql('.length, -1);
+    expect(inner.length).toBeLessThanOrEqual(60);
+    expect(inner.endsWith('…')).toBe(true);
+  });
+
+  it('formats execute_query like run_sql', () => {
+    const out = formatStart('execute_query', { sql: 'SELECT 1' });
+    expect(out.kind).toBe('QUERY');
+    expect(out.label).toBe('sql(SELECT 1)');
+  });
+
+  it('formats create_view with a truncated title', () => {
+    const out = formatStart('create_view', {
+      title: 'Top 10 Indian batters by TSR since 2010 in cricket world cups',
+    });
+    expect(out.kind).toBe('VIZ');
+    expect(out.label.startsWith('create_view(Top 10 Indian batters by TSR')).toBe(true);
+    const inner = out.label.slice('create_view('.length, -1);
+    expect(inner.length).toBeLessThanOrEqual(40);
+    expect(inner.endsWith('…')).toBe(true);
+  });
+
+  it('formats modify_view with the title when present', () => {
+    const out = formatStart('modify_view', { title: 'Sales by region' });
+    expect(out.kind).toBe('VIZ');
+    expect(out.label).toBe('modify_view(Sales by region)');
+  });
+
+  it('formats dispatch_query with the instruction', () => {
+    const out = formatStart('dispatch_query', {
+      instruction: 'Count orders grouped by customer region over the last quarter',
+    });
+    expect(out.kind).toBe('COMPUTE');
+    expect(out.label.startsWith('dispatch_query(Count orders grouped by')).toBe(true);
+  });
+
+  it('formats await_tasks with a count', () => {
+    expect(formatStart('await_tasks', { task_ids: ['a', 'b', 'c'] }).label).toBe(
+      'await_tasks(3 tasks)',
+    );
+    expect(formatStart('await_tasks', { task_ids: ['a'] }).label).toBe(
+      'await_tasks(1 task)',
+    );
+    expect(formatStart('await_tasks', { task_ids: [] }).label).toBe(
+      'await_tasks(0 tasks)',
+    );
+  });
+
+  it('falls back to name() for unknown tools', () => {
+    const out = formatStart('some_tool_we_have_never_seen', { random: 'stuff' });
+    expect(out.kind).toBe('COMPUTE');
+    expect(out.label).toBe('some_tool_we_have_never_seen()');
+  });
+
+  it('handles non-object input defensively', () => {
+    expect(formatStart('get_schema', null).label).toBe('get_schema()');
+    expect(formatStart('run_sql', 'not-an-object' as unknown).label).toBe('run_sql()');
+  });
+});
+
+describe('formatEnd', () => {
+  it('surfaces rowCount from a run_sql result', () => {
+    const out = formatEnd(
+      'run_sql',
+      JSON.stringify({ rowCount: 412, rows: [] }),
+      false,
+      42,
+    );
+    expect(out.resultSummary).toBe('→ 412 rows');
+  });
+
+  it('falls back to rows.length when rowCount is missing', () => {
+    const out = formatEnd(
+      'run_sql',
+      JSON.stringify({ rows: [{ a: 1 }, { a: 2 }] }),
+      false,
+      10,
+    );
+    expect(out.resultSummary).toBe('→ 2 rows');
+  });
+
+  it('reports → view created for create_view', () => {
+    const out = formatEnd('create_view', '{"viewSpec":{"html":"x"}}', false, 5);
+    expect(out.resultSummary).toBe('→ view created');
+  });
+
+  it('reports → view updated for modify_view', () => {
+    const out = formatEnd('modify_view', '{}', false, 5);
+    expect(out.resultSummary).toBe('→ view updated');
+  });
+
+  it('reports findings count for analyze_data when present', () => {
+    const out = formatEnd(
+      'analyze_data',
+      JSON.stringify({ findings: [{}, {}, {}] }),
+      false,
+      10,
+    );
+    expect(out.resultSummary).toBe('→ 3 findings');
+  });
+
+  it('reports rows for analyze_data when no findings are present', () => {
+    const out = formatEnd(
+      'analyze_data',
+      JSON.stringify({ rowCount: 5, rows: [] }),
+      false,
+      10,
+    );
+    expect(out.resultSummary).toBe('→ 5 rows');
+  });
+
+  it('reports task count for await_tasks', () => {
+    const out = formatEnd(
+      'await_tasks',
+      JSON.stringify({ task_q1: {}, task_v1: {} }),
+      false,
+      10,
+    );
+    expect(out.resultSummary).toBe('→ 2 tasks');
+  });
+
+  it('reports → proposed for propose_schema_doc', () => {
+    const out = formatEnd('propose_schema_doc', '{"proposed":true}', false, 8);
+    expect(out.resultSummary).toBe('→ proposed');
+  });
+
+  it('reports → error on the error path regardless of tool', () => {
+    expect(formatEnd('run_sql', 'connection refused', true, 1).resultSummary).toBe('→ error');
+    expect(formatEnd('create_view', 'boom', true, 1).resultSummary).toBe('→ error');
+    expect(formatEnd('get_schema', 'fail', true, 1).resultSummary).toBe('→ error');
+  });
+
+  it('returns an empty object for unknown tools', () => {
+    expect(formatEnd('get_schema', '{}', false, 1)).toEqual({});
+    expect(formatEnd('totally_unknown', 'stuff', false, 1)).toEqual({});
+  });
+
+  it('returns an empty object for run_sql results that are not JSON', () => {
+    expect(formatEnd('run_sql', 'plain text result', false, 1)).toEqual({});
+  });
+});

--- a/packages/agent/src/events/tool-event-formatter.ts
+++ b/packages/agent/src/events/tool-event-formatter.ts
@@ -1,0 +1,293 @@
+/**
+ * Pure classification and label/result formatters for tool call events.
+ *
+ * The editorial trace UI wants three things on every tool row:
+ *   1. a `kind` bucket so it can color-code the row (SCHEMA teal, QUERY warm,
+ *      VIZ butter, etc.);
+ *   2. a compact human-friendly `label` like `sql(SELECT batter, SUM(runs)…)`
+ *      instead of the tool name + a dump of its JSON arguments;
+ *   3. a terminal `result_summary` like `→ 412 rows` or `→ view created` so
+ *      the row reads at a glance.
+ *
+ * These functions are intentionally pure — no logger, no I/O, no timers — so
+ * they are trivial to test and cheap to call from both the leader and
+ * monolithic agent paths.
+ */
+
+/**
+ * Bucket a tool name falls into for display purposes. The UI maps each kind
+ * to a CSS token (`--kind-schema`, `--kind-query`, etc.). New tools should
+ * land in one of these six buckets — grow the union only if a new bucket
+ * genuinely cannot fit.
+ */
+export type ToolKind =
+  | 'SCHEMA'
+  | 'QUERY'
+  | 'COMPUTE'
+  | 'FILTER'
+  | 'VIZ'
+  | 'NARRATE';
+
+/** Max length of a compact single-line tool label before we truncate. */
+const LABEL_MAX_LEN = 60;
+
+/** Tools that introspect the data source and return schema metadata. */
+const SCHEMA_TOOLS = new Set([
+  'get_schema',
+  'describe_table',
+  'introspect_schema',
+  'propose_schema_doc',
+]);
+
+/** Tools that actually execute a query and return rows. */
+const QUERY_TOOLS = new Set(['run_sql', 'execute_query']);
+
+/** Tools that validate / shape a query without executing it on the source. */
+const FILTER_TOOLS = new Set(['check_query_hints', 'apply_filter']);
+
+/** Tools that produce or mutate a visualization. */
+const VIZ_TOOLS = new Set(['create_view', 'modify_view']);
+
+/**
+ * Tools that perform scratchpad / DuckDB-side computation or explicitly
+ * touch the in-memory scratchpad. Control-plane dispatch/await calls also
+ * land here — they aren't direct data work but they're "the agent doing
+ * something" in the COMPUTE sense the UI renders as a neutral lavender.
+ */
+const COMPUTE_TOOLS = new Set([
+  'analyze_data',
+  'list_scratchpads',
+  'load_scratchpad',
+]);
+
+/**
+ * Map a tool name to its {@link ToolKind}. Unknown tools fall through to
+ * `COMPUTE` so the UI always has a color to render — better than a blank
+ * row or a runtime error.
+ */
+export function classifyTool(name: string): ToolKind {
+  if (SCHEMA_TOOLS.has(name)) return 'SCHEMA';
+  if (QUERY_TOOLS.has(name)) return 'QUERY';
+  if (FILTER_TOOLS.has(name)) return 'FILTER';
+  if (VIZ_TOOLS.has(name)) return 'VIZ';
+  if (COMPUTE_TOOLS.has(name)) return 'COMPUTE';
+  if (name === 'narrate_summary') return 'NARRATE';
+  // dispatch_* / delegate_* / await_tasks / cancel_task — control plane.
+  if (
+    name.startsWith('dispatch_') ||
+    name.startsWith('delegate_') ||
+    name === 'await_tasks' ||
+    name === 'cancel_task'
+  ) {
+    return 'COMPUTE';
+  }
+  return 'COMPUTE';
+}
+
+/**
+ * Collapse runs of whitespace into a single space and trim both ends.
+ * Used on SQL bodies so multi-line statements render on one line.
+ */
+function compactWhitespace(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Truncate a string to `max` characters, appending a single-char ellipsis
+ * (`…`) when truncation happened. Leaves short strings untouched.
+ */
+function truncate(s: string, max: number = LABEL_MAX_LEN): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + '…';
+}
+
+/**
+ * Reduce a SQL body to its SELECT clause (up to but not including FROM),
+ * then truncate to the label ceiling. Falls back to a plain truncate when
+ * the SQL has no FROM clause (subqueries with only CTEs, `SELECT 1`, etc.).
+ */
+function summarizeSql(sql: string): string {
+  const compact = compactWhitespace(sql);
+  const fromMatch = /\bfrom\b/i.exec(compact);
+  const body = fromMatch ? compact.slice(0, fromMatch.index).trim() : compact;
+  return truncate(body);
+}
+
+/**
+ * Build the compact single-line label for a tool call as it starts.
+ *
+ * Shape mimics the design reference: `toolname(<short arg hint>)`. The
+ * shape stays consistent across tools so the UI renders a uniform column
+ * regardless of which specialist is running.
+ */
+export function formatStart(
+  name: string,
+  input: unknown,
+): { kind: ToolKind; label: string } {
+  const kind = classifyTool(name);
+  const obj = (input && typeof input === 'object' ? (input as Record<string, unknown>) : {});
+
+  // run_sql / execute_query — summarize the SQL body.
+  if (name === 'run_sql' || name === 'execute_query') {
+    const sql = typeof obj.sql === 'string' ? obj.sql : '';
+    if (sql) {
+      return { kind, label: `sql(${summarizeSql(sql)})` };
+    }
+    return { kind, label: `${name}()` };
+  }
+
+  // describe_table — prefer the table name directly so the row reads
+  // `describe_table(cricket.ball_by_ball)` not a JSON blob.
+  if (name === 'describe_table') {
+    const source = typeof obj.source_id === 'string' ? obj.source_id : '';
+    const table = typeof obj.table_name === 'string'
+      ? obj.table_name
+      : typeof obj.table === 'string'
+      ? obj.table
+      : '';
+    if (table) {
+      const qualified = source ? `${source}.${table}` : table;
+      return { kind, label: `describe_table(${truncate(qualified)})` };
+    }
+    return { kind, label: 'describe_table()' };
+  }
+
+  // create_view / modify_view — title is the most useful identifier.
+  if (name === 'create_view' || name === 'modify_view') {
+    const title = typeof obj.title === 'string' ? obj.title : '';
+    if (title) {
+      return { kind, label: `${name}(${truncate(title, 40)})` };
+    }
+    return { kind, label: `${name}()` };
+  }
+
+  // dispatch_* / delegate_* — instruction first ~40 chars.
+  if (name.startsWith('dispatch_') || name.startsWith('delegate_')) {
+    const instr = typeof obj.instruction === 'string' ? obj.instruction : '';
+    if (instr) {
+      return { kind, label: `${name}(${truncate(compactWhitespace(instr), 40)})` };
+    }
+    return { kind, label: `${name}()` };
+  }
+
+  // await_tasks — count the tasks the leader is waiting on.
+  if (name === 'await_tasks') {
+    const ids = Array.isArray(obj.task_ids) ? obj.task_ids.length : 0;
+    const plural = ids === 1 ? '' : 's';
+    return { kind, label: `await_tasks(${ids} task${plural})` };
+  }
+
+  // analyze_data — the description is the human-friendly hint.
+  if (name === 'analyze_data') {
+    const desc = typeof obj.description === 'string' ? obj.description : '';
+    if (desc) {
+      return { kind, label: `analyze_data(${truncate(compactWhitespace(desc), 40)})` };
+    }
+    return { kind, label: 'analyze_data()' };
+  }
+
+  // propose_schema_doc — no meaningful inputs to display.
+  if (name === 'propose_schema_doc') {
+    const source = typeof obj.source_id === 'string' ? obj.source_id : '';
+    return {
+      kind,
+      label: source ? `propose_schema_doc(${truncate(source, 40)})` : 'propose_schema_doc()',
+    };
+  }
+
+  // Default: tool name + parenthesized empty body so the UI stays uniform.
+  return { kind, label: `${name}()` };
+}
+
+/**
+ * Try to parse a tool's raw string output as JSON, returning `undefined`
+ * if the content isn't valid JSON. Kept loose because tools commonly
+ * return plain strings on error paths.
+ */
+function safeParseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Derive a terminal `→ ...` summary for a completed tool call.
+ *
+ * The UI falls back to a plain duration when `resultSummary` is undefined,
+ * so returning `{ }` on unknown shapes is a valid and expected outcome —
+ * do not invent a fake summary.
+ */
+export function formatEnd(
+  name: string,
+  output: string,
+  isError: boolean,
+  _durationMs: number,
+): { resultSummary?: string } {
+  if (isError) {
+    return { resultSummary: '→ error' };
+  }
+
+  // run_sql / execute_query — report the row count.
+  if (name === 'run_sql' || name === 'execute_query') {
+    const parsed = safeParseJson(output);
+    if (parsed && typeof parsed === 'object') {
+      const p = parsed as Record<string, unknown>;
+      const rowCount = typeof p.rowCount === 'number'
+        ? p.rowCount
+        : Array.isArray(p.rows)
+        ? p.rows.length
+        : undefined;
+      if (typeof rowCount === 'number') {
+        return { resultSummary: `→ ${rowCount.toLocaleString()} rows` };
+      }
+    }
+    return {};
+  }
+
+  if (name === 'create_view') {
+    return { resultSummary: '→ view created' };
+  }
+  if (name === 'modify_view') {
+    return { resultSummary: '→ view updated' };
+  }
+
+  // analyze_data — prefer the count of structured findings.
+  if (name === 'analyze_data') {
+    const parsed = safeParseJson(output);
+    if (parsed && typeof parsed === 'object') {
+      const p = parsed as Record<string, unknown>;
+      if (Array.isArray(p.findings)) {
+        const n = p.findings.length;
+        return { resultSummary: `→ ${n} finding${n === 1 ? '' : 's'}` };
+      }
+      // Fall through to rows-style summary for analyses that return rows.
+      const rowCount = typeof p.rowCount === 'number'
+        ? p.rowCount
+        : Array.isArray(p.rows)
+        ? p.rows.length
+        : undefined;
+      if (typeof rowCount === 'number') {
+        return { resultSummary: `→ ${rowCount.toLocaleString()} rows` };
+      }
+    }
+    return {};
+  }
+
+  // await_tasks — count of tasks returned.
+  if (name === 'await_tasks') {
+    const parsed = safeParseJson(output);
+    if (parsed && typeof parsed === 'object') {
+      const n = Object.keys(parsed as Record<string, unknown>).length;
+      return { resultSummary: `→ ${n} task${n === 1 ? '' : 's'}` };
+    }
+    return {};
+  }
+
+  if (name === 'propose_schema_doc') {
+    return { resultSummary: '→ proposed' };
+  }
+
+  return {};
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,5 @@
 export { Agent, type AgentConfig, type AgentDataSource, type AgentEvent } from './agent';
+export { classifyTool, formatStart, formatEnd, type ToolKind } from './events/tool-event-formatter';
 export {
   QueryAgent,
   ViewAgent,


### PR DESCRIPTION
## Summary

Round-2 harness tuning, Phase 1. Closes the gap between the editorial trace UI (`tool-call-row.tsx`) — which already renders the right design (color-coded kind badges, compact labels, per-row durations, `→ N rows` suffixes, nested indentation) — and the backend `AgentEvent` stream, which was only carrying `name` / `id` / `result` / `isError` and not bubbling sub-agent tool calls at all.

### What changed

- **New `packages/agent/src/events/tool-event-formatter.ts`** — pure `classifyTool`, `formatStart`, `formatEnd`. Six `ToolKind`s (SCHEMA / QUERY / COMPUTE / FILTER / VIZ / NARRATE). Compact labels: `sql(SELECT batter, SUM(runs)…)` truncated at FROM clause, `describe_table(cricket.ball_by_ball)`, `create_view(<title>)`, `await_tasks(N task(s))`. Terminal suffixes: `→ 412 rows`, `→ view created`, `→ 3 findings`, `→ error`. NARRATE kind mapped in advance; the `narrate_summary` tool itself is Phase 2 scope, not this PR.
- **`AgentEvent` union extended** — `tool_start` / `tool_end` gain optional `kind`, `label`, `resultSummary`, `durationMs`, `parentAgent`. Every new field is optional, so old consumers still compile and old session replays still render.
- **Leader + monolithic agent** time tool dispatch with `performance.now()` on either side of the router call, run `formatStart` / `formatEnd` before yielding, and flush pending sub-agent events before the parent `tool_end` so nested children land before the parent closes. The conversation log's authoritative `duration_ms` stays untouched — the new event `durationMs` is independent, UI-only.
- **Sub-agent bubble-up** — `SubAgentConfig.onEvent` callback added. `QueryAgent` / `ViewAgent` / `InsightsAgent` each emit enriched `tool_start` / `tool_end` through it. Leader injects a callback that pushes into its existing `pendingEvents` queue with `parentAgent: 'query' | 'view' | 'insights'` stamped on, so the outer stream carries sub-agent tool calls to the UI.
- **SSE route** forwards the new fields verbatim on `tool_start` / `tool_end` enqueue.
- **Frontend** `MessagePart.tool_call` gains `toolKind`, `label`, `resultSummary`. SSE reducer parses and stamps them. `tool-call-row.tsx` prefers the backend values (via a new `kindFromBackend` / `parseToolLabel`) with the existing `kindFor` / `rowsFromResult` helpers retained as fallbacks for stale bundles.

### Scope

Phase 1 of the round-2 plan at `we-have-done-one-ticklish-robin.md`. Functionality only — visual scaffolding (Phase 3) and the `narrate_summary` tool (Phase 2) are separate PRs per the plan's stacked workflow.

## Test plan

- [x] `pnpm --filter @lightboard/agent test -- --run` — 175 pass (+46 formatter, +2 leader, +1 each for query/view/insights agents)
- [x] `pnpm typecheck` — clean across all 9 packages
- [x] `pnpm --filter @lightboard/web lint` — zero warnings, zero errors
- [x] **Browser smoke test** against the cricket Postgres (localhost:5434) with the Haiku 4.5 provider configured by default. Verified:
  - `COMPUTE dispatch_query(Count the total number of rows in the b…)` outer parent
  - `COMPUTE await_tasks(1 task) → 1 task` at 8.4s
  - `QUERY sql(SELECT COUNT(*) AS total_rows) → 1 rows` at 109ms, indented under the parent via the dashed-border nesting the frontend already styles
  - On a follow-up "top 5 teams by total runs" question, the full chain rendered: `dispatch_query` → `await_tasks` → nested `QUERY sql(...) → error` (auto-retry path) → `QUERY sql(...) → 5 rows` → `dispatch_view` → `await_tasks` → nested `VIZ create_view(Top 5 Teams by Total Runs Scored) → view created` → the rendered chart iframe.
  - Error rows show `→ error` in red; success rows show the right kind color (teal for SCHEMA, warm amber for QUERY, butter for VIZ, lavender for COMPUTE).

Screenshots saved locally under `.claude/phase1-*.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)