### PR TITLE
fix(agent): dedupe Qwen-style duplicate tool_call_start chunks

### DIFF
--- a/packages/agent/src/provider/openai-compatible.test.ts
+++ b/packages/agent/src/provider/openai-compatible.test.ts
@@ -1,0 +1,417 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OpenAICompatibleProvider } from './openai-compatible';
+import { LLMError } from './types';
+import type { StreamEvent, ToolDefinition } from './types';
+
+/**
+ * Build a Response whose body streams a sequence of SSE chunks followed by the
+ * terminating `data: [DONE]` line. Each entry in `chunks` becomes one
+ * `data: <json>\n\n` frame.
+ */
+function sseResponse(chunks: Array<Record<string, unknown>>, opts: { includeDone?: boolean } = {}): Response {
+  const encoder = new TextEncoder();
+  const includeDone = opts.includeDone ?? true;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+      }
+      if (includeDone) {
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+/** Collect all events from a provider chat call into an array. */
+async function collectEvents(
+  provider: OpenAICompatibleProvider,
+  tools: ToolDefinition[] = [],
+): Promise<StreamEvent[]> {
+  const events: StreamEvent[] = [];
+  for await (const event of provider.chat([{ role: 'user', content: 'hi' }], tools)) {
+    events.push(event);
+  }
+  return events;
+}
+
+/** Shared tool fixture so every scenario looks the same on the request side. */
+const runSqlTool: ToolDefinition = {
+  name: 'run_sql',
+  description: 'run a SQL query',
+  inputSchema: { type: 'object', properties: {} },
+};
+
+describe('OpenAICompatibleProvider streaming', () => {
+  const fetchMock = vi.fn();
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('emits text deltas for a plain text stream with no tool calls', async () => {
+    fetchMock.mockResolvedValue(
+      sseResponse([
+        { choices: [{ index: 0, delta: { content: 'Hello ' }, finish_reason: null }] },
+        { choices: [{ index: 0, delta: { content: 'world' }, finish_reason: null }] },
+        { choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+      ]),
+    );
+
+    const provider = new OpenAICompatibleProvider({ baseUrl: 'http://mock', model: 'qwen' });
+    const events = await collectEvents(provider);
+
+    expect(events).toEqual([
+      { type: 'text_delta', text: 'Hello ' },
+      { type: 'text_delta', text: 'world' },
+      { type: 'message_end', stopReason: 'end_turn' },
+    ]);
+  });
+
+  it('handles a standard OpenAI tool-call stream (id+name once, then arg deltas)', async () => {
+    fetchMock.mockResolvedValue(
+      sseResponse([
+        {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_abc',
+                    type: 'function',
+                    function: { name: 'run_sql', arguments: '{"sq' },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [{ index: 0, function: { arguments: 'l":"SEL' } }],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [{ index: 0, function: { arguments: 'ECT 1"}' } }],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        { choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] },
+      ]),
+    );
+
+    const provider = new OpenAICompatibleProvider({ baseUrl: 'http://mock', model: 'gpt' });
+    const events = await collectEvents(provider, [runSqlTool]);
+
+    const starts = events.filter((e) => e.type === 'tool_call_start');
+    const deltas = events.filter((e) => e.type === 'tool_call_delta');
+    const ends = events.filter((e) => e.type === 'tool_call_end');
+
+    expect(starts).toHaveLength(1);
+    expect(starts[0]).toEqual({ type: 'tool_call_start', id: 'call_abc', name: 'run_sql' });
+    // Two delta chunks after the initial id+name chunk.
+    expect(deltas).toHaveLength(2);
+    expect(deltas.map((d) => (d.type === 'tool_call_delta' ? d.input : ''))).toEqual(['l":"SEL', 'ECT 1"}']);
+    expect(ends).toHaveLength(1);
+    expect(ends[0]).toEqual({
+      type: 'tool_call_end',
+      id: 'call_abc',
+      name: 'run_sql',
+      input: { sql: 'SELECT 1' },
+    });
+    expect(events.at(-1)).toEqual({ type: 'message_end', stopReason: 'tool_use' });
+  });
+
+  it('dedupes Qwen-style duplicate tool_call_start chunks (id+name on every chunk)', async () => {
+    // Quirk: some Qwen 3.6 35b builds via Ollama/vLLM re-send id + function.name
+    // on every streaming chunk. The provider must emit exactly ONE tool_call_start
+    // and fold subsequent argument fragments as deltas.
+    fetchMock.mockResolvedValue(
+      sseResponse([
+        {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_qwen_1',
+                    type: 'function',
+                    function: { name: 'run_sql', arguments: '{"sq' },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_qwen_1',
+                    type: 'function',
+                    function: { name: 'run_sql', arguments: 'l":"SEL' },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_qwen_1',
+                    type: 'function',
+                    function: { name: 'run_sql', arguments: 'ECT 42"}' },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        { choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] },
+      ]),
+    );
+
+    const provider = new OpenAICompatibleProvider({ baseUrl: 'http://mock', model: 'qwen' });
+    const events = await collectEvents(provider, [runSqlTool]);
+
+    const starts = events.filter((e) => e.type === 'tool_call_start');
+    const deltas = events.filter((e) => e.type === 'tool_call_delta');
+    const ends = events.filter((e) => e.type === 'tool_call_end');
+
+    // Exactly one start despite three chunks carrying id+name.
+    expect(starts).toHaveLength(1);
+    expect(starts[0]).toEqual({ type: 'tool_call_start', id: 'call_qwen_1', name: 'run_sql' });
+    // Two deltas — one per subsequent argument fragment.
+    expect(deltas).toHaveLength(2);
+    expect(deltas.map((d) => (d.type === 'tool_call_delta' ? d.input : ''))).toEqual(['l":"SEL', 'ECT 42"}']);
+    // End carries the assembled arguments parsed into an object.
+    expect(ends).toHaveLength(1);
+    expect(ends[0]).toEqual({
+      type: 'tool_call_end',
+      id: 'call_qwen_1',
+      name: 'run_sql',
+      input: { sql: 'SELECT 42' },
+    });
+  });
+
+  it('drops a pure duplicate tool_call chunk with no new argument fragment', async () => {
+    // Belt-and-suspenders: if a Qwen chunk re-announces id+name but carries no
+    // new argument bytes, nothing should be emitted for it.
+    fetchMock.mockResolvedValue(
+      sseResponse([
+        {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_x',
+                    type: 'function',
+                    function: { name: 'run_sql', arguments: '{"sql":"SELECT 1"}' },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  { index: 0, id: 'call_x', type: 'function', function: { name: 'run_sql' } },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        { choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] },
+      ]),
+    );
+
+    const provider = new OpenAICompatibleProvider({ baseUrl: 'http://mock', model: 'qwen' });
+    const events = await collectEvents(provider, [runSqlTool]);
+
+    expect(events.filter((e) => e.type === 'tool_call_start')).toHaveLength(1);
+    expect(events.filter((e) => e.type === 'tool_call_delta')).toHaveLength(0);
+    const ends = events.filter((e) => e.type === 'tool_call_end');
+    expect(ends).toHaveLength(1);
+    expect(ends[0]).toEqual({
+      type: 'tool_call_end',
+      id: 'call_x',
+      name: 'run_sql',
+      input: { sql: 'SELECT 1' },
+    });
+  });
+
+  it('keeps multi-tool-call indexes separate when interleaved', async () => {
+    fetchMock.mockResolvedValue(
+      sseResponse([
+        {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_a',
+                    type: 'function',
+                    function: { name: 'run_sql', arguments: '{"sql"' },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 1,
+                    id: 'call_b',
+                    type: 'function',
+                    function: { name: 'run_sql', arguments: '{"sql"' },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [{ index: 0, function: { arguments: ':"A"}' } }],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [{ index: 1, function: { arguments: ':"B"}' } }],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        { choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] },
+      ]),
+    );
+
+    const provider = new OpenAICompatibleProvider({ baseUrl: 'http://mock', model: 'qwen' });
+    const events = await collectEvents(provider, [runSqlTool]);
+
+    const starts = events.filter((e) => e.type === 'tool_call_start');
+    expect(starts).toHaveLength(2);
+    expect(starts.map((s) => (s.type === 'tool_call_start' ? s.id : ''))).toEqual(['call_a', 'call_b']);
+
+    const deltasByCall = new Map<string, string[]>();
+    for (const e of events) {
+      if (e.type === 'tool_call_delta') {
+        const existing = deltasByCall.get(e.id) ?? [];
+        existing.push(e.input);
+        deltasByCall.set(e.id, existing);
+      }
+    }
+    expect(deltasByCall.get('call_a')).toEqual([':"A"}']);
+    expect(deltasByCall.get('call_b')).toEqual([':"B"}']);
+
+    const ends = events.filter((e) => e.type === 'tool_call_end');
+    // Ends are emitted by flushToolCalls at finish — two of them, one per index.
+    expect(ends).toHaveLength(2);
+    const endsById = new Map(ends.map((e) => (e.type === 'tool_call_end' ? [e.id, e.input] : ['', {}])));
+    expect(endsById.get('call_a')).toEqual({ sql: 'A' });
+    expect(endsById.get('call_b')).toEqual({ sql: 'B' });
+  });
+
+  it('throws LLMError with reason=output_tokens_exceeded on finish_reason=length', async () => {
+    fetchMock.mockResolvedValue(
+      sseResponse([
+        { choices: [{ index: 0, delta: { content: 'partial' }, finish_reason: null }] },
+        { choices: [{ index: 0, delta: {}, finish_reason: 'length' }] },
+      ]),
+    );
+
+    const provider = new OpenAICompatibleProvider({ baseUrl: 'http://mock', model: 'qwen', maxTokens: 128 });
+
+    await expect(async () => {
+      for await (const _ of provider.chat([{ role: 'user', content: 'hi' }], [])) {
+        // drain
+      }
+    }).rejects.toMatchObject({
+      name: 'LLMError',
+      reason: 'output_tokens_exceeded',
+    });
+  });
+
+  it('surfaces non-2xx responses as retryable LLMError on 5xx', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('upstream down', { status: 502, statusText: 'Bad Gateway' }),
+    );
+
+    const provider = new OpenAICompatibleProvider({ baseUrl: 'http://mock', model: 'qwen' });
+
+    await expect(async () => {
+      for await (const _ of provider.chat([{ role: 'user', content: 'hi' }], [])) {
+        // drain
+      }
+    }).rejects.toBeInstanceOf(LLMError);
+  });
+});

--- a/packages/agent/src/provider/openai-compatible.ts
+++ b/packages/agent/src/provider/openai-compatible.ts
@@ -150,10 +150,25 @@ export class OpenAICompatibleProvider implements LLMProvider {
               const index = tc.index ?? 0;
               const existing = toolCallsByIndex.get(index);
 
+              // Qwen quirks: some Qwen 3.6 35b builds served via Ollama/vLLM emit
+              // tool_calls[N] with id + function.name on every chunk, not just the
+              // first. Naively starting a new tool call each time would corrupt
+              // downstream assembly (duplicate `tool_call_start`, lost arg
+              // fragments, wrong tool_call_id on the tool-result message).
+              // Only start once per index; if the same index shows up again with
+              // id+name, treat any accompanying `arguments` as an append.
               if (tc.id && tc.function?.name) {
-                // First chunk for this tool call — has id and name
-                toolCallsByIndex.set(index, { id: tc.id, name: tc.function.name, args: tc.function.arguments ?? '' });
-                yield { type: 'tool_call_start', id: tc.id, name: tc.function.name };
+                if (!existing) {
+                  // First chunk for this tool call — has id and name
+                  toolCallsByIndex.set(index, { id: tc.id, name: tc.function.name, args: tc.function.arguments ?? '' });
+                  yield { type: 'tool_call_start', id: tc.id, name: tc.function.name };
+                } else if (tc.function.arguments) {
+                  // Quirky duplicate-start chunk carrying a real argument fragment —
+                  // fold it into the existing entry instead of restarting.
+                  existing.args += tc.function.arguments;
+                  yield { type: 'tool_call_delta', id: existing.id, input: tc.function.arguments };
+                }
+                // If it's a pure duplicate (no new arguments), silently drop.
               } else if (tc.function?.arguments && existing) {
                 // Subsequent delta chunks — only have index and argument fragment
                 existing.args += tc.function.arguments;
@@ -185,7 +200,12 @@ export class OpenAICompatibleProvider implements LLMProvider {
               'output_tokens_exceeded',
             );
           }
-        } catch {
+        } catch (err) {
+          // Preserve structured provider errors (e.g. `output_tokens_exceeded`
+          // raised on finish_reason=length) — they're intentional signals, not
+          // SSE parse failures. Anything else is a malformed line and safe to
+          // skip.
+          if (err instanceof LLMError) throw err;
           // Skip malformed SSE lines
         }
       }


### PR DESCRIPTION
## Summary

- Fixes a streaming assembly bug in `OpenAICompatibleProvider` where some Qwen 3.6 35b builds served via Ollama/vLLM emit `tool_calls[N]` with `id` + `function.name` on **every** streaming chunk, not just the first. The previous code naively restarted the tool call each time, emitting duplicate `tool_call_start` events and losing argument fragments — downstream tool-call assembly was corrupted and the final tool-result message got the wrong `tool_call_id`, surfacing as "Unknown tool" errors.
- Only start a tool call once per `index`. If the same index reappears carrying a real argument fragment, fold it in as a `tool_call_delta`; pure duplicates are silently dropped.
- Standard OpenAI / Together / Groq streams (id+name on the first chunk, then bare `arguments` deltas) are unchanged — covered by a dedicated test.
- While in the neighborhood: stop swallowing `LLMError` inside the per-SSE-line `try/catch`. The `finish_reason: 'length'` path intentionally throws `output_tokens_exceeded` to tell the caller which knob to turn, but the catch was treating it like a malformed SSE line and discarding it. `LLMError` now rethrows; non-`LLMError` parse failures are still skipped.

Implements Phase 5 of `we-have-done-one-ticklish-robin.md`.

## Test plan

- [x] `pnpm --filter @lightboard/agent test` — 131 tests pass across 17 test files, including 7 new provider tests
- [x] New `openai-compatible.test.ts` covers:
  - Plain text stream with no tool calls → text deltas only
  - Standard OpenAI tool-call stream (id+name once, then arg deltas) → 1 start + N deltas + 1 end
  - **Qwen duplicate-start stream** (id+name on 3 consecutive chunks with incremental arguments) → exactly 1 `tool_call_start`, 2 `tool_call_delta`s, assembled input `{ sql: "SELECT 42" }`
  - Pure duplicate chunk (id+name, no new argument bytes) → silently dropped
  - Multi-tool-call streams with interleaved indexes → distinct start/delta/end events per index
  - `finish_reason: 'length'` → `LLMError` with `reason: 'output_tokens_exceeded'`
  - 5xx response → `LLMError`
- [x] `pnpm typecheck` — clean across all 9 packages
- [x] `pnpm --filter @lightboard/web lint` — clean (no ESLint warnings, `tsc --noEmit` green)
- [x] Local Qwen smoke test via Ollama/vLLM — **not run**; Ollama/vLLM not available in this session. The fixture-based regression test is the guard.

## Watch-outs / follow-ups

- Ollama's `eval_count` / `prompt_eval_count` usage-hook parsing (mentioned as optional in the plan) was **not** added — the current provider has no `usage` callback, so it would have required a cross-cutting hook. Left as a follow-up to land alongside Phase 4's eval harness, which is where the usage counters will actually be consumed.
- PR base is `harness-tweaking-2`, not `main`, per the plan.

PR base: `harness-tweaking-2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)