### PR TITLE
feat(agent,web): narrate_summary tool + KEY TAKEAWAYS block

### DIFF
--- a/apps/web/src/app/api/agent/chat/route.ts
+++ b/apps/web/src/app/api/agent/chat/route.ts
@@ -277,6 +277,7 @@ async function handleNonStreaming(
     const toolCalls: { name: string; status: string }[] = [];
     let viewSpec: Record<string, unknown> | null = null;
     let queryResult: Record<string, unknown> | null = null;
+    let narration: { bullets: unknown[]; caveat?: string } | null = null;
 
     for (const event of events) {
       mirrorAgentEventToLog(event, convLog);
@@ -319,6 +320,23 @@ async function handleNonStreaming(
               queryResult = JSON.parse(event.result);
             } catch { /* ignore parse errors */ }
           }
+
+          // Extract narration from narrate_summary so JSON callers (tests,
+          // the MCP pass-through) receive the structured takeaways alongside
+          // the view, mirroring the streaming path's `narrate_ready` event.
+          if (event.name === 'narrate_summary' && !event.isError) {
+            try {
+              const parsed = JSON.parse(event.result);
+              if (Array.isArray(parsed?.bullets)) {
+                narration = {
+                  bullets: parsed.bullets,
+                  ...(typeof parsed.caveat === 'string' && parsed.caveat
+                    ? { caveat: parsed.caveat }
+                    : {}),
+                };
+              }
+            } catch { /* ignore parse errors */ }
+          }
           break;
         }
         case 'done':
@@ -340,6 +358,7 @@ async function handleNonStreaming(
       toolCalls,
       viewSpec,
       queryResult,
+      narration,
     });
   } catch (err) {
     if (err instanceof LLMError) {
@@ -613,6 +632,21 @@ function handleStreaming(
                           }
                         }
                       }
+                    }
+                    // narrate_summary: emit a dedicated `narrate_ready` wire
+                    // event so the UI can render the KEY TAKEAWAYS block
+                    // without re-parsing the tool_end result payload. The
+                    // tool_end row itself still flows through — the
+                    // editorial log wants "NARRATE narrate_summary(3 bullets)
+                    // → 3 bullets 204ms" to appear. If parsing fails we
+                    // silently skip; the tool_end fallback covers it.
+                    if (event.name === 'narrate_summary' && Array.isArray(parsed?.bullets)) {
+                      enqueue('narrate_ready', {
+                        bullets: parsed.bullets,
+                        ...(typeof parsed.caveat === 'string' && parsed.caveat
+                          ? { caveat: parsed.caveat }
+                          : {}),
+                      });
                     }
                   } catch { /* ignore parse errors */ }
                 }

--- a/apps/web/src/components/explore/__tests__/sse-reducer.test.ts
+++ b/apps/web/src/components/explore/__tests__/sse-reducer.test.ts
@@ -364,4 +364,66 @@ describe('parseSSEJson', () => {
     expect(parseSSEJson('text', '{"notText":1}')).toBeNull();
     expect(parseSSEJson('tool_start', '{}')).toBeNull();
   });
+
+  describe('narrate_ready', () => {
+    const sample = JSON.stringify({
+      bullets: [
+        { rank: 2, headline: 'Second', body: 'mid-pack finding' },
+        { rank: 1, headline: 'First', value: '+11.59', body: 'big one' },
+        { rank: 3, headline: 'Third', body: 'also-ran' },
+      ],
+      caveat: 'Sample of 40.',
+    });
+
+    it('parses into a typed narrate_ready event with bullets sorted by rank', () => {
+      const parsed = parseSSEJson('narrate_ready', sample);
+      expect(parsed).not.toBeNull();
+      if (parsed?.type !== 'narrate_ready') throw new Error('wrong variant');
+      expect(parsed.narration.bullets.map((b) => b.rank)).toEqual([1, 2, 3]);
+      expect(parsed.narration.bullets[0]!.value).toBe('+11.59');
+      expect(parsed.narration.caveat).toBe('Sample of 40.');
+    });
+
+    it('drops payloads where a bullet is missing a required field', () => {
+      const bad = JSON.stringify({
+        bullets: [
+          { rank: 1, body: 'no headline' },
+          { rank: 2, headline: 'Second', body: 'ok' },
+          { rank: 3, headline: 'Third', body: 'ok' },
+        ],
+      });
+      expect(parseSSEJson('narrate_ready', bad)).toBeNull();
+    });
+
+    it('drops payloads where bullets is not an array', () => {
+      expect(parseSSEJson('narrate_ready', '{"bullets":42}')).toBeNull();
+      expect(parseSSEJson('narrate_ready', '{}')).toBeNull();
+    });
+
+    it('omits caveat when the server sent an empty string', () => {
+      const payload = JSON.stringify({
+        bullets: [
+          { rank: 1, headline: 'a', body: 'A' },
+          { rank: 2, headline: 'b', body: 'B' },
+          { rank: 3, headline: 'c', body: 'C' },
+        ],
+        caveat: '',
+      });
+      const parsed = parseSSEJson('narrate_ready', payload);
+      expect(parsed?.type).toBe('narrate_ready');
+      if (parsed?.type !== 'narrate_ready') throw new Error('wrong variant');
+      expect(parsed.narration.caveat).toBeUndefined();
+    });
+
+    it('does not mutate parts[] when reduced', () => {
+      const before: MessagePart[] = [
+        { kind: 'text', text: 'existing text' },
+      ];
+      const parsed = parseSSEJson('narrate_ready', sample);
+      expect(parsed).not.toBeNull();
+      const reducer = createReducer();
+      const after = reducer.apply(parsed!, before);
+      expect(after).toEqual(before);
+    });
+  });
 });

--- a/apps/web/src/components/explore/__tests__/turn.test.tsx
+++ b/apps/web/src/components/explore/__tests__/turn.test.tsx
@@ -145,4 +145,48 @@ describe('<Turn>', () => {
     expect(stream.children[1]?.textContent).toContain('run_sql');
     expect(stream.children[2]?.textContent).toContain('After tool.');
   });
+
+  it('renders the KEY TAKEAWAYS block below the stream when narration is set', () => {
+    const assistant: ChatMessageData = {
+      id: 'a',
+      role: 'assistant',
+      parts: [
+        { kind: 'text', text: 'Findings below.' },
+      ],
+      narration: {
+        bullets: [
+          { rank: 1, headline: 'Top region', value: '+12.4%', body: 'North led Q4.' },
+          { rank: 2, headline: 'East', body: 'Held steady.' },
+          { rank: 3, headline: 'West', body: 'Flat.' },
+        ],
+        caveat: 'Sample of 40 stores.',
+      },
+    };
+    const { container, getByText } = render(
+      <Turn userMessage={USER} assistantMessage={assistant} />,
+    );
+    // The takeaways eyebrow is in the DOM and the ranks render as 01/02/03.
+    expect(getByText(/Key takeaways/i)).toBeTruthy();
+    expect(getByText('01')).toBeTruthy();
+    expect(getByText('02')).toBeTruthy();
+    expect(getByText('03')).toBeTruthy();
+    // Signed value from bullet 1 shows.
+    expect(getByText('+12.4%')).toBeTruthy();
+    // Caveat banner appears with the interpretation-note label.
+    expect(container.textContent).toContain('Interpretation note');
+    expect(container.textContent).toContain('Sample of 40 stores.');
+  });
+
+  it('omits the KEY TAKEAWAYS block when narration is undefined', () => {
+    const assistant: ChatMessageData = {
+      id: 'a',
+      role: 'assistant',
+      parts: [{ kind: 'text', text: 'No narration here.' }],
+    };
+    const { container } = render(
+      <Turn userMessage={USER} assistantMessage={assistant} />,
+    );
+    expect(container.textContent).not.toContain('Key takeaways');
+    expect(container.textContent).not.toContain('Interpretation note');
+  });
 });

--- a/apps/web/src/components/explore/chat-message.tsx
+++ b/apps/web/src/components/explore/chat-message.tsx
@@ -73,16 +73,40 @@ export type ToolCallData = Extract<MessagePart, { kind: 'tool_call' }>;
 export type AgentIndicatorData = Extract<MessagePart, { kind: 'agent_delegation' }>;
 
 /**
+ * Structured KEY TAKEAWAYS block emitted by the leader's `narrate_summary`
+ * tool. The renderer draws three numbered rows (01 / 02 / 03) plus an
+ * optional amber interpretation-note banner when `caveat` is present.
+ *
+ * This is a message-level field rather than a {@link MessagePart} variant
+ * because it is derived from a dedicated `narrate_ready` SSE event that
+ * appears strictly once per assistant turn and renders below the whole
+ * parts[] sequence — not interleaved with other parts.
+ */
+export interface NarrationBlock {
+  bullets: Array<{
+    rank: 1 | 2 | 3;
+    headline: string;
+    value?: string;
+    body: string;
+  }>;
+  caveat?: string;
+}
+
+/**
  * A single message in the chat. Assistants carry an ordered `parts[]` that
  * the SSE reducer appends to as events arrive. User messages always carry
  * a single `{ kind: 'text' }` part — we keep them in the same shape so the
  * rendering layer doesn't have to branch on role for every field access.
+ *
+ * `narration`, when present, is the structured KEY TAKEAWAYS block emitted
+ * by the leader's `narrate_summary` tool at the end of a data turn.
  */
 export interface ChatMessageData {
   id: string;
   role: 'user' | 'assistant';
   parts: MessagePart[];
   isStreaming?: boolean;
+  narration?: NarrationBlock;
 }
 
 /**

--- a/apps/web/src/components/explore/explore-page-client.tsx
+++ b/apps/web/src/components/explore/explore-page-client.tsx
@@ -459,6 +459,23 @@ export function ExplorePageClient() {
           continue;
         }
 
+        // `narrate_ready` is a message-level field (not a parts[] entry).
+        // Patch the message directly so the KEY TAKEAWAYS block renders at
+        // the bottom of the turn the instant the leader finalizes.
+        if (parsed.type === 'narrate_ready') {
+          // Still run it through the reducer so its status-clear side
+          // effect (drops a trailing transient status) lands, but discard
+          // the returned parts — unchanged.
+          applyEvent(assistantMsgId, (prev) => reducer.apply(parsed, prev));
+          const narration = parsed.narration;
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === assistantMsgId ? { ...m, narration } : m,
+            ),
+          );
+          continue;
+        }
+
         applyEvent(assistantMsgId, (prev) => reducer.apply(parsed, prev));
       }
 

--- a/apps/web/src/components/explore/sse-reducer.ts
+++ b/apps/web/src/components/explore/sse-reducer.ts
@@ -23,7 +23,7 @@
  *   stamped with `parentAgent` so the renderer can indent them.
  */
 
-import type { MessagePart } from './chat-message';
+import type { MessagePart, NarrationBlock } from './chat-message';
 import type { ViewSpec } from '@lightboard/viz-core';
 import type { HtmlView } from '@/components/view-renderer';
 
@@ -66,6 +66,12 @@ export type SSEEventShape =
       viewSpec: HtmlView | ViewSpec;
       queryResult?: { rows?: Record<string, unknown>[] };
     }
+  /**
+   * Terminal narration block emitted once per turn. Carries the structured
+   * bullets + optional caveat that the UI renders below the assistant turn.
+   * Unlike `view_created`, this is not a part — it lives on the message.
+   */
+  | { type: 'narrate_ready'; narration: NarrationBlock }
   | { type: 'abort' }
   | { type: 'done' };
 
@@ -353,6 +359,14 @@ export function reduceParts(
       return { parts: [...basePartsForNonStatus, part], ctx };
     }
 
+    case 'narrate_ready': {
+      // Narration lives on the message, not on parts[] — the caller
+      // handles surfacing it. Parts are unchanged. We still strip a
+      // trailing status if one was sitting on the end, matching the
+      // "any real event clears status" contract.
+      return { parts: basePartsForNonStatus, ctx };
+    }
+
     case 'abort': {
       // Flip every running tool_call / agent_delegation to `aborted`.
       const nextParts = parts.map((p) => {
@@ -484,6 +498,37 @@ export function parseSSEJson(
           ? { queryResult: data.queryResult as { rows?: Record<string, unknown>[] } }
           : {}),
       };
+    case 'narrate_ready': {
+      if (!Array.isArray(data.bullets)) return null;
+      // Re-shape defensively — the server validates already, but parsing
+      // here protects against older backends that might drop keys.
+      const bullets: NarrationBlock['bullets'] = [];
+      for (const b of data.bullets) {
+        if (!b || typeof b !== 'object') return null;
+        const obj = b as Record<string, unknown>;
+        const rank = obj.rank;
+        const headline = obj.headline;
+        const body = obj.body;
+        if ((rank !== 1 && rank !== 2 && rank !== 3)
+          || typeof headline !== 'string'
+          || typeof body !== 'string') {
+          return null;
+        }
+        const value = typeof obj.value === 'string' ? obj.value : undefined;
+        bullets.push({
+          rank,
+          headline,
+          body,
+          ...(value ? { value } : {}),
+        });
+      }
+      bullets.sort((a, b) => a.rank - b.rank);
+      const narration: NarrationBlock = {
+        bullets,
+        ...(typeof data.caveat === 'string' && data.caveat ? { caveat: data.caveat } : {}),
+      };
+      return { type: 'narrate_ready', narration };
+    }
     case 'done':
       return { type: 'done' };
     default:

--- a/apps/web/src/components/explore/trace/key-takeaways.tsx
+++ b/apps/web/src/components/explore/trace/key-takeaways.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import type { NarrationBlock } from '../chat-message';
+
+/**
+ * Props for {@link KeyTakeaways}.
+ *
+ * This is a view-layer mirror of the backend {@link NarrationBlock} — kept
+ * inline rather than importing the backend type because the component is
+ * purely visual and the caller already has the shape in hand.
+ */
+interface KeyTakeawaysProps {
+  bullets: NarrationBlock['bullets'];
+  caveat?: string;
+}
+
+/**
+ * Format a bullet's rank as a two-digit monospace number (01 / 02 / 03).
+ * Matches the design reference's zero-padded column.
+ */
+function formatRank(rank: 1 | 2 | 3): string {
+  return `0${rank}`;
+}
+
+/**
+ * Renders the structured KEY TAKEAWAYS block that ends a data turn. Three
+ * numbered rows with bold headlines and amber-highlighted signed values,
+ * optionally followed by an interpretation-note banner when the model
+ * emitted a caveat.
+ *
+ * Ports `TakeawaysBlock` from `Lightboard-design/components/AgentTrace.jsx`
+ * (~lines 339-406). Colors come from CSS tokens already in globals.css:
+ * `--ink-1` / `--ink-5` / `--ink-6` for text hierarchy, `--accent` / `--accent-bg` /
+ * `--accent-border` / `--accent-ink` for the caveat banner, `--font-mono` and
+ * `--font-body` for typography.
+ *
+ * No emojis — the leading glyph on the caveat row is a unicode warning sign
+ * (`⚠`) rendered in the mono font, matching the design kit's rule that UI
+ * microcopy may use unicode glyphs but not emoji.
+ */
+export function KeyTakeaways({ bullets, caveat }: KeyTakeawaysProps) {
+  if (!bullets || bullets.length === 0) return null;
+
+  return (
+    <div
+      className="ml-[40px]"
+      style={{
+        padding: '18px 22px 20px',
+        borderTop: '1px solid var(--line-2, #1A1A1E)',
+        background: 'var(--bg-1, #0C0C0F)',
+        borderRadius: 8,
+      }}
+    >
+      <div
+        style={{
+          fontFamily: 'var(--font-mono), JetBrains Mono, ui-monospace, monospace',
+          fontSize: 11,
+          letterSpacing: '0.14em',
+          fontWeight: 500,
+          textTransform: 'uppercase',
+          color: 'var(--ink-6, #6B6B73)',
+          marginBottom: 10,
+        }}
+      >
+        Key takeaways
+      </div>
+
+      <ol
+        style={{
+          listStyle: 'none',
+          padding: 0,
+          margin: 0,
+          fontFamily: 'var(--font-body), Inter, system-ui, -apple-system, sans-serif',
+          fontSize: 13,
+          color: 'var(--ink-3, #BDBDC4)',
+          lineHeight: 1.55,
+        }}
+      >
+        {bullets.map((b) => (
+          <li
+            key={b.rank}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '22px 1fr',
+              alignItems: 'baseline',
+              padding: '4px 0',
+            }}
+          >
+            <span
+              style={{
+                fontFamily:
+                  'var(--font-mono), JetBrains Mono, ui-monospace, monospace',
+                fontSize: 10,
+                color: 'var(--ink-5, #55555C)',
+                fontVariantNumeric: 'tabular-nums',
+              }}
+            >
+              {formatRank(b.rank)}
+            </span>
+            <span>
+              <b style={{ color: 'var(--ink-1, #EDEDEE)', fontWeight: 600 }}>
+                {b.headline}
+              </b>
+              {b.value ? (
+                <>
+                  {' '}
+                  <b
+                    style={{
+                      color: 'var(--accent, #F2C265)',
+                      fontWeight: 600,
+                      fontFamily:
+                        'var(--font-mono), JetBrains Mono, ui-monospace, monospace',
+                      fontVariantNumeric: 'tabular-nums',
+                    }}
+                  >
+                    {b.value}
+                  </b>
+                </>
+              ) : null}
+              {b.body ? <> — {b.body}</> : null}
+            </span>
+          </li>
+        ))}
+      </ol>
+
+      {caveat ? (
+        <div
+          style={{
+            marginTop: 14,
+            padding: '10px 12px',
+            borderRadius: 8,
+            background: 'var(--accent-bg, #15120B)',
+            border: '1px solid var(--accent-border, #3B2E14)',
+            fontFamily: 'var(--font-body), Inter, system-ui, -apple-system, sans-serif',
+            fontSize: 12,
+            color: 'var(--accent-ink, #D9A441)',
+            display: 'flex',
+            gap: 10,
+            alignItems: 'flex-start',
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              fontFamily:
+                'var(--font-mono), JetBrains Mono, ui-monospace, monospace',
+              fontSize: 10,
+              marginTop: 2,
+            }}
+          >
+            ⚠
+          </span>
+          <span>
+            <b>Interpretation note</b> — {caveat}
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/explore/turn.tsx
+++ b/apps/web/src/components/explore/turn.tsx
@@ -4,6 +4,7 @@ import { AssistantStream } from './assistant-stream';
 import { SuggestionChips } from './suggestion-chips';
 import { UserMessage } from './user-message';
 import { getFirstText, type ChatMessageData } from './chat-message';
+import { KeyTakeaways } from './trace/key-takeaways';
 
 /**
  * Props for {@link Turn}.
@@ -72,6 +73,16 @@ export function Turn({
         <AssistantStream
           parts={assistantMessage.parts}
           isStreaming={assistantMessage.isStreaming}
+        />
+      )}
+
+      {/* Terminal narration — rendered below the assistant's stream once
+          the leader calls `narrate_summary`. Distinct from parts[] so it
+          always appears at the bottom of the turn, not interleaved. */}
+      {assistantMessage?.narration && (
+        <KeyTakeaways
+          bullets={assistantMessage.narration.bullets}
+          caveat={assistantMessage.narration.caveat}
         />
       )}
 

--- a/packages/agent/src/agents/leader.test.ts
+++ b/packages/agent/src/agents/leader.test.ts
@@ -579,4 +579,218 @@ describe('LeaderAgent', () => {
     leader.reset();
     expect(leader.getHistory()).toHaveLength(0);
   });
+
+  describe('narrate_summary', () => {
+    /** A canonical 3-bullet narrate_summary payload used across these tests. */
+    const validNarratePayload = {
+      bullets: [
+        {
+          rank: 1,
+          headline: 'North region',
+          value: '+12.4%',
+          body: 'North led Q4 growth, well ahead of the pack.',
+        },
+        {
+          rank: 2,
+          headline: 'East region',
+          value: '+4.1%',
+          body: 'East held steady with a modest uptick.',
+        },
+        {
+          rank: 3,
+          headline: 'West region',
+          body: 'West was flat within normal noise.',
+        },
+      ],
+      caveat: 'Sample size of 40 stores; treat with caution.',
+    };
+
+    it('ends the turn with end_turn and enriches tool_end with NARRATE kind', async () => {
+      const leader = new LeaderAgent({
+        provider: mockProvider([
+          [
+            { type: 'tool_call_start', id: 'nt_1', name: 'narrate_summary' },
+            {
+              type: 'tool_call_end',
+              id: 'nt_1',
+              name: 'narrate_summary',
+              input: validNarratePayload,
+            },
+            { type: 'message_end', stopReason: 'tool_use' },
+          ],
+          // This round should never execute — the leader short-circuits after
+          // narrate. If it does run, the fixture stops it harmlessly.
+          [
+            { type: 'text_delta', text: 'extra chatter that should never appear' },
+            { type: 'message_end', stopReason: 'end_turn' },
+          ],
+        ]),
+        toolContext: mockToolContext(),
+        dataSources: [],
+      });
+
+      const events = await collectEvents(leader, 'Summarize the regional breakdown');
+
+      const end = events.find(
+        (e) => e.type === 'tool_end' && e.name === 'narrate_summary',
+      ) as Extract<AgentEvent, { type: 'tool_end' }> | undefined;
+      expect(end).toBeDefined();
+      expect(end?.isError).toBe(false);
+      expect(end?.kind).toBe('NARRATE');
+      expect(typeof end?.durationMs).toBe('number');
+
+      // Result is a valid JSON blob carrying the normalized bullets + caveat.
+      const parsed = JSON.parse(end!.result);
+      expect(Array.isArray(parsed.bullets)).toBe(true);
+      expect(parsed.bullets).toHaveLength(3);
+      expect(parsed.bullets.map((b: { rank: number }) => b.rank)).toEqual([1, 2, 3]);
+      expect(parsed.caveat).toBe('Sample size of 40 stores; treat with caution.');
+      expect(parsed.rendered).toBe(true);
+
+      // Short-circuit must fire: the turn ends with end_turn after narrate,
+      // and no extra text chunk from the unreached fixture round leaks out.
+      const done = events.find(
+        (e) => e.type === 'done',
+      ) as Extract<AgentEvent, { type: 'done' }> | undefined;
+      expect(done?.stopReason).toBe('end_turn');
+
+      const leakedText = events.find(
+        (e) => e.type === 'text' && e.text.includes('extra chatter'),
+      );
+      expect(leakedText).toBeUndefined();
+    });
+
+    it('reports a validation error when the payload has the wrong bullet count', async () => {
+      const leader = new LeaderAgent({
+        provider: mockProvider([
+          [
+            { type: 'tool_call_start', id: 'nt_1', name: 'narrate_summary' },
+            {
+              type: 'tool_call_end',
+              id: 'nt_1',
+              name: 'narrate_summary',
+              input: { bullets: [{ rank: 1, headline: 'only one', body: 'oops' }] },
+            },
+            { type: 'message_end', stopReason: 'tool_use' },
+          ],
+          [
+            { type: 'text_delta', text: 'Let me retry.' },
+            { type: 'message_end', stopReason: 'end_turn' },
+          ],
+        ]),
+        toolContext: mockToolContext(),
+        dataSources: [],
+      });
+
+      const events = await collectEvents(leader, 'summarize');
+      const end = events.find(
+        (e) => e.type === 'tool_end' && e.name === 'narrate_summary',
+      ) as Extract<AgentEvent, { type: 'tool_end' }> | undefined;
+      expect(end?.isError).toBe(true);
+      expect(end?.result).toMatch(/expected exactly 3 bullets/);
+    });
+
+    it('reports a validation error when two bullets share a rank', async () => {
+      const leader = new LeaderAgent({
+        provider: mockProvider([
+          [
+            { type: 'tool_call_start', id: 'nt_1', name: 'narrate_summary' },
+            {
+              type: 'tool_call_end',
+              id: 'nt_1',
+              name: 'narrate_summary',
+              input: {
+                bullets: [
+                  { rank: 1, headline: 'a', body: 'A' },
+                  { rank: 1, headline: 'b', body: 'B' },
+                  { rank: 2, headline: 'c', body: 'C' },
+                ],
+              },
+            },
+            { type: 'message_end', stopReason: 'tool_use' },
+          ],
+          [
+            { type: 'text_delta', text: 'Retrying.' },
+            { type: 'message_end', stopReason: 'end_turn' },
+          ],
+        ]),
+        toolContext: mockToolContext(),
+        dataSources: [],
+      });
+
+      const events = await collectEvents(leader, 'summarize');
+      const end = events.find(
+        (e) => e.type === 'tool_end' && e.name === 'narrate_summary',
+      ) as Extract<AgentEvent, { type: 'tool_end' }> | undefined;
+      expect(end?.isError).toBe(true);
+      expect(end?.result).toMatch(/duplicate rank/);
+    });
+
+    it('reports a validation error when a bullet has an empty body', async () => {
+      const leader = new LeaderAgent({
+        provider: mockProvider([
+          [
+            { type: 'tool_call_start', id: 'nt_1', name: 'narrate_summary' },
+            {
+              type: 'tool_call_end',
+              id: 'nt_1',
+              name: 'narrate_summary',
+              input: {
+                bullets: [
+                  { rank: 1, headline: 'a', body: 'A' },
+                  { rank: 2, headline: 'b', body: '   ' },
+                  { rank: 3, headline: 'c', body: 'C' },
+                ],
+              },
+            },
+            { type: 'message_end', stopReason: 'tool_use' },
+          ],
+          [
+            { type: 'text_delta', text: 'Retrying.' },
+            { type: 'message_end', stopReason: 'end_turn' },
+          ],
+        ]),
+        toolContext: mockToolContext(),
+        dataSources: [],
+      });
+
+      const events = await collectEvents(leader, 'summarize');
+      const end = events.find(
+        (e) => e.type === 'tool_end' && e.name === 'narrate_summary',
+      ) as Extract<AgentEvent, { type: 'tool_end' }> | undefined;
+      expect(end?.isError).toBe(true);
+      expect(end?.result).toMatch(/empty or missing body/);
+    });
+
+    it('continues the leader loop when validation fails (does not short-circuit)', async () => {
+      const leader = new LeaderAgent({
+        provider: mockProvider([
+          [
+            { type: 'tool_call_start', id: 'nt_1', name: 'narrate_summary' },
+            {
+              type: 'tool_call_end',
+              id: 'nt_1',
+              name: 'narrate_summary',
+              input: { bullets: [] },
+            },
+            { type: 'message_end', stopReason: 'tool_use' },
+          ],
+          // After the validation error, the leader should get another turn
+          // and emit this retry text.
+          [
+            { type: 'text_delta', text: 'retry landed' },
+            { type: 'message_end', stopReason: 'end_turn' },
+          ],
+        ]),
+        toolContext: mockToolContext(),
+        dataSources: [],
+      });
+
+      const events = await collectEvents(leader, 'summarize');
+      const retryText = events.find(
+        (e) => e.type === 'text' && e.text === 'retry landed',
+      );
+      expect(retryText).toBeDefined();
+    });
+  });
 });

--- a/packages/agent/src/agents/leader.ts
+++ b/packages/agent/src/agents/leader.ts
@@ -139,6 +139,14 @@ export class LeaderAgent {
   private taskPool: TaskPool = new TaskPool();
   /** Events emitted by background tasks, flushed at safe yield points. */
   private pendingEvents: AgentEvent[] = [];
+  /**
+   * Whether `narrate_summary` has already been called successfully this turn.
+   * Set by the tool-dispatch branch; consumed by the outer loop to short-
+   * circuit the next LLM turn with `stopReason: 'end_turn'` so models that
+   * would otherwise keep emitting text / tool-calls after narrating are
+   * forced to end cleanly. Reset at the start of every `chat()` call.
+   */
+  private narrateCalled = false;
 
   constructor(config: LeaderAgentConfig) {
     if (!config.providers && !config.provider) {
@@ -192,6 +200,7 @@ export class LeaderAgent {
     // Fresh task pool per user turn — tasks should not survive across turns.
     this.taskPool = new TaskPool();
     this.pendingEvents = [];
+    this.narrateCalled = false;
 
     const scratchpad = this.scratchpadManager.getOrCreate(conversationId);
     const scratchpadTables = scratchpad.listTables().map((t) =>
@@ -301,6 +310,11 @@ export class LeaderAgent {
           result = { content: JSON.stringify(tables), isError: false };
         } else if (tc.name === 'load_scratchpad') {
           result = await this.handleLoadScratchpad(tc, conversationId);
+        } else if (tc.name === 'narrate_summary') {
+          result = this.handleNarrateSummary(tc);
+          if (!result.isError) {
+            this.narrateCalled = true;
+          }
         } else {
           result = { content: `Unknown tool: ${tc.name}`, isError: true };
         }
@@ -343,6 +357,16 @@ export class LeaderAgent {
         content: '',
         toolResults,
       });
+
+      // narrate_summary is the leader's terminal tool. If it ran successfully
+      // this round we short-circuit — no more LLM turns, no trailing
+      // chatter. Any model that would have kept calling tools after
+      // narrating is forced to end cleanly with `end_turn`.
+      if (this.narrateCalled) {
+        yield* this.drainOutstanding();
+        yield { type: 'done', stopReason: 'end_turn' };
+        return;
+      }
     }
 
     yield* this.drainOutstanding();
@@ -657,6 +681,102 @@ export class LeaderAgent {
     };
 
     return { result: await agent.run(task) };
+  }
+
+  /**
+   * Validate and echo a `narrate_summary` tool call. Returns a structured
+   * JSON payload the SSE route re-emits as a `narrate_ready` event for the
+   * UI. Validation is deliberately defensive — local Qwen builds drop
+   * minItems / maxItems constraints sometimes, so we check shape here even
+   * though the JSON Schema already declares it.
+   */
+  private handleNarrateSummary(
+    tc: ToolCallResult,
+  ): { content: string; isError: boolean } {
+    const input = (tc.input ?? {}) as Record<string, unknown>;
+    const rawBullets = input.bullets;
+    if (!Array.isArray(rawBullets)) {
+      return {
+        content: 'narrate_summary: `bullets` is required and must be an array of 3 objects.',
+        isError: true,
+      };
+    }
+    if (rawBullets.length !== 3) {
+      return {
+        content: `narrate_summary: expected exactly 3 bullets, received ${rawBullets.length}.`,
+        isError: true,
+      };
+    }
+
+    const seenRanks = new Set<number>();
+    const cleaned: Array<{
+      rank: 1 | 2 | 3;
+      headline: string;
+      value?: string;
+      body: string;
+    }> = [];
+    for (let i = 0; i < rawBullets.length; i++) {
+      const b = rawBullets[i];
+      if (!b || typeof b !== 'object') {
+        return {
+          content: `narrate_summary: bullet ${i} is not an object.`,
+          isError: true,
+        };
+      }
+      const obj = b as Record<string, unknown>;
+      const rank = obj.rank;
+      if (rank !== 1 && rank !== 2 && rank !== 3) {
+        return {
+          content: `narrate_summary: bullet ${i} has invalid rank "${String(rank)}" (must be 1, 2, or 3).`,
+          isError: true,
+        };
+      }
+      if (seenRanks.has(rank)) {
+        return {
+          content: `narrate_summary: duplicate rank ${rank} — each of 1, 2, 3 must appear exactly once.`,
+          isError: true,
+        };
+      }
+      seenRanks.add(rank);
+
+      const headline = typeof obj.headline === 'string' ? obj.headline.trim() : '';
+      if (!headline) {
+        return {
+          content: `narrate_summary: bullet ${i} (rank ${rank}) has empty or missing headline.`,
+          isError: true,
+        };
+      }
+
+      const body = typeof obj.body === 'string' ? obj.body.trim() : '';
+      if (!body) {
+        return {
+          content: `narrate_summary: bullet ${i} (rank ${rank}) has empty or missing body.`,
+          isError: true,
+        };
+      }
+
+      const value = typeof obj.value === 'string' ? obj.value.trim() : undefined;
+      cleaned.push({
+        rank,
+        headline,
+        body,
+        ...(value ? { value } : {}),
+      });
+    }
+
+    // Sort by rank so downstream consumers don't have to re-order.
+    cleaned.sort((a, b) => a.rank - b.rank);
+
+    const caveat = typeof input.caveat === 'string' ? input.caveat.trim() : '';
+
+    return {
+      content: JSON.stringify({
+        bullets: cleaned,
+        ...(caveat ? { caveat } : {}),
+        rendered: true,
+      }),
+      isError: false,
+    };
   }
 
   /** Handle load_scratchpad — returns summary, not full data. */

--- a/packages/agent/src/prompt/leader-prompt.ts
+++ b/packages/agent/src/prompt/leader-prompt.ts
@@ -40,6 +40,16 @@ The only acceptable reasons to end a turn without a view:
 - Every dispatched query failed and there is nothing to visualize
 - You asked the user a clarifying question and are waiting for their reply
 
+## End every answer with narrate_summary
+
+After \`dispatch_view\` + \`await_tasks\` succeed, your final tool call is exactly one \`narrate_summary\` with 3 ranked bullets (rank 1 = biggest finding). Use signed numbers for \`value\` (\`+11.59\`, \`-6.2%\`). \`headline\` should be the bolded subject phrase — a name, a metric, a time window. \`body\` is 1-2 sentences of context.
+
+Include a \`caveat\` whenever: the sample is small (<50 rows), the metric is filter-sensitive (changes meaning with date range / geography / category), the data has known gaps, or the interpretation could flip with different framing.
+
+Then close the turn with a single plain-text sentence — no markdown headers.
+
+If every query failed or the user asked for text-only, skip \`narrate_summary\`. Otherwise it is required.
+
 ## How you work
 
 You manage the conversation and dispatch tasks to specialists:

--- a/packages/agent/src/tools/leader-tools.ts
+++ b/packages/agent/src/tools/leader-tools.ts
@@ -1,4 +1,5 @@
 import type { ToolDefinition } from '../provider/types';
+import { narrateTools } from './narrate-tools';
 
 /**
  * Tool definitions available to the Leader Agent.
@@ -11,6 +12,9 @@ import type { ToolDefinition } from '../provider/types';
  *
  * Data stays server-side: query tasks auto-save results to the scratchpad.
  * The LLM only sees compact summaries (columns, row count, sample rows).
+ *
+ * The leader's tool list ends with `narrate_summary` — the terminal
+ * finalization tool. See {@link narrateTools} for the full contract.
  */
 export const leaderTools: ToolDefinition[] = [
   {
@@ -232,4 +236,5 @@ export const leaderTools: ToolDefinition[] = [
       required: ['table_name'],
     },
   },
+  ...narrateTools,
 ];

--- a/packages/agent/src/tools/narrate-tools.test.ts
+++ b/packages/agent/src/tools/narrate-tools.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { narrateTools } from './narrate-tools';
+
+/**
+ * These tests lock the public shape of the `narrate_summary` tool: the
+ * definition's schema is what the LLM sees and what the provider
+ * validates. If an edit here accidentally loosens the schema (e.g.,
+ * drops `minItems`), we want to know immediately — local Qwen 3.6
+ * depends on the constraint being impossible to miss.
+ */
+describe('narrateTools', () => {
+  it('exports exactly one tool definition', () => {
+    expect(narrateTools).toHaveLength(1);
+  });
+
+  it('uses the name "narrate_summary"', () => {
+    expect(narrateTools[0]!.name).toBe('narrate_summary');
+  });
+
+  it('declares a non-trivial description mentioning the 3-bullet contract', () => {
+    const desc = narrateTools[0]!.description;
+    expect(desc.length).toBeGreaterThan(100);
+    expect(desc).toMatch(/3 ranked bullets/);
+    expect(desc).toMatch(/rank 1 = biggest/);
+  });
+
+  it('requires bullets at the top level and constrains it to exactly 3 entries', () => {
+    const schema = narrateTools[0]!.inputSchema as Record<string, unknown>;
+    expect((schema.required as string[])).toContain('bullets');
+    const bullets = (schema.properties as Record<string, unknown>).bullets as Record<string, unknown>;
+    expect(bullets.type).toBe('array');
+    expect(bullets.minItems).toBe(3);
+    expect(bullets.maxItems).toBe(3);
+  });
+
+  it('constrains bullet.rank to the enum {1, 2, 3}', () => {
+    const schema = narrateTools[0]!.inputSchema as Record<string, unknown>;
+    const bullets = (schema.properties as Record<string, unknown>).bullets as Record<string, unknown>;
+    const item = bullets.items as Record<string, unknown>;
+    const rank = (item.properties as Record<string, unknown>).rank as Record<string, unknown>;
+    expect(rank.type).toBe('integer');
+    expect(rank.enum).toEqual([1, 2, 3]);
+  });
+
+  it('requires headline + body but leaves value optional', () => {
+    const schema = narrateTools[0]!.inputSchema as Record<string, unknown>;
+    const bullets = (schema.properties as Record<string, unknown>).bullets as Record<string, unknown>;
+    const item = bullets.items as Record<string, unknown>;
+    expect(item.required).toEqual(['rank', 'headline', 'body']);
+    const props = item.properties as Record<string, unknown>;
+    expect(props).toHaveProperty('value');
+    // `value` is a string but must not appear in required.
+    const value = props.value as Record<string, unknown>;
+    expect(value.type).toBe('string');
+  });
+
+  it('caveat is an optional string at the top level', () => {
+    const schema = narrateTools[0]!.inputSchema as Record<string, unknown>;
+    const caveat = (schema.properties as Record<string, unknown>).caveat as Record<string, unknown>;
+    expect(caveat.type).toBe('string');
+    expect((schema.required as string[])).not.toContain('caveat');
+  });
+});

--- a/packages/agent/src/tools/narrate-tools.ts
+++ b/packages/agent/src/tools/narrate-tools.ts
@@ -1,0 +1,62 @@
+import type { ToolDefinition } from '../provider/types';
+
+/**
+ * Tool definitions for the Leader Agent's finalization step.
+ *
+ * `narrate_summary` is the leader's terminal tool: after the visualization is
+ * ready, the leader calls this once to emit a structured KEY TAKEAWAYS block
+ * that the UI renders below the chart. Making this a typed tool (rather than
+ * relying on the model to emit markdown in a free-form text reply) prevents
+ * local Qwen 3.6 35b from drifting on shape — the provider rejects the call
+ * if the bullet count or rank layout is wrong, so the UI never has to parse
+ * ambiguous prose.
+ */
+export const narrateTools: ToolDefinition[] = [
+  {
+    name: 'narrate_summary',
+    description:
+      'Finalize the answer. Call this ONCE, last, after your visualization is ready. ' +
+      'Provide exactly 3 ranked bullets (rank 1 = biggest finding). ' +
+      'Each bullet has a bold subject (headline), an optional signed numeric value like "+11.59" or "-6.2%", ' +
+      'and 1-2 sentences of body. Include a caveat when the sample is small, the metric is filter-sensitive, ' +
+      'or the data has known gaps.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        bullets: {
+          type: 'array',
+          minItems: 3,
+          maxItems: 3,
+          items: {
+            type: 'object',
+            properties: {
+              rank: {
+                type: 'integer',
+                enum: [1, 2, 3],
+                description: 'Finding rank: 1 is the biggest, 3 is the smallest of the top three.',
+              },
+              headline: {
+                type: 'string',
+                description: 'Bold subject phrase, e.g. "G Gambhir" or "Q4 revenue"',
+              },
+              value: {
+                type: 'string',
+                description: 'Optional signed numeric highlight, e.g. "+11.59" or "-6.2%"',
+              },
+              body: {
+                type: 'string',
+                description: '1-2 sentences of context',
+              },
+            },
+            required: ['rank', 'headline', 'body'],
+          },
+        },
+        caveat: {
+          type: 'string',
+          description: 'Optional interpretation note — sample-size warning, filter sensitivity, methodology caveat.',
+        },
+      },
+      required: ['bullets'],
+    },
+  },
+];


### PR DESCRIPTION
## Summary

Gives the leader a structured finalization tool `narrate_summary` so every data answer ends with a typed 3-bullet KEY TAKEAWAYS block (plus optional caveat), rendered below the view in the conversation thread. A prompt-only markdown contract would drift on local Qwen 3.6 35b — a typed tool makes malformation impossible at the provider boundary.

Stacked on top of #101 (Phase 1 — enriched `AgentEvent` for the editorial trace). When #101 merges into `harness-tweaking-2`, GitHub will auto-retarget this PR.

### Backend (`packages/agent`)
- **NEW `tools/narrate-tools.ts`** — one tool definition. Input schema requires exactly 3 bullets with ranks constrained to `{1, 2, 3}`, `headline` + `body` required on each bullet, `value` and `caveat` optional.
- **`tools/leader-tools.ts`** — appends `...narrateTools` at the end of the leader's tool list.
- **`agents/leader.ts`** — adds a `narrateCalled` per-turn flag, a `handleNarrateSummary` defensive validator (wrong bullet count, duplicate ranks, empty headline/body → error with useful message), and a short-circuit after a successful narrate call so the leader ends the turn with `stopReason: 'end_turn'` instead of letting a chatty model emit more tool calls.
- **`prompt/leader-prompt.ts`** — new "End every answer with narrate_summary" section directing the leader: 3 ranked bullets, signed numbers for `value`, bolded subject phrase in `headline`, caveat when the sample is small / filter-sensitive / framing could flip.

### Wire + render (`apps/web`)
- **`api/agent/chat/route.ts`** — on a successful `narrate_summary` tool_end, parse the payload and enqueue a dedicated `narrate_ready` SSE event. Original `tool_end` still flows (the editorial log wants to show `NARRATE narrate_summary(...) → 3 bullets 204ms`). JSON (non-streaming) path surfaces `narration` alongside `viewSpec`.
- **`chat-message.tsx`** — adds optional `NarrationBlock` on `ChatMessageData`. Kept off `parts[]` so the block always renders once below the stream, not interleaved.
- **`sse-reducer.ts`** — adds the `narrate_ready` event shape + parser (auto-sorts bullets by rank, drops malformed payloads, strips empty caveats). Reducer passes the event through without mutating parts[] — the page client patches the message's `narration` field directly.
- **`explore-page-client.tsx`** — handles `narrate_ready` by setting `narration` on the assistant message.
- **NEW `trace/key-takeaways.tsx`** — ports the KEY TAKEAWAYS block + interpretation-note banner from `Lightboard-design/components/AgentTrace.jsx` (~lines 339-406). Three numbered rows (01/02/03) with bold headlines and amber-highlighted signed values; optional amber caveat banner with the `⚠` unicode glyph.
- **`turn.tsx`** — renders `<KeyTakeaways>` below the `AssistantStream` when the message carries a `narration` field.

### Tests
- **NEW `narrate-tools.test.ts`** (7 tests) — locks the public schema shape.
- **`leader.test.ts`** (5 new) — happy path (enriched tool_end with kind NARRATE, end_turn short-circuit, bullets normalized + sorted, caveat preserved), plus validation errors for wrong bullet count, duplicate ranks, empty body, and the non-short-circuit path when validation fails.
- **`sse-reducer.test.ts`** (5 new) — parsing, bullet sort, rejection of malformed payloads, empty-caveat stripping, no-op on parts[].
- **`turn.test.tsx`** (2 new) — asserts the block renders with ranks/headlines/values/caveat when `narration` is present; omitted when absent.

## Test plan
- [x] `pnpm typecheck` — all 9 packages clean
- [x] `pnpm --filter @lightboard/web lint` — zero warnings/errors
- [x] `pnpm test` — 187 agent tests + 144 web tests pass
- [x] **Browser tested**: fresh `/explore` session against cricket Postgres via Haiku 4.5 (dev server was running this provider). Asked "Show me the top 5 batsmen by total runs as a horizontal bar chart". Confirmed:
  - Editorial trace shows the final `NARRATE narrate_summary(...)` row next to the other kinds
  - Chart iframe renders the bar chart
  - KEY TAKEAWAYS block appears below the chart with three numbered rows:
    - `01 V Kohli +743 — Leads all batsmen with 6,624 runs…`
    - `02 DA Warner +97 — Sits in second place…`
    - `03 RG Sharma & SK Raina 5,611 / 5,536 — Round out the top 5…`
  - Interpretation-note banner shows with the ⚠ glyph and amber coloring ("Runs are aggregated from the deliveries table batting data…")
  - Screenshot: `.claude/phase2-narrate-takeaways.png` (attached to PR description via the verification doc)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)