### PR TITLE
feat(agent): bake Lightboard design system into view prompt (Phase 3)

### DIFF
--- a/apps/web/src/components/view-renderer/html-view-renderer.tsx
+++ b/apps/web/src/components/view-renderer/html-view-renderer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useMemo, useState } from 'react';
 import { LightboardLoader } from '../brand';
 
 /** An HTML view produced by the agent — rendered in a sandboxed iframe. */
@@ -15,6 +15,31 @@ export interface HtmlView {
 interface HtmlViewRendererProps {
   view: HtmlView;
   isLoading?: boolean;
+  /**
+   * When `true`, suppress the outer title + description header. Round-2 views
+   * carry their own `FIGURE 01 · <CATEGORY>` eyebrow, Space Grotesk title,
+   * and Inter subtitle *inside* the iframe, so repeating them outside would
+   * double-print the chart heading.
+   *
+   * When `false` (or `'auto'` and no inner `FIGURE` marker is detected), the
+   * outer header renders as it did pre-round-2 so legacy HTML views still
+   * get a heading.
+   *
+   * Defaults to `'auto'` — inspects the HTML for a `FIGURE` marker and picks.
+   */
+  chromeless?: boolean | 'auto';
+}
+
+/**
+ * Heuristic: does the generated HTML embed the design-system FIGURE anatomy
+ * (eyebrow + title + subtitle + footer) itself? If so, the outer wrapper
+ * should be chromeless to avoid doubling.
+ */
+function hasInternalChrome(html: string): boolean {
+  // The round-2 template emits `FIGURE 01 · ...` in the eyebrow. Looking for
+  // the prefix handles the common case without matching false positives in
+  // prose titles or descriptions.
+  return /FIGURE\s+\d{1,2}\s+·/.test(html);
 }
 
 /**
@@ -22,7 +47,7 @@ interface HtmlViewRendererProps {
  * The iframe allows scripts but NOT same-origin access, preventing
  * the generated HTML from accessing the parent page's cookies/storage/DOM.
  */
-export function HtmlViewRenderer({ view, isLoading }: HtmlViewRendererProps) {
+export function HtmlViewRenderer({ view, isLoading, chromeless = 'auto' }: HtmlViewRendererProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [iframeHeight, setIframeHeight] = useState(600);
 
@@ -45,10 +70,17 @@ export function HtmlViewRenderer({ view, isLoading }: HtmlViewRendererProps) {
     return () => iframe.removeEventListener('load', handleLoad);
   }, [view.html]);
 
+  const showHeader = useMemo(() => {
+    if (chromeless === true) return false;
+    if (chromeless === false) return true;
+    // 'auto' — hide the outer header only when the HTML already carries its own.
+    return !hasInternalChrome(view.html);
+  }, [chromeless, view.html]);
+
   return (
     <div className="flex h-full flex-col">
       {/* Header */}
-      {(view.title || view.description) && (
+      {showHeader && (view.title || view.description) && (
         <div className="shrink-0 border-b border-border px-6 py-4">
           {view.title && (
             <h2 className="text-lg font-semibold text-foreground">

--- a/packages/agent/eval/questions.yaml
+++ b/packages/agent/eval/questions.yaml
@@ -47,3 +47,13 @@
   dataSource: cricket
   expect:
     hasSchemaDoc: true
+
+# Delta chart — tests whether the view agent draws a dashed baseline rule
+# when the metric is a signed gap vs expectation. The reference figure in
+# Lightboard-design/Lightboard Explore.html uses this exact framing.
+- slug: batters-vs-model
+  question: Show me the top 10 IPL batters since 2014 by True Strike Rate, defined as (actual runs minus expected xruns) per 100 balls. Minimum 500 balls faced. Highlight the biggest outlier.
+  dataSource: cricket
+  expect:
+    chart: horizontal_bar
+    hasCaveat: true

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -3,6 +3,8 @@ export { ViewAgent } from './view-agent';
 export { InsightsAgent } from './insights-agent';
 export {
   LeaderAgent,
+  inferChartHint,
+  type InferChartHintColumn,
   type LeaderAgentConfig,
   type LeaderProviderMap,
   type LeaderMaxTokensMap,

--- a/packages/agent/src/agents/infer-chart-hint.test.ts
+++ b/packages/agent/src/agents/infer-chart-hint.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { inferChartHint } from './leader';
+
+describe('inferChartHint', () => {
+  it('returns auto for an empty summary', () => {
+    expect(inferChartHint([], 0)).toBe('auto');
+    expect(inferChartHint([{ name: 'x', type: 'number' }], 0)).toBe('auto');
+  });
+
+  it('returns stat for a single numeric value', () => {
+    expect(inferChartHint([{ name: 'total', type: 'number' }], 1)).toBe('stat');
+  });
+
+  it('returns line for one numeric + one date column', () => {
+    expect(
+      inferChartHint(
+        [
+          { name: 'month', type: 'string', sample: '2025-01-01' },
+          { name: 'revenue', type: 'number' },
+        ],
+        12,
+      ),
+    ).toBe('line');
+  });
+
+  it('returns line when the date column is detected by name', () => {
+    expect(
+      inferChartHint(
+        [
+          { name: 'day', type: 'string', sample: 'Monday' },
+          { name: 'visits', type: 'number' },
+        ],
+        7,
+      ),
+    ).toBe('line');
+  });
+
+  it('returns line for multiple numerics against a date axis', () => {
+    expect(
+      inferChartHint(
+        [
+          { name: 'timestamp', type: 'string', sample: '2025-04-01' },
+          { name: 'latency_p50', type: 'number' },
+          { name: 'latency_p99', type: 'number' },
+        ],
+        48,
+      ),
+    ).toBe('line');
+  });
+
+  it('returns donut for parts-of-whole (small N, one cat + one numeric)', () => {
+    expect(
+      inferChartHint(
+        [
+          { name: 'channel', type: 'string', sample: 'Web' },
+          { name: 'share', type: 'number' },
+        ],
+        4,
+      ),
+    ).toBe('donut');
+  });
+
+  it('returns horizontal-bar for ranked comparisons', () => {
+    expect(
+      inferChartHint(
+        [
+          { name: 'batter', type: 'string', sample: 'G Gambhir' },
+          { name: 'strike_rate', type: 'number' },
+        ],
+        10,
+      ),
+    ).toBe('horizontal-bar');
+  });
+
+  it('returns auto when too many categorical rows to rank cleanly', () => {
+    expect(
+      inferChartHint(
+        [
+          { name: 'user_id', type: 'string', sample: 'u_0001' },
+          { name: 'score', type: 'number' },
+        ],
+        500,
+      ),
+    ).toBe('auto');
+  });
+});

--- a/packages/agent/src/agents/leader.ts
+++ b/packages/agent/src/agents/leader.ts
@@ -1,5 +1,6 @@
 import type { AgentDataSource, AgentEvent } from '../agent';
 import { ConversationManager } from '../conversation/manager';
+import type { ChartHint } from '../design-system';
 import { classifyTool, formatEnd, formatStart } from '../events/tool-event-formatter';
 import { buildLeaderPrompt } from '../prompt/leader-prompt';
 import type { LLMProvider, Message, ToolCallResult } from '../provider/types';
@@ -95,6 +96,104 @@ function buildDataSummary(data: Record<string, unknown>): Record<string, unknown
     : [];
 
   return { columns, rowCount, sampleRows };
+}
+
+/** Heuristic: does a column name or value look date-like? */
+const DATE_NAME_RE = /\b(date|time|day|month|year|week|quarter|hour|minute|ts|timestamp|created|updated)\b/i;
+const ISO_DATE_RE = /^\d{4}-\d{2}(?:-\d{2})?/;
+
+/**
+ * Shape of the inferred column summary used by {@link inferChartHint}. Matches
+ * what {@link buildDataSummary} emits — name + primitive type string — plus
+ * (optional) a sample value so we can probe for ISO dates.
+ */
+export interface InferChartHintColumn {
+  name: string;
+  /** Primitive type returned by `typeof` on the first sample row. */
+  type: string;
+  /** Optional first sample value, used to detect date strings. */
+  sample?: unknown;
+}
+
+/**
+ * Infer a {@link ChartHint} from a compact data summary. Run locally in the
+ * leader before `dispatch_view` so the view specialist sees a snippet matching
+ * the query's actual shape. Heuristics (not ML):
+ *
+ *   - 1 numeric only                                   → `stat`
+ *   - 1 numeric + 1 date/time                          → `line`
+ *   - multiple numerics + date                         → `line`
+ *   - 1 numeric + 1 categorical (<=10 rows / buckets)  → `horizontal-bar`
+ *   - parts-of-whole (<=6 categories, single numeric)  → `donut`
+ *   - anything else                                    → `auto`
+ *
+ * Cheap, deterministic, and wrong-sometimes — that's fine. The view prompt
+ * always falls back to `auto` if we can't decide, which still includes the
+ * canonical horizontal-bar snippet as a reference.
+ */
+export function inferChartHint(
+  columns: InferChartHintColumn[],
+  rowCount: number,
+): ChartHint {
+  if (columns.length === 0 || rowCount === 0) return 'auto';
+
+  const isDate = (c: InferChartHintColumn): boolean => {
+    if (DATE_NAME_RE.test(c.name)) return true;
+    if (c.type === 'string' && typeof c.sample === 'string' && ISO_DATE_RE.test(c.sample)) return true;
+    if (c.type === 'object' && c.sample instanceof Date) return true;
+    return false;
+  };
+
+  const numerics = columns.filter((c) => c.type === 'number');
+  const dates = columns.filter((c) => isDate(c));
+  const categoricals = columns.filter((c) => c.type === 'string' && !isDate(c));
+
+  // 1 numeric only — stat card.
+  if (columns.length === 1 && numerics.length === 1 && rowCount === 1) {
+    return 'stat';
+  }
+
+  // Time series (one or more numerics against a date axis).
+  if (dates.length >= 1 && numerics.length >= 1) {
+    return 'line';
+  }
+
+  // Parts-of-whole — small N, one categorical + one numeric.
+  if (
+    numerics.length === 1 &&
+    categoricals.length === 1 &&
+    rowCount >= 2 &&
+    rowCount <= 6
+  ) {
+    return 'donut';
+  }
+
+  // Ranked comparison — one categorical + one numeric, more than a handful.
+  if (numerics.length >= 1 && categoricals.length >= 1 && rowCount <= 30) {
+    return 'horizontal-bar';
+  }
+
+  return 'auto';
+}
+
+const KNOWN_CHART_HINTS: ReadonlySet<ChartHint> = new Set([
+  'horizontal-bar',
+  'vertical-bar',
+  'line',
+  'donut',
+  'stat',
+  'auto',
+]);
+
+/**
+ * Coerce an untrusted string into a known {@link ChartHint} or return
+ * `undefined` if it isn't in the allowlist. Lets the leader accept an
+ * explicit `chart_hint` on `dispatch_view` without risking a freeform value
+ * leaking into the view prompt.
+ */
+function normalizeChartHint(raw: unknown): ChartHint | undefined {
+  if (typeof raw !== 'string') return undefined;
+  return KNOWN_CHART_HINTS.has(raw as ChartHint) ? (raw as ChartHint) : undefined;
 }
 
 /** Outcome of running a single sub-agent task end-to-end. */
@@ -672,10 +771,34 @@ export class LeaderAgent {
         } catch { /* fallback to empty summary */ }
       }
 
+      // chart_hint resolution order:
+      //   1. Explicit hint from the leader's dispatch_view call.
+      //   2. Inferred from the data summary (column types + row count).
+      //   3. 'auto' — the view prompt falls back to horizontal-bar + stat.
+      const explicitHint = typeof input.chart_hint === 'string' ? input.chart_hint : undefined;
+      const summaryCols = Array.isArray(dataSummary?.columns)
+        ? (dataSummary!.columns as Array<{ name?: unknown; type?: unknown }>)
+        : [];
+      const sampleRow =
+        Array.isArray(dataSummary?.sampleRows) && dataSummary!.sampleRows.length > 0
+          ? (dataSummary!.sampleRows as Array<Record<string, unknown>>)[0]
+          : undefined;
+      const rowCount =
+        typeof dataSummary?.rowCount === 'number' ? (dataSummary!.rowCount as number) : 0;
+      const inferCols: InferChartHintColumn[] = summaryCols
+        .map((c) => ({
+          name: typeof c?.name === 'string' ? c.name : '',
+          type: typeof c?.type === 'string' ? c.type : 'unknown',
+          sample: sampleRow && typeof c?.name === 'string' ? sampleRow[c.name] : undefined,
+        }))
+        .filter((c) => !!c.name);
+      const inferred = inferChartHint(inferCols, rowCount);
+      const chartHint: ChartHint = normalizeChartHint(explicitHint) ?? inferred;
+
       const task: AgentTask = {
         id: `task_${Date.now()}`,
         instruction,
-        context: { dataSummary: dataSummary ?? {} },
+        context: { dataSummary: dataSummary ?? {}, chartHint },
       };
 
       return { result: await agent.run(task) };

--- a/packages/agent/src/design-system/__tests__/design-system.test.ts
+++ b/packages/agent/src/design-system/__tests__/design-system.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildDesignContext,
+  DESIGN_RUBRIC,
+  DESIGN_TOKENS_CSS,
+  DESIGN_VOICE,
+} from '../index';
+
+describe('design-system/index', () => {
+  describe('DESIGN_TOKENS_CSS', () => {
+    it('exposes the :root token block', () => {
+      expect(DESIGN_TOKENS_CSS).toContain(':root');
+      expect(DESIGN_TOKENS_CSS).toContain('--ink-1');
+      expect(DESIGN_TOKENS_CSS).toContain('--accent');
+      expect(DESIGN_TOKENS_CSS).toContain('--bg-0');
+      expect(DESIGN_TOKENS_CSS).toContain('--font-display');
+    });
+
+    it('includes the editorial warm amber accent', () => {
+      expect(DESIGN_TOKENS_CSS).toContain('#F2C265');
+      expect(DESIGN_TOKENS_CSS).toContain('#E89B52');
+    });
+
+    it('does not ship the drifted indigo palette', () => {
+      // #6366f1 is the old generic Tailwind-indigo accent — the design kit
+      // replaced it with the amber ramp. If anyone adds it back, fail loud.
+      expect(DESIGN_TOKENS_CSS).not.toContain('#6366f1');
+    });
+  });
+
+  describe('DESIGN_VOICE', () => {
+    it('is short (~30 lines) and covers the key rules', () => {
+      const lines = DESIGN_VOICE.trim().split(/\r?\n/);
+      expect(lines.length).toBeLessThanOrEqual(80);
+      expect(DESIGN_VOICE).toMatch(/first.person/i);
+      expect(DESIGN_VOICE).toMatch(/no emoji/i);
+      expect(DESIGN_VOICE).toMatch(/\+/); // signed deltas
+      expect(DESIGN_VOICE).toMatch(/tabular-nums/);
+    });
+  });
+
+  describe('DESIGN_RUBRIC', () => {
+    it('enumerates ten checklist items', () => {
+      const boxes = DESIGN_RUBRIC.match(/- \[ \]/g) ?? [];
+      expect(boxes.length).toBe(10);
+      expect(DESIGN_RUBRIC).toMatch(/FIGURE/);
+      expect(DESIGN_RUBRIC).toMatch(/tabular-nums/);
+      expect(DESIGN_RUBRIC).toMatch(/signed/i);
+    });
+  });
+
+  describe('buildDesignContext', () => {
+    it('includes the horizontal-bar snippet when hint is horizontal-bar', () => {
+      const ctx = buildDesignContext('horizontal-bar');
+      expect(ctx).toContain('Horizontal bar');
+      expect(ctx).toContain('FIGURE 01');
+      expect(ctx).toContain('tabular-nums');
+    });
+
+    it('does not duplicate horizontal-bar when hint is horizontal-bar', () => {
+      const ctx = buildDesignContext('horizontal-bar');
+      // Only one instance of the canonical title should appear.
+      const matches = ctx.match(/Horizontal bar \(canonical reference\)/g) ?? [];
+      expect(matches.length).toBe(1);
+    });
+
+    it('includes horizontal-bar + stat for the auto hint', () => {
+      const ctx = buildDesignContext('auto');
+      expect(ctx).toContain('Horizontal bar');
+      expect(ctx).toContain('Single-KPI stat card');
+    });
+
+    it('pairs line with horizontal-bar canonical', () => {
+      const ctx = buildDesignContext('line');
+      expect(ctx).toContain('Line + filled area');
+      expect(ctx).toContain('Horizontal bar (canonical reference)');
+    });
+
+    it('pairs donut with horizontal-bar canonical', () => {
+      const ctx = buildDesignContext('donut');
+      expect(ctx).toContain('Donut + legend');
+      expect(ctx).toContain('Horizontal bar (canonical reference)');
+    });
+
+    it('stays inside a sane snippet budget for every hint', () => {
+      // A single-snippet variant (horizontal-bar) sits around 6.5k chars.
+      // Two-snippet variants (auto, line, donut, stat, vertical-bar) ship the
+      // canonical reference alongside the requested template and run ~12k
+      // chars. 14k is headroom.
+      const hints = [
+        'horizontal-bar',
+        'vertical-bar',
+        'line',
+        'donut',
+        'stat',
+        'auto',
+      ] as const;
+      for (const h of hints) {
+        const ctx = buildDesignContext(h);
+        expect(
+          ctx.length,
+          `buildDesignContext('${h}') exceeded 14000 chars (got ${ctx.length})`,
+        ).toBeLessThan(14_000);
+      }
+    });
+  });
+});

--- a/packages/agent/src/design-system/__tests__/token-drift.test.ts
+++ b/packages/agent/src/design-system/__tests__/token-drift.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Token-drift guard.
+ *
+ * `packages/agent/src/design-system/tokens.css` is a copy of the `:root` block
+ * in `apps/web/src/styles/globals.css` — which is itself the in-repo mirror of
+ * `Lightboard-design/colors_and_type.css`. This test fails CI if the two
+ * in-repo copies drift so the agent's system prompt never references stale
+ * tokens the web app no longer defines.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Extract just the first `:root { ... }` declaration block from a CSS string.
+ * Whitespace-tolerant brace matching — CSS lexing isn't needed for this check.
+ */
+function extractRootBlock(css: string): string {
+  const start = css.indexOf(':root');
+  if (start < 0) throw new Error('No :root block found');
+  const open = css.indexOf('{', start);
+  if (open < 0) throw new Error('Malformed :root block (no opening brace)');
+
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < css.length; i++) {
+    const ch = css[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end < 0) throw new Error('Malformed :root block (unbalanced braces)');
+  return css.slice(open + 1, end);
+}
+
+/**
+ * Parse a `--name: value;` declaration list into a map. Stripping comments and
+ * whitespace up front means the diff doesn't flare on cosmetic reformats.
+ */
+function parseDecls(body: string): Map<string, string> {
+  const decls = new Map<string, string>();
+  // Strip block comments.
+  const stripped = body.replace(/\/\*[\s\S]*?\*\//g, '');
+  for (const rawLine of stripped.split(';')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const name = line.slice(0, colon).trim();
+    if (!name.startsWith('--')) continue;
+    const value = line.slice(colon + 1).trim().replace(/\s+/g, ' ');
+    decls.set(name, value);
+  }
+  return decls;
+}
+
+describe('token-drift', () => {
+  it('tokens.css :root block matches apps/web/src/styles/globals.css :root block', () => {
+    const tokensCss = readFileSync(join(HERE, '..', 'tokens.css'), 'utf8');
+    const globalsCss = readFileSync(
+      join(HERE, '..', '..', '..', '..', '..', 'apps', 'web', 'src', 'styles', 'globals.css'),
+      'utf8',
+    );
+
+    const tokensDecls = parseDecls(extractRootBlock(tokensCss));
+    const globalsDecls = parseDecls(extractRootBlock(globalsCss));
+
+    const missingInTokens = [...globalsDecls.keys()].filter((k) => !tokensDecls.has(k));
+    const extraInTokens = [...tokensDecls.keys()].filter((k) => !globalsDecls.has(k));
+    const valueMismatches: Array<{ name: string; tokens: string; globals: string }> = [];
+    for (const [name, value] of tokensDecls) {
+      const g = globalsDecls.get(name);
+      if (g !== undefined && g !== value) {
+        valueMismatches.push({ name, tokens: value, globals: g });
+      }
+    }
+
+    if (missingInTokens.length || extraInTokens.length || valueMismatches.length) {
+      const lines: string[] = [
+        'packages/agent/src/design-system/tokens.css has drifted from',
+        'apps/web/src/styles/globals.css. Re-copy the :root block and retry.',
+        '',
+      ];
+      if (missingInTokens.length) {
+        lines.push('Missing from tokens.css:');
+        for (const n of missingInTokens) lines.push(`  ${n}: ${globalsDecls.get(n)}`);
+      }
+      if (extraInTokens.length) {
+        lines.push('Only in tokens.css (remove or add to globals.css):');
+        for (const n of extraInTokens) lines.push(`  ${n}: ${tokensDecls.get(n)}`);
+      }
+      if (valueMismatches.length) {
+        lines.push('Value mismatches:');
+        for (const { name, tokens, globals } of valueMismatches) {
+          lines.push(`  ${name}: tokens.css=${tokens} globals.css=${globals}`);
+        }
+      }
+      throw new Error(lines.join('\n'));
+    }
+
+    expect(tokensDecls.size).toBe(globalsDecls.size);
+  });
+});

--- a/packages/agent/src/design-system/index.ts
+++ b/packages/agent/src/design-system/index.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Chart shape hint emitted by the leader when it dispatches a view task.
+ *
+ * The leader infers this from the column types of the query result — see
+ * `inferChartHint` in `packages/agent/src/agents/leader.ts`. The view prompt
+ * uses it to pick which snippet(s) ship with the design context so the model
+ * sees the closest template first.
+ *
+ * `'auto'` means "we couldn't tell — fall back to the canonical reference".
+ */
+export type ChartHint =
+  | 'horizontal-bar'
+  | 'vertical-bar'
+  | 'line'
+  | 'donut'
+  | 'stat'
+  | 'auto';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Read a sibling design-system asset from disk. Assets are loaded once at
+ * module init (outside any hot path) so there's no IO cost per LLM call.
+ */
+function readAsset(relPath: string): string {
+  return readFileSync(join(HERE, relPath), 'utf8');
+}
+
+/**
+ * The `:root` token block the view prompt asks the model to paste verbatim at
+ * the top of every generated `<style>`. Mirrored from
+ * `apps/web/src/styles/globals.css` via the token-drift CI guard.
+ */
+export const DESIGN_TOKENS_CSS: string = readAsset('tokens.css');
+
+/**
+ * Voice and content rules the model should follow in every generated figure.
+ * Roughly 30 lines — first-person, no emoji, signed deltas, tabular-nums,
+ * uppercase-mono metadata.
+ */
+export const DESIGN_VOICE: string = readAsset('voice.md');
+
+/**
+ * Ten-item self-check the model walks before emitting HTML. Appended to the
+ * end of the view prompt to force a quick review pass.
+ */
+export const DESIGN_RUBRIC: string = readAsset('rubric.md');
+
+/** Canonical horizontal-bar snippet — the one every variant should resemble. */
+const SNIPPET_HORIZONTAL_BAR: string = readAsset('snippets/fig-horizontal-bar.html');
+const SNIPPET_VERTICAL_BAR: string = readAsset('snippets/fig-vertical-bar.html');
+const SNIPPET_LINE: string = readAsset('snippets/fig-line.html');
+const SNIPPET_DONUT: string = readAsset('snippets/fig-donut.html');
+const SNIPPET_STAT: string = readAsset('snippets/fig-stat.html');
+
+/**
+ * Human-readable titles shown above each snippet in the design context so the
+ * model knows which template it's looking at.
+ */
+const SNIPPET_TITLES: Record<Exclude<ChartHint, 'auto'>, string> = {
+  'horizontal-bar': 'Horizontal bar (canonical reference)',
+  'vertical-bar': 'Vertical bar (time-buckets, discrete periods)',
+  line: 'Line + filled area (time-series)',
+  donut: 'Donut + legend (parts-of-whole, <=6 slices)',
+  stat: 'Single-KPI stat card',
+};
+
+/** Map a hint to its snippet. `auto` falls back to horizontal-bar. */
+function snippetFor(hint: ChartHint): string {
+  switch (hint) {
+    case 'vertical-bar':
+      return SNIPPET_VERTICAL_BAR;
+    case 'line':
+      return SNIPPET_LINE;
+    case 'donut':
+      return SNIPPET_DONUT;
+    case 'stat':
+      return SNIPPET_STAT;
+    case 'horizontal-bar':
+    case 'auto':
+    default:
+      return SNIPPET_HORIZONTAL_BAR;
+  }
+}
+
+/** Format a snippet as a fenced HTML block with a human title above it. */
+function formatSnippet(title: string, snippet: string): string {
+  return `### ${title}\n\n\`\`\`html\n${snippet}\n\`\`\``;
+}
+
+/**
+ * Assemble the chart-component section of the view system prompt for a given
+ * chart hint. Shape: one or two snippet templates, with the horizontal-bar
+ * canonical always present so the model has a stable reference.
+ *
+ * Budget: target ~2.6k tokens total (voice + tokens + 1-2 snippets + rubric).
+ * Capped at two snippets to stay honest against the budget.
+ */
+export function buildDesignContext(hint: ChartHint): string {
+  // 'auto' → include the canonical (horizontal-bar) plus the stat card so the
+  // two most common shapes (ranked comparison, single KPI) are covered.
+  if (hint === 'auto') {
+    return [
+      formatSnippet(SNIPPET_TITLES['horizontal-bar'], SNIPPET_HORIZONTAL_BAR),
+      formatSnippet(SNIPPET_TITLES.stat, SNIPPET_STAT),
+    ].join('\n\n');
+  }
+
+  // If the hint IS horizontal-bar, don't duplicate it. Otherwise, include the
+  // requested snippet first (so it's primed in the model's attention) and the
+  // canonical second as a reference.
+  if (hint === 'horizontal-bar') {
+    return formatSnippet(SNIPPET_TITLES['horizontal-bar'], SNIPPET_HORIZONTAL_BAR);
+  }
+
+  return [
+    formatSnippet(SNIPPET_TITLES[hint], snippetFor(hint)),
+    formatSnippet(SNIPPET_TITLES['horizontal-bar'], SNIPPET_HORIZONTAL_BAR),
+  ].join('\n\n');
+}

--- a/packages/agent/src/design-system/rubric.md
+++ b/packages/agent/src/design-system/rubric.md
@@ -1,0 +1,12 @@
+# Self-check rubric — walk every item before emitting HTML
+
+- [ ] FIGURE eyebrow present (mono, 0.14em tracking, uppercase, `--ink-4`).
+- [ ] Title in Space Grotesk (display font), `--text-chart-h`, weight 600, `--ink-1`.
+- [ ] Subtitle in Inter (body font), `--text-small`, `--ink-3`.
+- [ ] Rank column zero-padded (01, 02, 03, ...) — never bare `1`, `2`, `3`.
+- [ ] All numeric cells use `font-variant-numeric: tabular-nums` and the mono font.
+- [ ] Signed deltas use explicit `+` for positives; no unsigned positives.
+- [ ] Footer row has `SOURCE · <source> · <period>` on the left and `N = <rowCount> · UPDATED <YYYY-MM-DD>` on the right.
+- [ ] Outliers: `--accent` color + `box-shadow: 0 0 0 1px var(--accent)` glow + bold weight.
+- [ ] Bars: copper/warm ramp by magnitude, dashed baseline rule (1px dashed `--ink-5`) behind the bars.
+- [ ] No emoji, no `system-ui` fallback, no hardcoded hex outside the ramp, no gradients (except the sigil).

--- a/packages/agent/src/design-system/snippets/fig-donut.html
+++ b/packages/agent/src/design-system/snippets/fig-donut.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  /* PASTE tokens.css :root block verbatim here. */
+  body { margin:0; background:var(--bg-0); color:var(--ink-1); font-family:var(--font-body); padding:32px 40px; }
+  .fig { max-width:880px; margin:0 auto; }
+  .fig__eyebrow { font-family:var(--font-mono); font-size:var(--text-eyebrow); letter-spacing:var(--track-eyebrow); text-transform:uppercase; color:var(--ink-4); margin-bottom:6px; }
+  .fig__title { font-family:var(--font-display); font-size:var(--text-chart-h); font-weight:600; letter-spacing:var(--track-tight); margin:0; line-height:1.2; }
+  .fig__sub { font-family:var(--font-body); font-size:12.5px; color:var(--ink-3); margin:6px 0 22px; }
+  .fig__body { display:grid; grid-template-columns:240px 1fr; gap:32px; align-items:center; }
+  svg.donut { width:220px; height:220px; }
+  .slice { transform-origin:center; transition:transform var(--dur-chart) var(--ease-draw); transform:scale(0.94); opacity:0.94; }
+  .slice.in { transform:scale(1); opacity:1; }
+  .slice.is-outlier { filter:drop-shadow(0 0 0 1px var(--accent)); }
+  .center-label { font-family:var(--font-mono); font-variant-numeric:tabular-nums; font-size:var(--text-body); fill:var(--ink-2); }
+  .center-val { font-family:var(--font-display); font-size:28px; font-weight:600; fill:var(--ink-1); letter-spacing:var(--track-tight); }
+  .legend { display:flex; flex-direction:column; gap:8px; }
+  .legend__row { display:grid; grid-template-columns:10px 1fr 68px; gap:10px; align-items:center; }
+  .legend__swatch { width:10px; height:10px; border-radius:2px; }
+  .legend__name { font-family:var(--font-body); font-size:var(--text-small); color:var(--ink-2); }
+  .legend__val { font-family:var(--font-mono); font-variant-numeric:tabular-nums; font-size:var(--text-small); color:var(--ink-2); text-align:right; }
+  .legend__row.is-outlier .legend__name, .legend__row.is-outlier .legend__val { color:var(--accent); font-weight:600; }
+  .fig__foot { display:flex; justify-content:space-between; font-family:var(--font-mono); font-size:var(--text-micro); letter-spacing:var(--track-label); text-transform:uppercase; color:var(--ink-5); margin-top:24px; padding-top:12px; border-top:1px solid var(--line-2); }
+</style>
+</head>
+<body>
+<div class="fig">
+  <div class="fig__eyebrow">FIGURE 01 · <!-- CATEGORY --></div>
+  <h1 class="fig__title"><!-- FINDING HEADLINE --></h1>
+  <p class="fig__sub"><!-- QUALIFICATION --></p>
+  <div class="fig__body">
+    <svg class="donut" viewBox="-110 -110 220 220"></svg>
+    <div class="legend" id="legend"></div>
+  </div>
+  <div class="fig__foot">
+    <span>SOURCE · <!-- SOURCE --> · <!-- PERIOD --></span>
+    <span>N = <!-- ROWCOUNT --> · UPDATED <!-- DATE --></span>
+  </div>
+</div>
+<script>
+  // DATA: [{ name: 'Web', value: 52.1, outlier: true }, ...] — keep N <= 6 slices.
+  const DATA = [/* <!-- DATA JSON --> */];
+  const TOTAL = DATA.reduce(function (s, d) { return s + d.value; }, 0) || 1;
+  const RAMP = ['#F2C265', '#E89B52', '#D97A44', '#B85C3A', '#8AB4B8', '#B08CA8'];
+  function polar(r, a) { return [Math.cos(a) * r, Math.sin(a) * r]; }
+  function arc(r1, r2, a0, a1) {
+    var [x0, y0] = polar(r1, a0), [x1, y1] = polar(r1, a1);
+    var [x2, y2] = polar(r2, a1), [x3, y3] = polar(r2, a0);
+    var large = (a1 - a0) > Math.PI ? 1 : 0;
+    return 'M' + x0.toFixed(2) + ',' + y0.toFixed(2) +
+      ' A' + r1 + ',' + r1 + ' 0 ' + large + ' 1 ' + x1.toFixed(2) + ',' + y1.toFixed(2) +
+      ' L' + x2.toFixed(2) + ',' + y2.toFixed(2) +
+      ' A' + r2 + ',' + r2 + ' 0 ' + large + ' 0 ' + x3.toFixed(2) + ',' + y3.toFixed(2) + ' Z';
+  }
+  var svg = document.querySelector('svg.donut');
+  var legend = document.getElementById('legend');
+  var acc = -Math.PI / 2;
+  DATA.forEach(function (d, i) {
+    var a0 = acc, a1 = acc + (d.value / TOTAL) * Math.PI * 2;
+    acc = a1;
+    var color = d.outlier ? getComputedStyle(document.documentElement).getPropertyValue('--accent').trim() || '#F2C265' : RAMP[i % RAMP.length];
+    var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', arc(90, 64, a0, a1));
+    path.setAttribute('fill', color);
+    path.setAttribute('class', 'slice' + (d.outlier ? ' is-outlier' : ''));
+    svg.appendChild(path);
+    var row = document.createElement('div');
+    row.className = 'legend__row' + (d.outlier ? ' is-outlier' : '');
+    var pct = ((d.value / TOTAL) * 100).toFixed(1);
+    row.innerHTML =
+      '<span class="legend__swatch" style="background:' + color + '"></span>' +
+      '<span class="legend__name">' + d.name + '</span>' +
+      '<span class="legend__val">' + pct + '%</span>';
+    legend.appendChild(row);
+  });
+  svg.innerHTML += '<text class="center-label" x="0" y="-6" text-anchor="middle">TOTAL</text>' +
+    '<text class="center-val" x="0" y="22" text-anchor="middle">' + TOTAL.toFixed(0) + '</text>';
+  (document.fonts && document.fonts.ready ? document.fonts.ready : Promise.resolve()).then(function () {
+    requestAnimationFrame(function () {
+      document.querySelectorAll('.slice').forEach(function (s, i) { setTimeout(function () { s.classList.add('in'); }, i * 40); });
+    });
+  });
+</script>
+</body>
+</html>

--- a/packages/agent/src/design-system/snippets/fig-horizontal-bar.html
+++ b/packages/agent/src/design-system/snippets/fig-horizontal-bar.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<style>
+  /* PASTE tokens.css :root block verbatim here — the snippet below assumes it. */
+  :root {
+    --font-display: 'Space Grotesk', system-ui, sans-serif;
+    --font-body: 'Inter', system-ui, sans-serif;
+    --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+    /* ... rest of tokens.css ... */
+  }
+  body { margin:0; background:var(--bg-0); color:var(--ink-1); font-family:var(--font-body); padding:32px 40px; }
+  .fig { max-width: 880px; margin: 0 auto; position: relative; }
+  .fig__eyebrow { font-family:var(--font-mono); font-size:var(--text-eyebrow); letter-spacing:var(--track-eyebrow); text-transform:uppercase; color:var(--ink-4); margin-bottom: 6px; }
+  .fig__title { font-family:var(--font-display); font-size:var(--text-chart-h); font-weight:600; letter-spacing:var(--track-tight); color:var(--ink-1); line-height:1.2; margin:0; }
+  .fig__sub { font-family:var(--font-body); font-size:12.5px; color:var(--ink-3); margin:6px 0 22px; }
+  .fig__grid { display:grid; grid-template-columns:24px 120px 1fr 68px; gap:10px 14px; align-items:center; position:relative; padding: 14px 0; }
+  .fig__grid::before { content:''; position:absolute; left:158px; right:68px; top:50%; border-top:1px dashed var(--ink-5); pointer-events:none; }
+  .fig__rank { font-family:var(--font-mono); font-variant-numeric:tabular-nums; font-size:var(--text-micro); color:var(--ink-5); }
+  .fig__name { font-family:var(--font-body); font-size:var(--text-small); color:var(--ink-2); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .fig__bar-track { position:relative; height:10px; }
+  .fig__bar { position:absolute; left:0; top:0; bottom:0; height:10px; border-radius:2px; width:0; transition:width var(--dur-chart) var(--ease-draw); }
+  .fig__bar.is-outlier { box-shadow: 0 0 0 1px var(--accent); }
+  .fig__val { font-family:var(--font-mono); font-variant-numeric:tabular-nums; font-size:var(--text-small); color:var(--ink-2); text-align:right; }
+  .fig__val.is-outlier { color:var(--accent); font-weight:600; }
+  .fig__foot { display:flex; justify-content:space-between; font-family:var(--font-mono); font-size:var(--text-micro); letter-spacing:var(--track-label); text-transform:uppercase; color:var(--ink-5); margin-top: 18px; padding-top: 12px; border-top: 1px solid var(--line-2); }
+  .fig__png { position:fixed; top:16px; right:16px; font-family:var(--font-mono); font-size:var(--text-micro); letter-spacing:var(--track-label); text-transform:uppercase; color:var(--ink-3); background:var(--bg-5); border:1px solid var(--line-3); border-radius:999px; padding:6px 12px; cursor:pointer; z-index:20; }
+  .fig__png:hover { color:var(--ink-1); border-color:var(--line-5); }
+</style>
+</head>
+<body>
+<button class="fig__png" id="png-btn">PNG</button>
+<div class="fig">
+  <div class="fig__eyebrow">FIGURE 01 · <!-- CATEGORY --></div>
+  <h1 class="fig__title"><!-- FINDING HEADLINE --></h1>
+  <p class="fig__sub"><!-- QUALIFICATION --></p>
+  <div class="fig__grid" id="grid"></div>
+  <div class="fig__foot">
+    <span>SOURCE · <!-- SOURCE --> · <!-- PERIOD --></span>
+    <span>N = <!-- ROWCOUNT --> · UPDATED <!-- DATE --></span>
+  </div>
+</div>
+<script>
+  // Hardcode rows inline — the iframe has no fetch access.
+  const DATA = [/* <!-- DATA JSON -->
+    { name: 'G Gambhir', value: 11.59, outlier: true },
+    { name: 'V Kohli',   value:  8.42 },
+    { name: 'R Sharma',  value:  7.81 },
+    { name: 'S Dhawan',  value:  5.34 },
+    { name: 'K Rahul',   value:  4.92 },
+  */];
+  // Copper/warm magnitude ramp. Value thresholds are illustrative — adjust the
+  // breakpoints to fit the dataset range while keeping the ramp order intact.
+  const MAX = Math.max(1, ...DATA.map(function (d) { return Math.abs(d.value); }));
+  function rampColor(v) {
+    var r = Math.abs(v) / MAX;
+    if (r > 0.80) return '#F2C265';
+    if (r > 0.55) return '#E89B52';
+    if (r > 0.35) return '#D97A44';
+    return '#B85C3A';
+  }
+  function signed(v) { return (v > 0 ? '+' : '') + v.toFixed(2); }
+  var grid = document.getElementById('grid');
+  DATA.forEach(function (d, i) {
+    var rank = String(i + 1).padStart(2, '0');
+    var pct = (Math.abs(d.value) / MAX) * 100;
+    var row = document.createElement('div');
+    row.style.display = 'contents';
+    row.innerHTML = '' +
+      '<div class="fig__rank">' + rank + '</div>' +
+      '<div class="fig__name">' + d.name + '</div>' +
+      '<div class="fig__bar-track"><div class="fig__bar' + (d.outlier ? ' is-outlier' : '') + '" data-w="' + pct.toFixed(2) + '%" style="background:' + (d.outlier ? 'var(--accent)' : rampColor(d.value)) + '"></div></div>' +
+      '<div class="fig__val' + (d.outlier ? ' is-outlier' : '') + '">' + signed(d.value) + '</div>';
+    grid.appendChild(row);
+  });
+  // Wait for Google Fonts before animating bars to avoid FOUT jitter.
+  (document.fonts && document.fonts.ready ? document.fonts.ready : Promise.resolve()).then(function () {
+    requestAnimationFrame(function () {
+      var bars = document.querySelectorAll('.fig__bar');
+      bars.forEach(function (b, i) { setTimeout(function () { b.style.width = b.dataset.w; }, i * 32); });
+    });
+  });
+  // PNG export — hide the button before capture so it isn't in the output.
+  document.getElementById('png-btn').onclick = function () {
+    var btn = this;
+    btn.style.display = 'none';
+    html2canvas(document.body, { backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--bg-0').trim() || '#08080A' })
+      .then(function (canvas) {
+        var a = document.createElement('a');
+        a.href = canvas.toDataURL('image/png');
+        a.download = 'lightboard-figure.png';
+        a.click();
+        btn.style.display = '';
+      })
+      .catch(function () { btn.style.display = ''; });
+  };
+</script>
+</body>
+</html>

--- a/packages/agent/src/design-system/snippets/fig-line.html
+++ b/packages/agent/src/design-system/snippets/fig-line.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  /* PASTE tokens.css :root block verbatim here. */
+  body { margin:0; background:var(--bg-0); color:var(--ink-1); font-family:var(--font-body); padding:32px 40px; }
+  .fig { max-width:880px; margin:0 auto; }
+  .fig__eyebrow { font-family:var(--font-mono); font-size:var(--text-eyebrow); letter-spacing:var(--track-eyebrow); text-transform:uppercase; color:var(--ink-4); margin-bottom:6px; }
+  .fig__title { font-family:var(--font-display); font-size:var(--text-chart-h); font-weight:600; letter-spacing:var(--track-tight); margin:0; line-height:1.2; }
+  .fig__sub { font-family:var(--font-body); font-size:12.5px; color:var(--ink-3); margin:6px 0 22px; }
+  svg { width:100%; height:260px; display:block; }
+  .axis text { font-family:var(--font-mono); font-size:var(--text-micro); fill:var(--ink-5); letter-spacing:var(--track-label); text-transform:uppercase; }
+  .line { fill:none; stroke:var(--accent-warm); stroke-width:1.5; stroke-dasharray:2000; stroke-dashoffset:2000; transition:stroke-dashoffset var(--dur-chart) var(--ease-draw); }
+  .area { fill:var(--accent-warm); fill-opacity:0; transition:fill-opacity var(--dur-chart) var(--ease-draw); }
+  .line.in, .area.in { stroke-dashoffset:0; }
+  .area.in { fill-opacity:0.2; }
+  .peak { fill:var(--accent); stroke:var(--bg-0); stroke-width:2; }
+  .peak-label { font-family:var(--font-mono); font-variant-numeric:tabular-nums; font-size:var(--text-small); fill:var(--accent); font-weight:600; }
+  .baseline { stroke:var(--ink-5); stroke-dasharray:2 4; stroke-width:1; }
+  .fig__foot { display:flex; justify-content:space-between; font-family:var(--font-mono); font-size:var(--text-micro); letter-spacing:var(--track-label); text-transform:uppercase; color:var(--ink-5); margin-top:20px; padding-top:12px; border-top:1px solid var(--line-2); }
+</style>
+</head>
+<body>
+<div class="fig">
+  <div class="fig__eyebrow">FIGURE 01 · <!-- CATEGORY --></div>
+  <h1 class="fig__title"><!-- FINDING HEADLINE --></h1>
+  <p class="fig__sub"><!-- QUALIFICATION --></p>
+  <svg id="svg" viewBox="0 0 800 260" preserveAspectRatio="none"></svg>
+  <div class="fig__foot">
+    <span>SOURCE · <!-- SOURCE --> · <!-- PERIOD --></span>
+    <span>N = <!-- ROWCOUNT --> · UPDATED <!-- DATE --></span>
+  </div>
+</div>
+<script>
+  // DATA: [{ x: '2024-01', y: 42.1 }, ...] — x is the period label, y the metric value.
+  const DATA = [/* <!-- DATA JSON --> */];
+  const W = 800, H = 260, PAD = 24;
+  const xs = DATA.map(function (_, i) { return i; });
+  const ys = DATA.map(function (d) { return d.y; });
+  const minY = Math.min.apply(null, ys), maxY = Math.max.apply(null, ys);
+  const sx = function (i) { return PAD + (i / Math.max(1, xs.length - 1)) * (W - PAD * 2); };
+  const sy = function (v) { return H - PAD - ((v - minY) / Math.max(1e-9, maxY - minY)) * (H - PAD * 2); };
+  const path = DATA.map(function (d, i) { return (i === 0 ? 'M' : 'L') + sx(i).toFixed(1) + ',' + sy(d.y).toFixed(1); }).join(' ');
+  const area = 'M' + PAD + ',' + (H - PAD) + ' ' + DATA.map(function (d, i) { return 'L' + sx(i).toFixed(1) + ',' + sy(d.y).toFixed(1); }).join(' ') + ' L' + sx(DATA.length - 1).toFixed(1) + ',' + (H - PAD) + ' Z';
+  const peakIdx = ys.indexOf(maxY);
+  const svg = document.getElementById('svg');
+  svg.innerHTML =
+    '<line class="baseline" x1="' + PAD + '" x2="' + (W - PAD) + '" y1="' + (H - PAD) + '" y2="' + (H - PAD) + '"></line>' +
+    '<path class="area" d="' + area + '"></path>' +
+    '<path class="line" d="' + path + '"></path>' +
+    '<circle class="peak" cx="' + sx(peakIdx).toFixed(1) + '" cy="' + sy(maxY).toFixed(1) + '" r="4"></circle>' +
+    '<text class="peak-label" x="' + (sx(peakIdx) + 8).toFixed(1) + '" y="' + (sy(maxY) - 6).toFixed(1) + '">+' + maxY.toFixed(2) + '</text>' +
+    '<g class="axis">' +
+    '<text x="' + PAD + '" y="' + (H - 4) + '">' + (DATA[0] ? DATA[0].x : '') + '</text>' +
+    '<text x="' + (W - PAD) + '" y="' + (H - 4) + '" text-anchor="end">' + (DATA[DATA.length - 1] ? DATA[DATA.length - 1].x : '') + '</text>' +
+    '</g>';
+  (document.fonts && document.fonts.ready ? document.fonts.ready : Promise.resolve()).then(function () {
+    requestAnimationFrame(function () {
+      svg.querySelector('.line').classList.add('in');
+      svg.querySelector('.area').classList.add('in');
+    });
+  });
+</script>
+</body>
+</html>

--- a/packages/agent/src/design-system/snippets/fig-stat.html
+++ b/packages/agent/src/design-system/snippets/fig-stat.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  /* PASTE tokens.css :root block verbatim here. */
+  body { margin:0; background:var(--bg-0); color:var(--ink-1); font-family:var(--font-body); padding:32px 40px; }
+  .fig { max-width:520px; margin:0 auto; }
+  .fig__eyebrow { font-family:var(--font-mono); font-size:var(--text-eyebrow); letter-spacing:var(--track-eyebrow); text-transform:uppercase; color:var(--ink-4); margin-bottom:6px; }
+  .fig__title { font-family:var(--font-display); font-size:var(--text-chart-h); font-weight:600; letter-spacing:var(--track-tight); margin:0; line-height:1.2; }
+  .fig__sub { font-family:var(--font-body); font-size:12.5px; color:var(--ink-3); margin:6px 0 28px; }
+  .stat { display:grid; grid-template-columns:1fr auto; gap:20px; align-items:baseline; padding: 20px 0 24px; border-top: 1px solid var(--line-2); border-bottom: 1px solid var(--line-2); }
+  .stat__value { font-family:var(--font-display); font-variant-numeric:tabular-nums; font-size: 56px; font-weight: 600; letter-spacing:var(--track-tight); color:var(--ink-1); line-height:1; }
+  .stat__delta { font-family:var(--font-mono); font-variant-numeric:tabular-nums; font-size: var(--text-body); color:var(--accent); font-weight:600; white-space:nowrap; }
+  .stat__delta.is-negative { color:var(--ink-3); }
+  .stat__label { font-family:var(--font-mono); font-size:var(--text-micro); letter-spacing:var(--track-label); text-transform:uppercase; color:var(--ink-4); margin-top: 6px; }
+  .fig__foot { display:flex; justify-content:space-between; font-family:var(--font-mono); font-size:var(--text-micro); letter-spacing:var(--track-label); text-transform:uppercase; color:var(--ink-5); margin-top:18px; padding-top:12px; }
+</style>
+</head>
+<body>
+<div class="fig">
+  <div class="fig__eyebrow">FIGURE 01 · <!-- CATEGORY --></div>
+  <h1 class="fig__title"><!-- FINDING HEADLINE --></h1>
+  <p class="fig__sub"><!-- QUALIFICATION --></p>
+  <div class="stat">
+    <div>
+      <div class="stat__value" id="val"><!-- BIG NUMBER --></div>
+      <div class="stat__label"><!-- UNIT / LABEL --></div>
+    </div>
+    <div class="stat__delta" id="delta"><!-- +11.59 --></div>
+  </div>
+  <div class="fig__foot">
+    <span>SOURCE · <!-- SOURCE --> · <!-- PERIOD --></span>
+    <span>N = <!-- ROWCOUNT --> · UPDATED <!-- DATE --></span>
+  </div>
+</div>
+<script>
+  // Hardcode the primary number and optional signed delta.
+  const DATA = { value: 0 /* <!-- BIG NUMBER --> */, delta: 0 /* optional signed delta, null to hide */ };
+  function fmt(v) { return (Math.abs(v) >= 1000 ? v.toLocaleString('en-US', { maximumFractionDigits: 0 }) : v.toFixed(2)); }
+  function signed(v) { return (v > 0 ? '+' : '') + fmt(v); }
+  document.getElementById('val').textContent = fmt(DATA.value);
+  var deltaEl = document.getElementById('delta');
+  if (DATA.delta == null) {
+    deltaEl.style.display = 'none';
+  } else {
+    deltaEl.textContent = signed(DATA.delta);
+    if (DATA.delta < 0) deltaEl.classList.add('is-negative');
+  }
+</script>
+</body>
+</html>

--- a/packages/agent/src/design-system/snippets/fig-vertical-bar.html
+++ b/packages/agent/src/design-system/snippets/fig-vertical-bar.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  /* PASTE tokens.css :root block verbatim here. */
+  body { margin:0; background:var(--bg-0); color:var(--ink-1); font-family:var(--font-body); padding:32px 40px; }
+  .fig { max-width:880px; margin:0 auto; position:relative; }
+  .fig__eyebrow { font-family:var(--font-mono); font-size:var(--text-eyebrow); letter-spacing:var(--track-eyebrow); text-transform:uppercase; color:var(--ink-4); margin-bottom:6px; }
+  .fig__title { font-family:var(--font-display); font-size:var(--text-chart-h); font-weight:600; letter-spacing:var(--track-tight); color:var(--ink-1); margin:0; line-height:1.2; }
+  .fig__sub { font-family:var(--font-body); font-size:12.5px; color:var(--ink-3); margin:6px 0 28px; }
+  .bars { display:grid; grid-auto-flow:column; grid-auto-columns:1fr; gap:12px; height:220px; align-items:end; position:relative; padding: 0 0 30px; border-bottom: 1px dashed var(--ink-5); }
+  .bar { display:flex; flex-direction:column; align-items:center; justify-content:flex-end; position:relative; }
+  .bar__fill { width:60%; max-width:48px; min-height:1px; border-radius:2px 2px 0 0; transform-origin:bottom; transform:scaleY(0); transition:transform var(--dur-chart) var(--ease-draw); }
+  .bar__fill.is-outlier { box-shadow:0 0 0 1px var(--accent); }
+  .bar__label { font-family:var(--font-mono); font-variant-numeric:tabular-nums; font-size:var(--text-micro); color:var(--ink-4); margin-top:8px; position:absolute; bottom:-26px; letter-spacing:var(--track-label); text-transform:uppercase; }
+  .bar__val { font-family:var(--font-mono); font-variant-numeric:tabular-nums; font-size:var(--text-micro); color:var(--ink-3); position:absolute; top:-16px; }
+  .bar__val.is-outlier { color:var(--accent); font-weight:600; }
+  .fig__foot { display:flex; justify-content:space-between; font-family:var(--font-mono); font-size:var(--text-micro); letter-spacing:var(--track-label); text-transform:uppercase; color:var(--ink-5); margin-top:36px; padding-top:12px; border-top:1px solid var(--line-2); }
+</style>
+</head>
+<body>
+<div class="fig">
+  <div class="fig__eyebrow">FIGURE 01 · <!-- CATEGORY --></div>
+  <h1 class="fig__title"><!-- FINDING HEADLINE --></h1>
+  <p class="fig__sub"><!-- QUALIFICATION --></p>
+  <div class="bars" id="bars"></div>
+  <div class="fig__foot">
+    <span>SOURCE · <!-- SOURCE --> · <!-- PERIOD --></span>
+    <span>N = <!-- ROWCOUNT --> · UPDATED <!-- DATE --></span>
+  </div>
+</div>
+<script>
+  const DATA = [/* <!-- DATA JSON --> { name: 'Q1', value: 42.1 }, ... */];
+  const MAX = Math.max(1, ...DATA.map(function (d) { return Math.abs(d.value); }));
+  function ramp(v) { var r = Math.abs(v) / MAX; if (r > 0.80) return '#F2C265'; if (r > 0.55) return '#E89B52'; if (r > 0.35) return '#D97A44'; return '#B85C3A'; }
+  function signed(v) { return (v > 0 ? '+' : '') + (Math.abs(v) >= 100 ? v.toFixed(0) : v.toFixed(2)); }
+  var bars = document.getElementById('bars');
+  DATA.forEach(function (d, i) {
+    var scale = (Math.abs(d.value) / MAX);
+    var wrap = document.createElement('div'); wrap.className = 'bar';
+    wrap.innerHTML =
+      '<div class="bar__val' + (d.outlier ? ' is-outlier' : '') + '">' + signed(d.value) + '</div>' +
+      '<div class="bar__fill' + (d.outlier ? ' is-outlier' : '') + '" data-s="' + scale.toFixed(3) + '" style="height:100%; background:' + (d.outlier ? 'var(--accent)' : ramp(d.value)) + '"></div>' +
+      '<div class="bar__label">' + d.name + '</div>';
+    bars.appendChild(wrap);
+  });
+  (document.fonts && document.fonts.ready ? document.fonts.ready : Promise.resolve()).then(function () {
+    requestAnimationFrame(function () {
+      document.querySelectorAll('.bar__fill').forEach(function (f, i) {
+        setTimeout(function () { f.style.transform = 'scaleY(' + f.dataset.s + ')'; }, i * 32);
+      });
+    });
+  });
+</script>
+</body>
+</html>

--- a/packages/agent/src/design-system/tokens.css
+++ b/packages/agent/src/design-system/tokens.css
@@ -1,0 +1,99 @@
+/*
+ * Lightboard design tokens — dark editorial canvas, warm amber accent.
+ * Generated from apps/web/src/styles/globals.css (:root block) which is the
+ * canonical in-repo copy of Lightboard-design/colors_and_type.css. Do not
+ * edit directly — the token-drift test in __tests__/token-drift.test.ts
+ * fails loudly if this file diverges from globals.css.
+ */
+:root {
+  /* ---------- Typography ---------- */
+  /* next/font/google exposes --font-display / --font-body / --font-mono with
+   * the actual CSS font-family names injected at build time. We intentionally
+   * leave the variables above untouched here so the fonts from next/font wire
+   * through; the rest of the design system uses these raw tokens by name. */
+
+  /* Type scale */
+  --text-eyebrow: 9.5px;
+  --text-micro: 10px;
+  --text-caption: 11px;
+  --text-small: 12px;
+  --text-body: 13px;
+  --text-message: 14px;
+  --text-message-l: 15px;
+  --text-chart-h: 22px;
+  --text-page-h: 26px;
+
+  /* Letter spacing */
+  --track-eyebrow: 0.14em;
+  --track-label: 0.10em;
+  --track-tight: -0.015em;
+
+  /* ---------- Color · Surfaces ---------- */
+  --bg-0: #08080A;
+  --bg-1: #09090B;
+  --bg-2: #0A0A0C;
+  --bg-3: #0C0C0F;
+  --bg-4: #0D0D10;
+  --bg-5: #101013;
+  --bg-6: #131317;
+  --bg-7: #18181C;
+
+  /* Borders */
+  --line-1: #17171B;
+  --line-2: #1A1A1E;
+  --line-3: #1E1E22;
+  --line-4: #26262C;
+  --line-5: #2A2A30;
+
+  /* ---------- Color · Ink ---------- */
+  --ink-1: #EDEDEE;
+  --ink-2: #BDBDC4;
+  --ink-3: #8A8A92;
+  --ink-4: #6B6B73;
+  --ink-5: #55555C;
+  --ink-6: #3E3E45;
+
+  /* ---------- Color · Accent (amber editorial) ---------- */
+  --accent: #F2C265;
+  --accent-warm: #E89B52;
+  --accent-deep: #D97A44;
+  --accent-ink: #D9A441;
+  --accent-bg: #16120B;
+  --accent-border: #3B2E14;
+
+  /* ---------- Color · Semantic (tool-call kinds) ---------- */
+  --kind-schema: #8AB4B8;
+  --kind-query: #E89B52;
+  --kind-compute: #B08CA8;
+  --kind-filter: #D9A441;
+  --kind-viz: #F2C265;
+  --kind-narrate: #7DB469;
+
+  /* ---------- Color · Sigil palette (L I G H T B O A R D) ---------- */
+  --sigil-1: #F4A261;
+  --sigil-2: #E76F51;
+  --sigil-3: #E9C46A;
+  --sigil-4: #D9A441;
+  --sigil-5: #EDEDEE;
+  --sigil-6: #8AB4B8;
+  --sigil-7: #5E8B95;
+  --sigil-8: #6A7BA2;
+  --sigil-9: #B08CA8;
+  --sigil-10: #D4846F;
+
+  /* ---------- Shadow / glow ---------- */
+  --shadow-pop: 0 4px 14px rgba(237, 237, 238, 0.12);
+  --shadow-panel: 0 12px 40px rgba(0, 0, 0, 0.45);
+  --glow-accent: 0 0 0 3px rgba(232, 155, 82, 0.15);
+  --glow-accent-wide: 0 0 0 6px rgba(232, 155, 82, 0.05);
+
+  /* ---------- Motion ---------- */
+  --ease-out-quint: cubic-bezier(.2, .8, .2, 1);
+  --ease-draw: cubic-bezier(.6, .1, .2, 1);
+  --dur-fast: 150ms;
+  --dur-base: 180ms;
+  --dur-med: 260ms;
+  --dur-slow: 420ms;
+  --dur-chart: 720ms;
+  --dur-sigil: 900ms;
+}

--- a/packages/agent/src/design-system/voice.md
+++ b/packages/agent/src/design-system/voice.md
@@ -1,0 +1,38 @@
+# Lightboard voice — content fundamentals for the view specialist
+
+You are writing as the Lightboard data agent, first-person, editorial.
+
+## Writing rules
+- Write in first person. "I compared...", "I pulled...", "I notice..." — never "The system..." or "The user requested...".
+- Sentence case for headlines and subtitles. Capital-case for FIGURE / SOURCE / N / UPDATED metadata only.
+- No emoji. Ever. Not in titles, not in hints, not in metadata.
+- No marketing adjectives ("amazing", "powerful", "beautiful"). The data speaks; you annotate.
+- Use `+` explicitly on positive deltas. Never leave a positive number unsigned. Example: `+11.59`, not `11.59`.
+- Use `−` (U+2212) or `-` consistently for negatives. Never surround a minus with spaces.
+- Numeric values render in mono (`var(--font-mono)`) with `font-variant-numeric: tabular-nums`.
+- Zero-pad rank columns: `01`, `02`, `03` — never `1`, `2`, `3`. Use `String(i + 1).padStart(2, '0')`.
+
+## Headline discipline
+- **Title = the finding, not the axis label.** "Top 3 batters carry 54% of runs" beats "Batter runs by player". Put the insight in the headline.
+- Subtitle = the qualification (filters, window, sample size) that makes the headline provable. Inter 12.5px `--ink-3`.
+- If the data is flat, say so. Don't dress up a dull result with a shiny chart.
+
+## Metadata row (SOURCE / N / UPDATED)
+- All metadata is uppercase mono at `--text-micro` with `letter-spacing: var(--track-label)` in `--ink-5`.
+- Left: `SOURCE · <source name> · <period>`.
+- Right: `N = <rowCount> · UPDATED <YYYY-MM-DD>`.
+- Use a middle-dot `·` (U+00B7) as the separator, never a bullet `•` or pipe `|`.
+
+## FIGURE eyebrow
+- Format: `FIGURE 01 · <CATEGORY>`. Mono, uppercase, `letter-spacing: var(--track-eyebrow)` (0.14em), color `--ink-4`.
+- CATEGORY is a one-to-three-word domain tag in uppercase: `CRICKET · BATTING`, `REVENUE`, `LATENCY`.
+
+## Color discipline
+- One accent (`--accent` warm amber) for the lead finding or outlier row.
+- Magnitude ramp on bars: `#F2C265` (brightest) → `#E89B52` → `#D97A44` → `#B85C3A` (darkest). Never introduce new hex outside this set or the tokens.
+- Outlier rows get the accent color plus a 1px glow (`box-shadow: 0 0 0 1px var(--accent)`) and bold value weight.
+- Tool-call kinds are the only place where non-warm colors appear (`--kind-schema` teal, `--kind-compute` violet, etc.).
+
+## Keyboard hints and inline code
+- Keyboard hints in mono uppercase: `PRESS ENTER TO SUBMIT`, `TAB FOR SUGGESTIONS`.
+- Column names and identifiers appear in backticks when quoted in prose.

--- a/packages/agent/src/prompt/leader-prompt.test.ts
+++ b/packages/agent/src/prompt/leader-prompt.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildLeaderPrompt } from './leader-prompt';
+
+describe('buildLeaderPrompt', () => {
+  it('includes the voice card with the core editorial rules', () => {
+    const prompt = buildLeaderPrompt({ dataSources: [] });
+    expect(prompt).toContain('Voice');
+    expect(prompt).toMatch(/first person/i);
+    expect(prompt).toMatch(/no emoji/i);
+    // Signed-delta rule is explicit about the + marker.
+    expect(prompt).toContain('+');
+    // Numeric-value formatting rule is present.
+    expect(prompt).toMatch(/backtick/i);
+  });
+
+  it('keeps the narrate_summary directive (Phase 2)', () => {
+    const prompt = buildLeaderPrompt({ dataSources: [] });
+    expect(prompt).toContain('narrate_summary');
+    expect(prompt).toMatch(/ranked bullets/i);
+  });
+
+  it('lists available data sources', () => {
+    const prompt = buildLeaderPrompt({
+      dataSources: [{ id: 'pg-1', name: 'Cricket DB', type: 'postgres' }],
+    });
+    expect(prompt).toContain('Cricket DB');
+    expect(prompt).toContain('pg-1');
+  });
+
+  it('lists scratchpad tables when provided', () => {
+    const prompt = buildLeaderPrompt({
+      dataSources: [],
+      scratchpadTables: ['query_1 (250 rows): ...'],
+    });
+    expect(prompt).toContain('Scratchpad Tables');
+    expect(prompt).toContain('query_1');
+  });
+
+  it('stays under a sane token budget with the voice card', () => {
+    // Original leader prompt sat at ~5.2k chars (~1.3k tokens). The voice
+    // card adds ~1k chars on top. 6k is the realistic ceiling without
+    // chopping directive text; regress loudly if someone crosses it.
+    const prompt = buildLeaderPrompt({ dataSources: [] });
+    expect(prompt.length).toBeLessThan(6_000);
+  });
+});

--- a/packages/agent/src/prompt/leader-prompt.ts
+++ b/packages/agent/src/prompt/leader-prompt.ts
@@ -28,6 +28,16 @@ export function buildLeaderPrompt(context: {
 
 const LEADER_INSTRUCTIONS = `You are Lightboard's data exploration assistant. You help users understand their data by orchestrating specialist agents.
 
+## Voice
+
+- First person: "I pulled…", "I compared…", "I notice…". Never "The system…" or "The user asked…".
+- Sentence case. Uppercase only for editorial metadata (SOURCE, N, UPDATED, FIGURE).
+- No emoji. Ever. Not in text, tool args, or narrate bullets.
+- Signed deltas always carry \`+\` on positives: \`+11.59\`, \`-6.2%\`.
+- Backtick column names, table names, and numeric values in prose — the UI renders them mono / tabular-nums.
+- No marketing adjectives ("amazing", "beautiful"). The data speaks; you annotate.
+- Close every data answer with a single plain-text sentence after \`narrate_summary\` — no markdown headers.
+
 ## The one rule that matters most
 
 **Every data answer ends with a visualization.** After \`await_tasks\` returns successful query results, your next tool call MUST be \`dispatch_view\` — unless the user explicitly asked for text only, asked you to do schema setup, or every query failed.

--- a/packages/agent/src/prompt/view-prompt.test.ts
+++ b/packages/agent/src/prompt/view-prompt.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildViewPrompt } from './view-prompt';
+
+describe('buildViewPrompt', () => {
+  it('asserts the figure anatomy vocabulary', () => {
+    const prompt = buildViewPrompt({ chartHint: 'horizontal-bar' });
+    expect(prompt).toContain('FIGURE');
+    expect(prompt).toContain('Space Grotesk');
+    expect(prompt).toContain('tabular-nums');
+    expect(prompt).toContain('SOURCE');
+    expect(prompt).toContain('--accent');
+  });
+
+  it('includes the horizontal-bar snippet when asked', () => {
+    const prompt = buildViewPrompt({ chartHint: 'horizontal-bar' });
+    expect(prompt).toContain('Horizontal bar (canonical reference)');
+    // The snippet's signed-delta helper is embedded as code.
+    expect(prompt).toContain("String(i + 1).padStart(2, '0')");
+  });
+
+  it('includes both canonical + stat for the auto hint', () => {
+    const prompt = buildViewPrompt({ chartHint: 'auto' });
+    expect(prompt).toContain('Horizontal bar (canonical reference)');
+    expect(prompt).toContain('Single-KPI stat card');
+  });
+
+  it('falls back to auto when no hint is provided', () => {
+    const prompt = buildViewPrompt();
+    expect(prompt).toContain('Horizontal bar (canonical reference)');
+    expect(prompt).toContain('Single-KPI stat card');
+  });
+
+  it('normalizes unknown hint values to auto', () => {
+    const prompt = buildViewPrompt({ chartHint: 'unknown-shape' as never });
+    expect(prompt).toContain('Horizontal bar (canonical reference)');
+    expect(prompt).toContain('Single-KPI stat card');
+  });
+
+  it('pairs line hint with the horizontal-bar canonical reference', () => {
+    const prompt = buildViewPrompt({ chartHint: 'line' });
+    expect(prompt).toContain('Line + filled area');
+    expect(prompt).toContain('Horizontal bar (canonical reference)');
+  });
+
+  it('does NOT include the old indigo palette', () => {
+    // Regression guard: the old prompt hardcoded #6366f1 as the accent.
+    for (const hint of ['horizontal-bar', 'line', 'donut', 'stat', 'auto', 'vertical-bar'] as const) {
+      const prompt = buildViewPrompt({ chartHint: hint });
+      expect(prompt, `hint=${hint}`).not.toContain('#6366f1');
+    }
+  });
+
+  it('does NOT include the old hardcoded #0a0a0f background', () => {
+    for (const hint of ['horizontal-bar', 'line', 'donut', 'stat', 'auto', 'vertical-bar'] as const) {
+      const prompt = buildViewPrompt({ chartHint: hint });
+      expect(prompt, `hint=${hint}`).not.toContain('#0a0a0f');
+    }
+  });
+
+  it('does NOT mandate system-ui fonts anywhere', () => {
+    // The old prompt said "system-ui font stack." — that's off-brand.
+    // Generated CSS inside snippets may legitimately use system-ui as a fallback
+    // tail on font-family declarations (e.g. inside `<link>`-less contexts),
+    // so we only guard the parts of the prompt that are Lightboard-authored
+    // prose, not the code blocks.
+    const prompt = buildViewPrompt({ chartHint: 'horizontal-bar' });
+    // No "system-ui font stack" instruction anywhere.
+    expect(prompt).not.toMatch(/system-ui font stack/i);
+    // No "use system-ui" instruction.
+    expect(prompt).not.toMatch(/use system-ui/i);
+  });
+
+  it('carries a current-view payload when provided', () => {
+    const prompt = buildViewPrompt({
+      chartHint: 'horizontal-bar',
+      currentView: { title: 'Existing chart', html: '<html></html>' },
+    });
+    expect(prompt).toContain('Current view (to modify)');
+    expect(prompt).toContain('Existing chart');
+  });
+
+  it('emits a data summary block when provided', () => {
+    const prompt = buildViewPrompt({
+      chartHint: 'horizontal-bar',
+      dataSummary: { columns: ['name', 'value'], rowCount: 5 },
+    });
+    expect(prompt).toContain('Data summary');
+    expect(prompt).toContain('rowCount');
+  });
+
+  it('keeps the total length within a sane budget', () => {
+    // Tokens (~2.8k), voice (~0.7k), rubric (~0.3k), one snippet (~6k), plus
+    // the prose wrapper brings horizontal-bar in around 17k chars. Two-snippet
+    // variants climb higher. The ceiling is a smoke test — the real budget
+    // lives in the snippet + voice + rubric file sizes, which have their own
+    // drift guards. 22k gives headroom for minor prose tweaks without the
+    // tests flaring.
+    const prompt = buildViewPrompt({ chartHint: 'horizontal-bar' });
+    expect(prompt.length).toBeLessThan(22_000);
+    const autoPrompt = buildViewPrompt({ chartHint: 'auto' });
+    expect(autoPrompt.length).toBeLessThan(22_000);
+  });
+});

--- a/packages/agent/src/prompt/view-prompt.ts
+++ b/packages/agent/src/prompt/view-prompt.ts
@@ -1,94 +1,173 @@
+import {
+  buildDesignContext,
+  DESIGN_RUBRIC,
+  DESIGN_TOKENS_CSS,
+  DESIGN_VOICE,
+  type ChartHint,
+} from '../design-system';
+
 /**
- * Builds the system prompt for the View Agent specialist.
- * Instructs the agent to generate complete, self-contained HTML visualizations.
+ * Extra context the leader (or a caller) can forward to the view specialist.
+ * `chartHint` lets the leader propose a figure shape inferred from the query
+ * result's column types; the view prompt uses it to pick the most relevant
+ * snippet(s) from the design system. If omitted or unrecognized, we fall
+ * back to `'auto'` (horizontal-bar + stat).
  */
-export function buildViewPrompt(context: Record<string, unknown>): string {
-  const parts = [VIEW_SYSTEM_PROMPT];
-
-  if (context.dataSummary) {
-    parts.push(`\n## Data Summary\n${JSON.stringify(context.dataSummary, null, 2)}`);
-  }
-
-  if (context.currentView) {
-    parts.push(`\n## Current View (to modify)\n${JSON.stringify(context.currentView, null, 2)}`);
-  }
-
-  return parts.join('\n');
+export interface ViewPromptContext {
+  dataSummary?: unknown;
+  currentView?: unknown;
+  chartHint?: ChartHint;
+  [key: string]: unknown;
 }
 
-const VIEW_SYSTEM_PROMPT = `You are a visualization specialist. Your job is to create beautiful, self-contained HTML visualizations from data.
+/**
+ * Known chart hint values. Anything outside this set is normalized to 'auto'
+ * so a misspelled hint from the leader can't break the prompt.
+ */
+const KNOWN_HINTS: ReadonlyArray<ChartHint> = [
+  'horizontal-bar',
+  'vertical-bar',
+  'line',
+  'donut',
+  'stat',
+  'auto',
+];
 
-## Output Format
+function normalizeHint(raw: unknown): ChartHint {
+  if (typeof raw === 'string' && (KNOWN_HINTS as readonly string[]).includes(raw)) {
+    return raw as ChartHint;
+  }
+  return 'auto';
+}
 
-Generate a complete HTML document that renders the visualization. The document must be entirely self-contained — all CSS and JS inline, no external dependencies except CDN scripts.
+/**
+ * Builds the system prompt for the View Agent specialist.
+ *
+ * The prompt is assembled in a specific order so the model sees the
+ * design-system tokens and voice rules BEFORE it sees the data summary — the
+ * intent is to lock in the visual contract first, then teach the data shape.
+ * Total size targets roughly 3.5k tokens; {@link buildDesignContext} caps its
+ * snippet count at 2 to stay within budget.
+ */
+export function buildViewPrompt(context: ViewPromptContext = {}): string {
+  const hint = normalizeHint(context.chartHint);
 
-Use create_view with:
-- title: descriptive title for the view
-- description: what the visualization shows
-- sql: the SQL query that produced the data
-- html: the complete HTML document string
+  const parts: string[] = [];
 
-## HTML Requirements
+  // 1. Role & iframe contract.
+  parts.push(ROLE_AND_IFRAME);
 
-1. **Data**: You MUST embed the actual query result rows directly as a JSON array literal: \`const DATA = [{...}, {...}, ...];\`. Do NOT use template variables like \${DATA} — the data must be hardcoded in the HTML string.
-2. **Charts**: Use Chart.js from CDN (\`https://cdn.jsdelivr.net/npm/chart.js\`) or pure SVG. Choose the best chart type for the data.
-3. **Layout**: Responsive, centered, max-width 900px. Use CSS Grid or Flexbox for multi-panel layouts.
-4. **Theme**: Dark background (#0a0a0f), light text (#e4e4e7), accent colors from this palette: #6366f1 (indigo), #22d3ee (cyan), #f59e0b (amber), #10b981 (emerald), #f43f5e (rose), #a855f7 (purple).
-5. **Typography**: system-ui font stack. Title 1.5rem bold, labels 0.75rem.
-6. **Stat cards**: For single KPI values, show a large number with label and optional delta/sparkline.
+  // 2. Voice.
+  parts.push(`## Voice\n\n${DESIGN_VOICE.trim()}`);
 
-## Chart Selection
+  // 3. Design tokens — paste-verbatim instruction.
+  parts.push(
+    '## Design tokens — paste this `:root` block verbatim\n\n' +
+      'Paste the following CSS at the top of your generated `<style>` block.\n' +
+      'Reference every color, radius, duration, and type value via `var(--…)`.\n' +
+      'Do not hardcode hex values except inside the magnitude ramp function (see below).\n\n' +
+      '```css\n' +
+      DESIGN_TOKENS_CSS.trim() +
+      '\n```',
+  );
 
-- Categorical + numeric → bar chart (horizontal if >6 categories)
-- Time + numeric → line chart with filled area
-- Single aggregate → stat card with large number
-- Two numeric columns → scatter plot
-- Multiple metrics over time → multi-line chart
-- Parts of whole → donut chart (never pie)
-- Tabular data → styled HTML table with alternating row colors
+  // 4. Figure anatomy.
+  parts.push(FIGURE_ANATOMY);
 
-## Findings Checklist (do this BEFORE writing HTML)
+  // 5. Chart component templates for the requested hint.
+  parts.push(`## Chart component templates\n\n${buildDesignContext(hint)}`);
 
-Visualizations that tell a story beat visualizations that label an axis. Before you start writing HTML, answer these four questions:
+  // 6. Palette rules.
+  parts.push(PALETTE_RULES);
 
-1. **What's the finding?** Name it in one sentence — outlier, gap, cluster, trend, flat, concentration, crossover.
-2. **Title = the finding, not a label.** "Top 3 regions drive 70% of revenue" beats "Revenue by Region". Put the insight in the headline.
-3. **One enrichment.** Pick a single complementary dimension (time, segment, baseline, benchmark) that creates tension or context. Resist the urge to pack in more — one well-chosen enrichment is sharper than three weak ones.
-4. **Subtitle = qualification criteria.** What filters, thresholds, date range, or sample size makes this claim true? Put it in the subtitle so the reader can trust the number.
+  // 7. Data contract.
+  parts.push(DATA_CONTRACT);
 
-If the data is flat or the finding is "nothing interesting", say so in the title — do not dress up a dull result with a shiny chart.
+  // 8. Don't list.
+  parts.push(DONT_LIST);
 
-## Craft Checklist
+  // 9. Rubric tail.
+  parts.push(
+    '## Self-check before emitting\n\n' +
+      'Walk this checklist. If any item fails, revise the HTML before calling `create_view` / `modify_view`.\n\n' +
+      DESIGN_RUBRIC.trim(),
+  );
 
-- [ ] Chart has clear axis labels
-- [ ] Colors have sufficient contrast on dark background
-- [ ] Numbers are formatted (commas, 1-2 decimal places)
-- [ ] Dates are human-readable (not ISO timestamps)
-- [ ] Responsive: works at 400px-1200px width
-- [ ] No scrollbars unless data table has many rows
+  // Optional data summary + current view payload.
+  if (context.dataSummary) {
+    parts.push(`## Data summary\n\n\`\`\`json\n${JSON.stringify(context.dataSummary, null, 2)}\n\`\`\``);
+  }
+  if (context.currentView) {
+    parts.push(
+      `## Current view (to modify)\n\n\`\`\`json\n${JSON.stringify(context.currentView, null, 2)}\n\`\`\``,
+    );
+  }
 
-## PNG Export
+  return parts.join('\n\n');
+}
 
-Include a small download button (top-right corner, semi-transparent) that exports the visualization as PNG:
+const ROLE_AND_IFRAME = `## Role
 
-\`\`\`html
-<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
-<button id="download-btn" style="position:fixed;top:8px;right:8px;padding:4px 12px;font-size:12px;background:rgba(255,255,255,0.1);color:#e4e4e7;border:1px solid rgba(255,255,255,0.2);border-radius:4px;cursor:pointer;z-index:100">⬇ PNG</button>
-<script>
-document.getElementById('download-btn').onclick=function(){
-  this.style.display='none';
-  html2canvas(document.body,{backgroundColor:'#0a0a0f'}).then(function(c){
-    var a=document.createElement('a');a.href=c.toDataURL('image/png');a.download='chart.png';a.click();
-    document.getElementById('download-btn').style.display='';
-  });
-};
-</script>
-\`\`\`
+You are Lightboard's visualization specialist. Your job is to generate a complete, self-contained HTML document that tells the story of the data. You write the HTML; Lightboard renders it in a sandboxed iframe.
 
-## Rules
+## Iframe contract
 
-- Always include title and description in the create_view call
-- Use create_view for new visualizations, modify_view for changes
-- The HTML must render correctly in a sandboxed iframe
-- Do NOT use document.cookie, localStorage, or fetch — the iframe is sandboxed
-- Always include the PNG download button and html2canvas script`;
+The iframe uses \`sandbox="allow-scripts"\` only — no \`allow-same-origin\`. That means:
+- \`fetch()\`, \`document.cookie\`, \`localStorage\`, and \`sessionStorage\` are BLOCKED. All data must be hardcoded into the HTML string.
+- Google Fonts loads via \`<link>\` (CORS-open). CDN scripts like \`html2canvas\` load fine via \`<script src>\`.
+- The HTML must be self-contained: no file:// references, no relative URLs, no external CSS files except Google Fonts and CDN scripts.
+
+Always use \`create_view\` for a new visualization and \`modify_view\` to update an existing one. Both take \`{ title, description, sql, html }\` — \`html\` is the full \`<!doctype html>…</html>\` string.`;
+
+const FIGURE_ANATOMY = `## Figure anatomy — every figure has these elements in this order
+
+1. **FIGURE eyebrow** — \`FIGURE 01 · <CATEGORY>\`. Mono, uppercase, \`letter-spacing: var(--track-eyebrow)\` (0.14em), color \`var(--ink-4)\`. CATEGORY is 1-3 words, uppercase: \`CRICKET · BATTING\`, \`REVENUE\`, \`LATENCY\`.
+2. **Title** — the finding, not the axis label. Space Grotesk (\`var(--font-display)\`), \`var(--text-chart-h)\` (22px), weight 600, \`var(--ink-1)\`. Sentence case.
+3. **Subtitle** — the qualification that makes the title provable. Inter (\`var(--font-body)\`), 12.5px, \`var(--ink-3)\`. One sentence, no trailing period needed.
+4. **Chart body** — bars / lines / donut / stat. Uses the magnitude ramp and the dashed baseline rule where applicable.
+5. **Footer row** — \`SOURCE · <source> · <period>\` on the left, \`N = <rowCount> · UPDATED <YYYY-MM-DD>\` on the right. Mono, \`var(--text-micro)\`, \`letter-spacing: var(--track-label)\`, uppercase, \`var(--ink-5)\`. Use middle-dot (·) separators.
+
+Optional:
+- **PNG export pill** — fixed top-right, mono uppercase, \`var(--bg-5)\` background, \`var(--line-3)\` border, \`999px\` radius, \`var(--ink-3)\` label. The canonical snippet includes this button with the html2canvas wiring — mirror that shape.`;
+
+const PALETTE_RULES = `## Palette rules
+
+- **One accent.** \`var(--accent)\` (#F2C265) highlights the lead finding or outlier row. Do not use it for decoration.
+- **Magnitude ramp** — map bar color to \`|value| / MAX\`:
+  - > 0.80 → \`#F2C265\`
+  - > 0.55 → \`#E89B52\`
+  - > 0.35 → \`#D97A44\`
+  - else  → \`#B85C3A\`
+- **Outlier rows** get the accent color AND a 1px glow (\`box-shadow: 0 0 0 1px var(--accent)\`) AND bold weight on the value cell.
+- **Dashed baseline rule** sits behind horizontal bars: \`1px dashed var(--ink-5)\`, positioned on the zero line. The horizontal-bar snippet implements this via an absolutely-positioned pseudo-element — mirror that approach.
+- **Do not introduce any hex values outside the ramp above.** Every other color reads from a \`var(--…)\` token.`;
+
+const DATA_CONTRACT = `## Data contract
+
+- Embed the query result rows as a literal JS array at the top of the \`<script>\`:
+  \`\`\`js
+  const DATA = [
+    { name: 'G Gambhir', value: 11.59, outlier: true },
+    { name: 'V Kohli',   value:  8.42 },
+    // ...
+  ];
+  \`\`\`
+  Do NOT use template variables like \`\${DATA}\` — the data must be hardcoded so the sandboxed iframe works.
+- **Rank column** uses \`String(i + 1).padStart(2, '0')\` → \`01\`, \`02\`, \`03\`.
+- **Every numeric cell** gets \`font-family: var(--font-mono)\` and \`font-variant-numeric: tabular-nums\` so columns align.
+- **Signed delta helper** — positives get an explicit \`+\`:
+  \`\`\`js
+  function signed(v) { return (v > 0 ? '+' : '') + v.toFixed(2); }
+  \`\`\`
+- Wait for Google Fonts before animating: wrap the kickoff in \`(document.fonts && document.fonts.ready || Promise.resolve()).then(...)\` to avoid FOUT jitter.
+- Bar width / scaleY animates from zero with \`transition: … var(--dur-chart) var(--ease-draw)\` and a 32ms stagger per row.`;
+
+const DONT_LIST = `## Don't
+
+- No emoji. Not in titles, not in metadata, not in buttons.
+- No \`system-ui\` font fallbacks in generated CSS. Always use \`var(--font-display)\`, \`var(--font-body)\`, \`var(--font-mono)\`.
+- No hex values outside the magnitude ramp.
+- No gradients (except the sigil, which you do not render here).
+- No serif faces.
+- No marketing adjectives in the subtitle ("amazing", "powerful"). Write like an editorial data team — dry, specific, signed.
+- No \`fetch()\`, \`document.cookie\`, \`localStorage\`, or \`sessionStorage\` — the iframe blocks them.`;

--- a/packages/agent/src/tools/leader-tools.ts
+++ b/packages/agent/src/tools/leader-tools.ts
@@ -45,7 +45,9 @@ export const leaderTools: ToolDefinition[] = [
       'Dispatch a visualization task to the View specialist and return immediately with a task_id. ' +
       'Use `await_tasks` to collect the result. ' +
       'You may dispatch this before a `dispatch_query` result is available by referencing a scratchpad table — ' +
-      'just wait on the query task first with `await_tasks`.',
+      'just wait on the query task first with `await_tasks`. ' +
+      'Pass `chart_hint` only when you have a strong signal from the data shape — the leader auto-infers it ' +
+      'from the query result columns otherwise.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -56,6 +58,13 @@ export const leaderTools: ToolDefinition[] = [
         scratchpad_table: {
           type: 'string',
           description: 'Name of the scratchpad table containing the data',
+        },
+        chart_hint: {
+          type: 'string',
+          enum: ['horizontal-bar', 'vertical-bar', 'line', 'donut', 'stat', 'auto'],
+          description:
+            'Optional chart shape hint. Usually omit — the leader infers this from the query result column types ' +
+            'before dispatching. Only set when you have explicit reason to pick a specific shape.',
         },
       },
       required: ['instruction'],


### PR DESCRIPTION
## Summary

Round 2 Phase 3 — teach the view specialist the Lightboard editorial visual language so generated HTML figures consistently match the reference design. The current view prompt teaches the wrong palette (`#6366f1` indigo) and mandates `system-ui` fonts; this rewrite swaps in a paste-verbatim `:root` token block, a figure anatomy contract (FIGURE eyebrow, Space Grotesk title, Inter subtitle, copper/gold bar ramp, dashed baseline rule, SOURCE/N/UPDATED footer), a magnitude ramp, and a 10-item self-check rubric.

**Stack:** #101 (Phase 1, AgentEvent enrichment) → #103 (Phase 2, narrate_summary) → #104 (Phase 4, eval harness) → **this** (Phase 3). Base = `feat/qwen-eval-harness`; GitHub auto-retargets as lower PRs merge.

### What landed

- **NEW** `packages/agent/src/design-system/` module:
  - `tokens.css` — `:root` block from globals.css (in-repo mirror of `Lightboard-design/colors_and_type.css`).
  - `voice.md` — 30-line content fundamentals (first-person, no emoji, signed deltas, tabular-nums, mono uppercase metadata).
  - `rubric.md` — 10-item self-check the model walks before emitting HTML.
  - `snippets/` — 5 canonical templates (horizontal-bar, vertical-bar, line, donut, stat).
  - `index.ts` — `buildDesignContext(hint)` returns the closest snippet(s) for the inferred chart shape; capped at two snippets per budget.
- **NEW** `__tests__/token-drift.test.ts` — diffs `tokens.css` against `apps/web/src/styles/globals.css` `:root`; fails loudly on divergence.
- **REWRITE** `packages/agent/src/prompt/view-prompt.ts` — sections in the exact order the plan called for: role + iframe contract, voice, paste-verbatim tokens, figure anatomy, chart templates, palette rules, data contract, don't-list, rubric tail.
- **ADD** voice card to `leader-prompt.ts` — first-person, no emoji, signed `+`, backticks around numeric values in chat text.
- **ADD** `inferChartHint(columns, rowCount)` in `leader.ts` + `chart_hint` field on `dispatch_view` tool schema. Threads through `runSubAgentTask` → `ViewAgent` → `buildViewPrompt` so the view specialist sees a snippet matching the query's actual column shape.
- **ADD** optional `chromeless` mode to `HtmlViewRenderer`. Default `'auto'` detects inline `FIGURE` eyebrow and suppresses the outer header so round-2 views don't double-print titles; legacy views render unchanged.
- **ADD** tests: `design-system.test.ts`, `token-drift.test.ts`, `infer-chart-hint.test.ts`, `view-prompt.test.ts` (with regression guards against `#6366f1`, `#0a0a0f`, and `system-ui font stack`), and `leader-prompt.test.ts`.

### Preserved

- `create_view` / `modify_view` tool usage instructions
- The PNG export button pattern (restyled to use tokens + mono uppercase pill shape)
- The Findings Checklist (title = finding, enrichment, subtitle = qualification)
- All Phase 1 / 2 / 4 surfaces — didn't touch `narrate-tools.ts`, the SSE reducer, the AgentEvent union, the eval harness, or `openai-compatible.ts`

## Test plan

- [x] `pnpm --filter @lightboard/agent test --run` — 252 tests pass, including 8 design-system tests, the token-drift guard, 8 inferChartHint cases, 10 view-prompt cases, 5 leader-prompt cases.
- [x] `pnpm test` (all packages) — 144 web tests + 252 agent tests + others, all passing.
- [x] `pnpm typecheck` — clean across all 9 packages.
- [x] `pnpm --filter @lightboard/web lint` — no ESLint warnings or errors.
- [x] `pnpm --filter @lightboard/web build` — production build completes; design-system assets ship inside the bundled agent module.
- [x] **Browser smoke test**: rendered the horizontal-bar snippet with a Gambhir batting fixture and screenshotted — matches the reference figure: mono FIGURE 01 · CRICKET · BATTING eyebrow, Space Grotesk 22px 600 title, Inter subtitle, zero-padded 01-10 ranks, copper ramp with `+11.59` outlier in amber + bold + 1px glow, dashed baseline rule behind bars, mono SOURCE · IPL BALL-BY-BALL · 2014-2024 and N = 10 · UPDATED 2026-04-20 footer, PNG export pill top-right.
- [x] CI passes.
- [x] Eval harness run with Qwen (deferred — user plans to pull the real Qwen 3.6 35b separately; Phase 6 in the plan covers tuning against the eval).

### Watch-outs addressed

- Design tokens live in one place (tokens.css) with a CI drift guard against globals.css — no manual sync required.
- Iframe sandbox remains `allow-scripts` only; every snippet is self-contained (Google Fonts via `<link>`, html2canvas via CDN, no `fetch()` or `document.cookie`).
- Prompt budget: horizontal-bar prompt lands ~17k chars (~4k tokens) with one snippet + tokens + voice + rubric; `auto` variant with two snippets ~21k chars. Well inside Qwen 35b's window.
- Unknown `chart_hint` values normalize to `'auto'` — a misspelled hint from the leader can't break the prompt.

Out of scope (per the plan): prompt-tuning experiments against Qwen. That's Phase 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)