### PR TITLE
fix(web,agent): round-2 explore polish — dispatch/await merge, card chrome, resilient create_view

### DIFF
--- a/apps/web/src/components/explore/__tests__/assistant-stream.test.tsx
+++ b/apps/web/src/components/explore/__tests__/assistant-stream.test.tsx
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { AssistantStream } from '../assistant-stream';
+import type { MessagePart } from '../chat-message';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+// MarkdownRenderer hits `next-intl` transitively; the AgentMessage wrapper
+// around it does not. No other collaborators to mock.
+
+describe('<AssistantStream> ghost-text suppression', () => {
+  afterEach(() => cleanup());
+
+  it('skips rendering an empty text part that sits before a trace cluster', () => {
+    // Whitespace-only text parts occasionally fall out of Claude's stream
+    // around tool boundaries. Rendering them adds a ghost 26px agent avatar
+    // next to the following cluster with nothing on its right — the exact
+    // "empty gutter above the panel" the user flagged in round-2 review.
+    const parts: MessagePart[] = [
+      { kind: 'text', text: '   \n  ' },
+      {
+        kind: 'tool_call',
+        name: 'run_sql',
+        status: 'done',
+        durationMs: 12,
+      },
+    ];
+    const { container } = render(<AssistantStream parts={parts} />);
+    // No AgentMessage avatars — the 26×26 rounded-md div from
+    // AgentMessage is unique to that component.
+    const avatars = container.querySelectorAll('.rounded-md.h-\\[26px\\]');
+    expect(avatars.length).toBe(0);
+  });
+
+  it('still renders a non-empty text part with its avatar', () => {
+    const parts: MessagePart[] = [
+      { kind: 'text', text: 'Checking the schema.' },
+    ];
+    const { container } = render(<AssistantStream parts={parts} />);
+    // Text content should appear.
+    expect(container.textContent).toContain('Checking the schema.');
+  });
+
+  it('keeps rendering an empty text part when it is the actively streaming last part', () => {
+    // While the agent is still typing into the tail text part, the text can
+    // legitimately be empty for a few frames. We keep rendering it so the
+    // blinking cursor has a home — otherwise the UI flickers avatar-in,
+    // avatar-out as every delta arrives.
+    const parts: MessagePart[] = [
+      {
+        kind: 'tool_call',
+        name: 'run_sql',
+        status: 'done',
+        durationMs: 10,
+      },
+      { kind: 'text', text: '' },
+    ];
+    const { container } = render(
+      <AssistantStream parts={parts} isStreaming={true} />,
+    );
+    // The empty trailing text part renders because it's the streaming tail.
+    // Detect via the cursor element (1px-wide inline-block span).
+    const cursors = container.querySelectorAll('span[class*="inline-block"]');
+    expect(cursors.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/components/explore/__tests__/sse-reducer.test.ts
+++ b/apps/web/src/components/explore/__tests__/sse-reducer.test.ts
@@ -332,6 +332,187 @@ describe('reduceParts', () => {
     expect(texts[0]?.text).toBe('Before');
     expect(texts[1]?.text).toBe('After');
   });
+
+  // Dispatch + await merge — the editorial log renders ONE row per
+  // dispatch_*, no await_tasks row, and the dispatch row picks up the
+  // duration + resultSummary from the eventual await resolution.
+  describe('dispatch_* + await_tasks merge', () => {
+    it('a single dispatch_query + await resolves into one "done" dispatch row with row count', () => {
+      const parts = run([
+        { type: 'tool_start', name: 'dispatch_query' },
+        {
+          type: 'tool_end',
+          name: 'dispatch_query',
+          result: JSON.stringify({
+            task_id: 'task_query_1',
+            role: 'query',
+            status: 'dispatched',
+            dispatched_at: 1,
+          }),
+          durationMs: 0,
+        },
+        { type: 'tool_start', name: 'await_tasks' },
+        {
+          type: 'tool_end',
+          name: 'await_tasks',
+          result: JSON.stringify({
+            task_query_1: {
+              success: true,
+              role: 'query',
+              explanation: 'ok',
+              data_summary: { rowCount: 412, columns: [], sampleRows: [] },
+            },
+          }),
+          durationMs: 850,
+        },
+      ]);
+
+      // Exactly one tool_call part (no await_tasks row).
+      const toolParts = parts.filter((p) => p.kind === 'tool_call');
+      expect(toolParts).toHaveLength(1);
+      expect(toolParts[0]).toMatchObject({
+        kind: 'tool_call',
+        name: 'dispatch_query',
+        status: 'done',
+        durationMs: 850,
+        resultSummary: '→ 412 rows',
+        taskId: 'task_query_1',
+      });
+    });
+
+    it('keeps the dispatch row in running state between dispatch_end and await_end', () => {
+      // This is the visual contract: while the task is still off in the
+      // background, the user sees a spinner on the dispatch row, NOT a
+      // grey-done row with 0ms.
+      let parts: MessagePart[] = [];
+      let ctx = createReducerContext();
+      const steps: SSEEventShape[] = [
+        { type: 'tool_start', name: 'dispatch_query' },
+        {
+          type: 'tool_end',
+          name: 'dispatch_query',
+          result: JSON.stringify({ task_id: 'task_query_1', role: 'query' }),
+          durationMs: 0,
+        },
+      ];
+      for (const ev of steps) {
+        const next = reduceParts(parts, ev, ctx);
+        parts = next.parts;
+        ctx = next.ctx;
+      }
+      const toolParts = parts.filter((p) => p.kind === 'tool_call');
+      expect(toolParts).toHaveLength(1);
+      expect(toolParts[0]).toMatchObject({
+        kind: 'tool_call',
+        name: 'dispatch_query',
+        status: 'running',
+        taskId: 'task_query_1',
+      });
+      // No await_tasks row appeared.
+      expect(toolParts.every((p) => p.name !== 'await_tasks')).toBe(true);
+    });
+
+    it('parallel dispatch_query + dispatch_view merged by a single await resolve each row independently', () => {
+      const parts = run([
+        { type: 'tool_start', name: 'dispatch_query' },
+        {
+          type: 'tool_end',
+          name: 'dispatch_query',
+          result: JSON.stringify({ task_id: 'task_query_1', role: 'query' }),
+          durationMs: 0,
+        },
+        { type: 'tool_start', name: 'dispatch_view' },
+        {
+          type: 'tool_end',
+          name: 'dispatch_view',
+          result: JSON.stringify({ task_id: 'task_view_1', role: 'view' }),
+          durationMs: 0,
+        },
+        { type: 'tool_start', name: 'await_tasks' },
+        {
+          type: 'tool_end',
+          name: 'await_tasks',
+          result: JSON.stringify({
+            task_query_1: {
+              success: true,
+              role: 'query',
+              data_summary: { rowCount: 10, columns: [], sampleRows: [] },
+            },
+            task_view_1: { success: true, role: 'view' },
+          }),
+          durationMs: 1200,
+        },
+      ]);
+
+      const toolParts = parts.filter(
+        (p) => p.kind === 'tool_call',
+      ) as Extract<MessagePart, { kind: 'tool_call' }>[];
+      expect(toolParts).toHaveLength(2);
+      expect(toolParts[0]).toMatchObject({
+        name: 'dispatch_query',
+        status: 'done',
+        durationMs: 1200,
+        resultSummary: '→ 10 rows',
+      });
+      expect(toolParts[1]).toMatchObject({
+        name: 'dispatch_view',
+        status: 'done',
+        durationMs: 1200,
+        resultSummary: '→ view created',
+      });
+    });
+
+    it('a failed task inside await marks its dispatch row as error', () => {
+      const parts = run([
+        { type: 'tool_start', name: 'dispatch_query' },
+        {
+          type: 'tool_end',
+          name: 'dispatch_query',
+          result: JSON.stringify({ task_id: 'task_query_1', role: 'query' }),
+          durationMs: 0,
+        },
+        { type: 'tool_start', name: 'await_tasks' },
+        {
+          type: 'tool_end',
+          name: 'await_tasks',
+          result: JSON.stringify({
+            task_query_1: {
+              success: false,
+              role: 'query',
+              error: 'timeout',
+            },
+          }),
+          durationMs: 30000,
+        },
+      ]);
+
+      const toolParts = parts.filter((p) => p.kind === 'tool_call');
+      expect(toolParts).toHaveLength(1);
+      expect(toolParts[0]).toMatchObject({
+        kind: 'tool_call',
+        name: 'dispatch_query',
+        status: 'error',
+        durationMs: 30000,
+        resultSummary: '→ error',
+      });
+    });
+
+    it('await with no prior dispatch is a no-op (no parts produced or crashed)', () => {
+      const parts = run([
+        { type: 'text', text: 'hello' },
+        { type: 'tool_start', name: 'await_tasks' },
+        {
+          type: 'tool_end',
+          name: 'await_tasks',
+          result: '{}',
+          durationMs: 5,
+        },
+      ]);
+      // Text survives, no tool_call rows.
+      expect(parts).toHaveLength(1);
+      expect(parts[0]).toMatchObject({ kind: 'text', text: 'hello' });
+    });
+  });
 });
 
 describe('createReducer', () => {

--- a/apps/web/src/components/explore/assistant-stream.tsx
+++ b/apps/web/src/components/explore/assistant-stream.tsx
@@ -161,16 +161,29 @@ export function AssistantStream({ parts, isStreaming }: AssistantStreamProps) {
                 isActive={isStreaming && index === parts.length - 1}
               />
             );
-          case 'text':
+          case 'text': {
+            const textIsStreaming =
+              !!isStreaming &&
+              index === lastTextIndex &&
+              lastTextIndex === parts.length - 1;
+            // An empty, non-streaming text part is a ghost row — it renders
+            // as a 26px agent avatar next to an empty content area and
+            // sits awkwardly above the following trace cluster. These
+            // arise from leading/trailing whitespace deltas the model
+            // occasionally emits around tool calls. Skip them so the
+            // cluster panel reads as the first visible block after the
+            // preceding real text.
+            if (part.text.trim().length === 0 && !textIsStreaming) {
+              return null;
+            }
             return (
               <AgentMessage
                 key={`text-${index}`}
                 content={part.text}
-                isStreaming={
-                  !!isStreaming && index === lastTextIndex && lastTextIndex === parts.length - 1
-                }
+                isStreaming={textIsStreaming}
               />
             );
+          }
           case 'status':
             return (
               <div

--- a/apps/web/src/components/explore/chat-message.tsx
+++ b/apps/web/src/components/explore/chat-message.tsx
@@ -41,6 +41,14 @@ export type MessagePart =
       label?: string;
       /** Backend-supplied terminal suffix like `→ 412 rows`. */
       resultSummary?: string;
+      /**
+       * Task id extracted from a `dispatch_*` tool_end result. The reducer
+       * uses this to resolve the row's final status / duration / summary when
+       * the later `await_tasks` call returns — no intermediate `await_tasks`
+       * row is rendered, so the dispatch row itself carries the spinner until
+       * the work actually completes.
+       */
+      taskId?: string;
     }
   | {
       kind: 'agent_delegation';

--- a/apps/web/src/components/explore/sse-reducer.ts
+++ b/apps/web/src/components/explore/sse-reducer.ts
@@ -176,6 +176,21 @@ export function reduceParts(
     }
 
     case 'tool_start': {
+      // `await_tasks` is a control-plane wait, not a distinct piece of
+      // work. Hiding its row keeps the editorial log focused on the
+      // `dispatch_*` rows that represent the actual tasks — when the
+      // await resolves, its duration + per-task result summaries merge
+      // back into the matching dispatch rows (see `tool_end` below).
+      // Track start time so the merge can compute duration when the
+      // backend didn't send one.
+      if (event.name === 'await_tasks') {
+        const nextCtx: ReducerContext = {
+          ...ctx,
+          toolStartTimes: { ...ctx.toolStartTimes, [event.name]: Date.now() },
+        };
+        return { parts: basePartsForNonStatus, ctx: nextCtx };
+      }
+
       // Prefer the backend's explicit parentAgent (sub-agent bubble-up)
       // over the locally-tracked active-agent stack. The stack only moves
       // on agent_start/agent_end which don't fire in dispatch mode.
@@ -199,6 +214,168 @@ export function reduceParts(
     }
 
     case 'tool_end': {
+      // `dispatch_*` tool_end returns a task handle immediately — the
+      // actual work happens off-thread. We stash the returned task_id on
+      // the dispatch row but deliberately leave `status: 'running'` so
+      // the spinner stays up until the corresponding `await_tasks` merge
+      // lands. This is what produces the reference-image behavior: one
+      // row per dispatch, no await row, duration reflects the whole task.
+      if (event.name.startsWith('dispatch_')) {
+        let matchIndex = -1;
+        for (let i = basePartsForNonStatus.length - 1; i >= 0; i -= 1) {
+          const p = basePartsForNonStatus[i]!;
+          if (
+            p.kind === 'tool_call' &&
+            p.name === event.name &&
+            p.status === 'running'
+          ) {
+            matchIndex = i;
+            break;
+          }
+        }
+        // Clear the start-time mapping so a subsequent same-name dispatch
+        // doesn't pick up this row's clock.
+        const nextToolStartTimes = { ...ctx.toolStartTimes };
+        delete nextToolStartTimes[event.name];
+        const nextCtx: ReducerContext = { ...ctx, toolStartTimes: nextToolStartTimes };
+
+        if (matchIndex === -1) {
+          return { parts: basePartsForNonStatus, ctx: nextCtx };
+        }
+        const existing = basePartsForNonStatus[matchIndex]! as Extract<
+          MessagePart,
+          { kind: 'tool_call' }
+        >;
+        // Parse the handle {task_id, role, status, dispatched_at} so the
+        // await_tasks merge below can resolve by task id.
+        let taskId: string | undefined;
+        if (event.result) {
+          try {
+            const parsed = JSON.parse(event.result);
+            if (parsed && typeof parsed.task_id === 'string') {
+              taskId = parsed.task_id;
+            }
+          } catch {
+            /* handle parse errors silently — row stays running, which is fine */
+          }
+        }
+        // If the dispatch itself failed (should be rare — the handler
+        // only errors on bad input) flip to error so the user sees it.
+        if (event.isError) {
+          const updated: MessagePart = {
+            ...existing,
+            status: 'error',
+            ...(event.result !== undefined ? { result: String(event.result) } : {}),
+            ...(event.resultSummary !== undefined ? { resultSummary: event.resultSummary } : {}),
+          };
+          const nextParts = [
+            ...basePartsForNonStatus.slice(0, matchIndex),
+            updated,
+            ...basePartsForNonStatus.slice(matchIndex + 1),
+          ];
+          return { parts: nextParts, ctx: nextCtx };
+        }
+        const updated: MessagePart = {
+          ...existing,
+          // Deliberately keep status: 'running' until await_tasks resolves.
+          ...(taskId ? { taskId } : {}),
+        };
+        const nextParts = [
+          ...basePartsForNonStatus.slice(0, matchIndex),
+          updated,
+          ...basePartsForNonStatus.slice(matchIndex + 1),
+        ];
+        return { parts: nextParts, ctx: nextCtx };
+      }
+
+      // `await_tasks` tool_end: parse the per-task-id result map and
+      // merge each entry into its matching dispatch row. Drop the await
+      // row itself — it was never rendered in the first place (see the
+      // `tool_start` branch above), but we still need to clean up the
+      // toolStartTimes entry.
+      if (event.name === 'await_tasks') {
+        const start = ctx.toolStartTimes[event.name];
+        const awaitDuration =
+          event.durationMs ?? (start != null ? Date.now() - start : undefined);
+        const nextToolStartTimes = { ...ctx.toolStartTimes };
+        delete nextToolStartTimes[event.name];
+
+        let taskMap: Record<string, Record<string, unknown>> | null = null;
+        if (event.result && !event.isError) {
+          try {
+            const parsed = JSON.parse(event.result);
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+              taskMap = parsed as Record<string, Record<string, unknown>>;
+            }
+          } catch {
+            /* no structured map — dispatches stay running, user sees a
+               graceful fallback rather than a crash */
+          }
+        }
+
+        // Also track rows seen on the most recent query so view parts
+        // that land via a dispatch_view task can inherit the data.
+        let nextLastQueryRows = ctx.lastQueryRows;
+
+        if (!taskMap) {
+          return {
+            parts: basePartsForNonStatus,
+            ctx: { ...ctx, toolStartTimes: nextToolStartTimes, lastQueryRows: nextLastQueryRows },
+          };
+        }
+
+        const nextParts = basePartsForNonStatus.map((p) => {
+          if (
+            p.kind !== 'tool_call' ||
+            !p.taskId ||
+            !Object.prototype.hasOwnProperty.call(taskMap, p.taskId)
+          ) {
+            return p;
+          }
+          const entry = taskMap[p.taskId]!;
+          const success = entry.success === true;
+          const role = typeof entry.role === 'string' ? entry.role : '';
+          let summary: string | undefined;
+          if (!success) {
+            summary = '→ error';
+          } else if (role === 'query') {
+            const ds = entry.data_summary as Record<string, unknown> | undefined;
+            const rc = ds && typeof ds.rowCount === 'number' ? ds.rowCount : null;
+            if (rc != null) {
+              summary = `→ ${rc.toLocaleString()} rows`;
+              // Surface the rows for legacy ViewSpec renderers that
+              // expect ctx.lastQueryRows.
+              if (Array.isArray(ds!.sampleRows)) {
+                nextLastQueryRows = ds!.sampleRows as Record<string, unknown>[];
+              }
+            }
+          } else if (role === 'view') {
+            summary = '→ view created';
+          } else if (role === 'insights') {
+            const data = entry.data as Record<string, unknown> | undefined;
+            if (data && Array.isArray(data.findings)) {
+              const n = (data.findings as unknown[]).length;
+              summary = `→ ${n} finding${n === 1 ? '' : 's'}`;
+            }
+          }
+
+          return {
+            ...p,
+            status: (success ? 'done' : 'error') as 'done' | 'error',
+            ...(awaitDuration !== undefined ? { durationMs: awaitDuration } : {}),
+            ...(summary ? { resultSummary: summary } : {}),
+          };
+        });
+
+        return {
+          parts: nextParts,
+          ctx: {
+            ...ctx,
+            toolStartTimes: nextToolStartTimes,
+            lastQueryRows: nextLastQueryRows,
+          },
+        };
+      }
       // Find the last running tool_call part matching this name. We scan
       // right-to-left so overlapping tools with the same name resolve in
       // LIFO order — matches how tool runs actually complete.

--- a/apps/web/src/components/explore/trace/__tests__/trace-cluster.test.tsx
+++ b/apps/web/src/components/explore/trace/__tests__/trace-cluster.test.tsx
@@ -88,4 +88,22 @@ describe('<TraceCluster>', () => {
     expect(container.textContent).toContain('1/1 tool call');
     expect(container.textContent).not.toContain('tool calls');
   });
+
+  it('wraps the cluster in a bordered card chrome', () => {
+    // Round-2 visual contract: cluster reads as a self-contained soft
+    // card, not a top-only dashed rule. Asserting the inline style on
+    // the wrapper pins down the chrome enough that a future refactor
+    // that accidentally reverts to "border-top only" fails here.
+    const { container } = renderCluster();
+    const wrapper = container.querySelector('[data-testid="trace-cluster"]') as
+      | HTMLElement
+      | null;
+    expect(wrapper).toBeTruthy();
+    const style = wrapper!.style;
+    expect(style.border).toContain('1px solid');
+    expect(style.borderRadius).toBe('10px');
+    // Background must be the lifted `--bg-4` (not transparent / --bg-0)
+    // so the card reads as its own surface.
+    expect(style.background).toContain('var(--bg-4)');
+  });
 });

--- a/apps/web/src/components/explore/trace/tool-call-row.tsx
+++ b/apps/web/src/components/explore/trace/tool-call-row.tsx
@@ -144,9 +144,10 @@ interface ToolCallRowProps {
  * - `error`   — destructive red dot, duration if available.
  * - `aborted` — ink-5 dot, struck-through tool name.
  *
- * When `parentAgent` is set (a sub-agent ran this tool), the row indents
- * 12px and shows a subtle dimmed bracket on the left so nesting reads
- * visually.
+ * All rows in a cluster share the same left alignment. `parentAgent` is
+ * still carried on the part as metadata for future filtering/grouping,
+ * but it no longer produces visual indentation — the cluster panel chrome
+ * already expresses grouping.
  */
 export function ToolCallRow({ part }: ToolCallRowProps) {
   // Prefer the backend-supplied kind; fall back to the name-based map so
@@ -157,7 +158,11 @@ export function ToolCallRow({ part }: ToolCallRowProps) {
   const isRunning = part.status === 'running';
   const isError = part.status === 'error';
   const isAborted = part.status === 'aborted';
-  const isNested = !!part.parentAgent;
+  // `parentAgent` used to drive a 12px indent + dashed left rule for sub-agent
+  // rows. Round-2 feedback: inside a cluster panel every row should sit at
+  // the same x-alignment so kind badges line up. Keep the field available
+  // on MessagePart — it's still useful metadata for filters / debugging —
+  // but don't express it visually here.
 
   // Derive display parts. If the backend supplied a compact `label` use
   // that; otherwise reconstruct from the tool name + args. Long SQL (>100
@@ -197,22 +202,17 @@ export function ToolCallRow({ part }: ToolCallRowProps) {
         gap: 14,
         padding: '6px 0 6px 14px',
         position: 'relative',
-        marginLeft: isNested ? 12 : 0,
-        // Nested rows used to carry a dashed left rule that duplicated the
-        // cluster panel's outer chrome. With the panel in place the inner
-        // rule is visual noise — the 12px indent alone reads as nesting.
-        paddingLeft: 14,
       }}
     >
       {/* Status glyph — 14px rainbow loader while running, hollow kind-colored
           dot when terminal. Absolute-positioned so the size swap doesn't shift
-          sibling content. Visual centers align: 8x8 dot centered at x=2 (top) /
-          x=14 (nested), y=16; 14x14 loader uses left = center - 7, top = 9. */}
+          sibling content. Single alignment for all rows in a cluster — the
+          dot sits flush with the kind badge's left edge. */}
       {isRunning ? (
         <div
           style={{
             position: 'absolute',
-            left: isNested ? 7 : -5,
+            left: -5,
             top: 9,
             width: 14,
             height: 14,
@@ -225,7 +225,7 @@ export function ToolCallRow({ part }: ToolCallRowProps) {
           aria-hidden="true"
           style={{
             position: 'absolute',
-            left: isNested ? 10 : -2,
+            left: -2,
             top: 12,
             width: 8,
             height: 8,

--- a/apps/web/src/components/explore/trace/trace-cluster.tsx
+++ b/apps/web/src/components/explore/trace/trace-cluster.tsx
@@ -56,11 +56,17 @@ export function TraceCluster({
 
   return (
     <div
-      className="ml-[40px]"
+      className="ml-[40px] overflow-hidden"
+      data-testid="trace-cluster"
       style={{
-        borderTop: '1px dashed var(--line-4, var(--line-2))',
-        borderBottom: '1px dashed var(--line-4, var(--line-2))',
-        padding: '4px 0',
+        // Soft bordered card — matches reference image 15: a quiet
+        // slightly-lifted surface, not a loud tile. `--bg-4` sits one step
+        // above `--bg-0` so the panel reads as its own object without
+        // shouting; `--line-3` is soft enough to stay subordinate to the
+        // chat around it while still giving the shape a clear edge.
+        border: '1px solid var(--line-3)',
+        borderRadius: 10,
+        background: 'var(--bg-4)',
       }}
     >
       <button
@@ -68,8 +74,14 @@ export function TraceCluster({
         onClick={() => setCollapsed((v) => !v)}
         aria-expanded={!collapsed}
         aria-label={collapsed ? 'Expand tool calls' : 'Collapse tool calls'}
-        className="flex w-full items-center gap-3 border-0 bg-transparent px-2 py-2 text-left"
-        style={{ cursor: 'pointer' }}
+        className="flex w-full items-center gap-3 border-0 bg-transparent text-left"
+        style={{
+          cursor: 'pointer',
+          // Header is the clickable area across the whole width. Padding
+          // is on the header itself (not the card) so when collapsed the
+          // whole border-radius clips the click target cleanly.
+          padding: '10px 16px',
+        }}
       >
         {/* Status dot — 8px solid dot; adds a pulsing ring while running. */}
         <span
@@ -153,7 +165,16 @@ export function TraceCluster({
         </span>
       </button>
       {!collapsed && (
-        <div style={{ padding: '2px 2px 6px' }} data-testid="trace-cluster-body">
+        <div
+          data-testid="trace-cluster-body"
+          style={{
+            // Subtle divider between header row and the body — reads as
+            // one card with a clear header/body split rather than two
+            // separate panels stacked.
+            borderTop: '1px solid var(--line-2)',
+            padding: '8px 16px 12px',
+          }}
+        >
           {children}
         </div>
       )}

--- a/packages/agent/src/tools/router-normalize.test.ts
+++ b/packages/agent/src/tools/router-normalize.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ToolRouter, type ToolContext } from './router';
+
+/**
+ * Focused tests for the malformed-input coercion paths added to make
+ * `create_view` survive local-model quirks (Qwen chunking the html body into
+ * arrays, wrapping the whole tool payload in an `input:` envelope, etc.).
+ *
+ * Each test exercises one concrete failure mode from the live eval logs.
+ * The goal is not schema coverage — `router.test.ts` already asserts the
+ * happy path — but to pin down the shapes we now tolerate and the ones we
+ * still reject with a readable error.
+ */
+function createMockContext(): ToolContext {
+  return {
+    getSchema: vi.fn().mockResolvedValue({ tables: [] }),
+  };
+}
+
+describe('ToolRouter — create_view malformed input tolerance', () => {
+  it('accepts html delivered as an array of strings (joined with "")', async () => {
+    const router = new ToolRouter(createMockContext());
+    const htmlChunks = ['<!doc>', '<html>', '<body>chart</body>', '</html>'];
+
+    const result = await router.execute('create_view', {
+      title: 'Top Batters',
+      sql: 'SELECT batter FROM ball_by_ball LIMIT 10',
+      html: htmlChunks,
+    });
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.viewSpec.html).toBe(htmlChunks.join(''));
+  });
+
+  it('preserves newlines when html is an array of lines', async () => {
+    const router = new ToolRouter(createMockContext());
+    const lines = ['line1\n', 'line2\n', 'line3\n'];
+
+    const result = await router.execute('create_view', {
+      title: 't',
+      sql: 's',
+      html: lines,
+    });
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.viewSpec.html).toBe('line1\nline2\nline3\n');
+  });
+
+  it('unwraps a single-key `input: "<json>"` envelope and routes through', async () => {
+    const router = new ToolRouter(createMockContext());
+    const body = JSON.stringify({
+      title: 'x',
+      sql: 'SELECT 1',
+      html: '<html></html>',
+    });
+
+    const result = await router.execute('create_view', { input: body });
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.viewSpec.title).toBe('x');
+    expect(parsed.viewSpec.html).toBe('<html></html>');
+  });
+
+  it('coerces numeric title / sql to strings instead of failing Zod', async () => {
+    const router = new ToolRouter(createMockContext());
+
+    const result = await router.execute('create_view', {
+      title: 42 as unknown as string,
+      sql: 1 as unknown as string,
+      html: '<html></html>',
+    });
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.viewSpec.title).toBe('42');
+    expect(parsed.viewSpec.sql).toBe('1');
+  });
+
+  it('returns a precise per-field error when html is missing', async () => {
+    const router = new ToolRouter(createMockContext());
+
+    const result = await router.execute('create_view', {
+      title: 'x',
+      sql: 'SELECT 1',
+      // html intentionally missing
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('create_view');
+    expect(result.content).toContain('html');
+    expect(result.content).toContain('got undefined');
+    // The retry guidance is load-bearing — without it Qwen repeats the same
+    // malformed call 8 times in a row.
+    expect(result.content).toContain('Re-emit');
+  });
+
+  it('returns a precise per-field error when html is a raw number', async () => {
+    const router = new ToolRouter(createMockContext());
+
+    const result = await router.execute('create_view', {
+      title: 'x',
+      sql: 'SELECT 1',
+      // coerceViewInput stringifies numbers, so html:42 actually succeeds;
+      // use an object instead — that path is not coerced and Zod must flag it.
+      html: { nested: 'oops' } as unknown as string,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('html');
+    expect(result.content).toContain('got object');
+  });
+
+  it('returns a precise per-field error when html is an array of non-strings', async () => {
+    const router = new ToolRouter(createMockContext());
+
+    const result = await router.execute('create_view', {
+      title: 'x',
+      sql: 'SELECT 1',
+      // Mixed-type array — not safe to join, so coerceViewInput leaves it.
+      html: ['<html>', 42, '</html>'] as unknown as string,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('html');
+    expect(result.content).toContain('got array');
+  });
+});

--- a/packages/agent/src/tools/router.ts
+++ b/packages/agent/src/tools/router.ts
@@ -74,6 +74,78 @@ const toolInputSchemas = {
 };
 
 /**
+ * Describe a value's runtime shape for error reporting. Keeps the strings
+ * stable so tests can assert on them and the model can read them on retry.
+ */
+function describeType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+/**
+ * Format a Zod error into a single-line human (and model) readable string.
+ * The default `parsed.error.message` is a pretty-printed multi-line JSON
+ * which truncates badly in SSE logs and leaves the model guessing which
+ * field to fix. This version collapses to `path: expected X (got Y)` per
+ * issue so the retry has enough information to succeed.
+ */
+function formatZodErrors(
+  toolName: string,
+  input: Record<string, unknown>,
+  error: z.ZodError,
+): string {
+  const parts: string[] = [];
+  for (const issue of error.issues) {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+    const received = describeType(
+      issue.path.reduce<unknown>((acc, key) => {
+        if (acc && typeof acc === 'object') {
+          return (acc as Record<string | number, unknown>)[key as string | number];
+        }
+        return undefined;
+      }, input),
+    );
+    if (issue.code === 'invalid_type') {
+      parts.push(`${path} must be a ${issue.expected} (got ${received})`);
+    } else {
+      parts.push(`${path}: ${issue.message} (got ${received})`);
+    }
+  }
+  return `Invalid input for ${toolName}: ${parts.join('; ')}. Re-emit the whole tool input with every field as a plain JSON value of the expected type.`;
+}
+
+/**
+ * Pre-process `create_view` / `modify_view` input to tolerate the quirks
+ * local models (Qwen, Llama, etc.) emit under pressure:
+ *   - `html` chunked into an array of strings → join with '' so multi-line
+ *     HTML bodies arrive intact.
+ *   - `sql` / `title` / `description` emitted as arrays → join with ''.
+ *   - Scalar numbers where strings are expected → coerce via `String()`.
+ *
+ * Anything we can't safely coerce is left alone so Zod returns a readable
+ * error rather than a silently wrong value. This helper runs after
+ * {@link ToolRouter.normalizeInput} (which unwraps JSON-stringified bodies)
+ * and before `safeParse`.
+ */
+function coerceViewInput(input: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...input };
+  for (const key of ['title', 'description', 'sql', 'html'] as const) {
+    const value = result[key];
+    if (Array.isArray(value)) {
+      // Accept arrays of strings — any non-string element short-circuits so
+      // Zod can flag it with a precise `got array` error.
+      if (value.every((v) => typeof v === 'string')) {
+        result[key] = value.join('');
+      }
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      result[key] = String(value);
+    }
+  }
+  return result;
+}
+
+/**
  * Routes tool calls from the LLM to the appropriate handler.
  * Accepts a dynamic set of tool definitions at construction time,
  * allowing different agents to use different tool subsets.
@@ -96,8 +168,30 @@ export class ToolRouter {
       return { content: `Tool "${toolName}" is not available for this agent`, isError: true };
     }
 
+    // Some local-model clients wrap the entire tool body in a single
+    // `{ input: "...stringified JSON..." }` envelope instead of passing the
+    // parsed object directly. Unwrap that shape before normalizing so the
+    // per-field coercion below sees the real keys.
+    let workingInput: Record<string, unknown> = input;
+    if (
+      Object.keys(workingInput).length === 1 &&
+      typeof workingInput.input === 'string'
+    ) {
+      const raw = workingInput.input.trim();
+      if (raw.startsWith('{') && raw.endsWith('}')) {
+        try {
+          const parsed = JSON.parse(raw);
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            workingInput = parsed as Record<string, unknown>;
+          }
+        } catch {
+          /* fall through — Zod will produce a readable error below */
+        }
+      }
+    }
+
     // Auto-parse stringified JSON values — local models often send nested objects as strings
-    const normalizedInput = this.normalizeInput(input);
+    const normalizedInput = this.normalizeInput(workingInput);
     for (const [key, val] of Object.entries(input)) {
       if (typeof val === 'string' && typeof normalizedInput[key] !== 'string') {
         console.log(`[ToolRouter] Normalized "${key}" from string to ${typeof normalizedInput[key]}`);
@@ -212,9 +306,13 @@ export class ToolRouter {
 
   /** Handle create_view tool call — stores an HTML view. */
   private async handleCreateView(input: Record<string, unknown>): Promise<ToolExecutionResult> {
-    const parsed = toolInputSchemas.create_view.safeParse(input);
+    const coerced = coerceViewInput(input);
+    const parsed = toolInputSchemas.create_view.safeParse(coerced);
     if (!parsed.success) {
-      return { content: `Invalid input: ${parsed.error.message}`, isError: true };
+      return {
+        content: formatZodErrors('create_view', coerced, parsed.error),
+        isError: true,
+      };
     }
 
     const viewId = `view_${Date.now()}`;
@@ -234,9 +332,13 @@ export class ToolRouter {
 
   /** Handle modify_view tool call — patches an existing HTML view. */
   private async handleModifyView(input: Record<string, unknown>): Promise<ToolExecutionResult> {
-    const parsed = toolInputSchemas.modify_view.safeParse(input);
+    const coerced = coerceViewInput(input);
+    const parsed = toolInputSchemas.modify_view.safeParse(coerced);
     if (!parsed.success) {
-      return { content: `Invalid input: ${parsed.error.message}`, isError: true };
+      return {
+        content: formatZodErrors('modify_view', coerced, parsed.error),
+        isError: true,
+      };
     }
 
     const existing = this.viewStore.get(parsed.data.view_id);


### PR DESCRIPTION
## Summary
Round-2 feedback on #106. Five issues surfaced during live testing with the Qwen local model; all five fixed with live verification.

### Issue 1 — `create_view` Zod validation loop (HIGH)
Local Qwen occasionally emits `html` as an array of strings, or wraps the entire tool body in a single `{ input: "..." }` envelope, or sends scalar numbers where strings are expected. The router now tolerates all three via pre-Zod coercion in `packages/agent/src/tools/router.ts`. Error messages for anything that still fails use a single-line per-field format (`html must be a string (got array). Re-emit the whole tool input with every field as a plain JSON value of the expected type.`) so the model gets actionable retry guidance instead of a truncated multi-line Zod dump.

### Issue 2 — hide `await_tasks`, merge into `dispatch_*` rows (HIGH)
SSE reducer (`apps/web/src/components/explore/sse-reducer.ts`) now keeps `dispatch_*` rows in `running` state after their `tool_end` (they only return a task handle immediately), stashes the returned `task_id`, and on the subsequent `await_tasks` `tool_end` merges the per-task success / duration / result summary into each matching dispatch row. Parallel dispatches spread the resolution — each dispatch gets its own final duration + summary. The `await_tasks` row itself never appears.

### Issue 3 — empty gutter above trace panel
`assistant-stream.tsx` now skips empty, non-streaming text parts so leading/trailing whitespace deltas around tool calls no longer leave a ghost 26px agent avatar sitting next to an empty content area above a cluster. Streaming tail-text stays rendered so the blinking cursor has a home.

### Issue 4 — uniform row alignment inside a cluster
Dropped the 12px `marginLeft` indent for `parentAgent` rows in `tool-call-row.tsx`. Kind badges across every row in a cluster now sit on the same x-axis. The `parentAgent` metadata is still carried on the part for future filtering.

### Issue 5 — proper card chrome on the cluster panel
`trace-cluster.tsx` replaces the top/bottom-only dashed rules with a soft bordered card: `--line-3` border, 10px radius, `--bg-4` background, inner `--line-2` divider between the header row and body. Header row is the full click target; padding lives on the header, not the card, so the border-radius clips cleanly when collapsed.

## Test plan
- [x] `pnpm --filter @lightboard/web typecheck` — clean
- [x] `pnpm --filter @lightboard/agent typecheck` — clean
- [x] `pnpm --filter @lightboard/web lint` — no warnings or errors
- [x] `pnpm --filter @lightboard/web test` — 165 tests pass (8 new across reducer / assistant-stream / trace-cluster)
- [x] `pnpm --filter @lightboard/agent test` — 259 tests pass (7 new in `router-normalize.test.ts`)
- [x] Live browser test with Qwen via LM Studio — ran the user's TSR question end-to-end:
  - `create_view` succeeded on first attempt (no 8-retry Zod loop). Server log confirms `[ToolRouter] ✓ create_view (0ms) → 9597 chars`.
  - No `await_tasks` rows anywhere in the trace; `dispatch_query` shows `→ 10 rows` / 19.2s, `dispatch_view` shows `→ view created` / 109.8s.
  - No ghost agent avatars between panels.
  - All rows inside each panel align at the same x-axis.
  - Panels render as clean bordered cards with a subtle header/body divider.
  - When Qwen called `modify_view` with an empty body, the new error message gave a clear per-field retry guide and the next call succeeded with a proper `view_id`.

## Base branch
`fix/explore-ui-polish` (PR #106). Once that merges, this branch's diff collapses to just the round-2 fixes.

## Observed edge behavior, unchanged from plan
Qwen occasionally called `modify_view({})` with no `view_id`. The router now returns a single-line actionable error; the model recovers on the next turn. No hardcoded retry count added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)