### PR TITLE
feat(d2): persist Explore conversations and resume from sidebar

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -70,7 +70,13 @@
     "filmstripClose": "Close filmstrip",
     "filmstripOpen": "Open filmstrip",
     "filmstripPinned": "pinned",
-    "suggestionsLabel": "Follow-up suggestions"
+    "suggestionsLabel": "Follow-up suggestions",
+    "conversationsHeading": "Conversations",
+    "conversationsToday": "Today",
+    "conversationsYesterday": "Yesterday",
+    "conversationsThisWeek": "This week",
+    "conversationsOlder": "Older",
+    "conversationsEmpty": "No saved conversations yet."
   },
   "dataSources": {
     "title": "Data Sources",

--- a/apps/web/src/app/api/agent/chat/route.ts
+++ b/apps/web/src/app/api/agent/chat/route.ts
@@ -8,19 +8,23 @@ import {
 } from '@/lib/data-source-service';
 import { checkRateLimit, addRateLimitHeaders } from '@/lib/rate-limit';
 import { redis } from '@/lib/redis';
-import { dataSources } from '@lightboard/db/schema';
-import { eq } from 'drizzle-orm';
+import type { Database } from '@lightboard/db';
+import { conversationMessages, conversations, dataSources } from '@lightboard/db/schema';
+import { and, asc, eq, sql } from 'drizzle-orm';
 import {
   LeaderAgent,
   ScratchpadManager,
   LLMError,
   generateSchemaContext,
   ConversationLog,
+  hydratePersistedMessage,
+  toPersistedMessagesWithNames,
   wrapToolContext,
   defaultLogDir,
   type AgentDataSource,
   type AgentEvent,
   type Message,
+  type PersistedToolResult,
   type ToolContext,
 } from '@lightboard/agent';
 import { resolveAIProviders } from '@/lib/ai-provider';
@@ -39,8 +43,16 @@ const scratchpadManager = new ScratchpadManager({
  * Leaders persist across turns to maintain conversation state in-memory,
  * avoiding Redis round-trips and keeping the ConversationManager warm.
  * Entries expire after 1 hour of inactivity.
+ *
+ * `priorSeq` tracks the highest `conversation_messages.sequence` we have
+ * already persisted for this session. Each turn writes only the diff between
+ * the leader's in-memory history and that watermark, so multi-turn chats
+ * never re-insert the same row.
  */
-const leaderCache = new Map<string, { leader: LeaderAgent; lastAccess: number }>();
+const leaderCache = new Map<
+  string,
+  { leader: LeaderAgent; lastAccess: number; priorSeq: number }
+>();
 
 /** Max age for cached leaders before eviction (1 hour). */
 const LEADER_CACHE_MAX_AGE_MS = 60 * 60 * 1000;
@@ -79,7 +91,7 @@ const AGENT_RATE_LIMIT_BUCKET = 'query' as const;
  * Supports conversation persistence via Redis-backed sessions.
  * When Accept: text/event-stream is set, streams SSE events.
  */
-export const POST = withAuth(async (req, { db, orgId }) => {
+export const POST = withAuth(async (req, { db, orgId, user }) => {
   let body: Record<string, unknown>;
   try {
     body = await req.json();
@@ -87,16 +99,33 @@ export const POST = withAuth(async (req, { db, orgId }) => {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
-  const { message, conversationId } = body as {
+  // Accept both `dataSourceId` (canonical) and `sourceId` (legacy client field)
+  // so the existing explore-page-client keeps working without a coordinated
+  // ship. Empty string from the picker is treated as "no source selected".
+  const {
+    message,
+    conversationId,
+    dataSourceId: rawDataSourceId,
+    sourceId,
+  } = body as {
     message?: string;
     conversationId?: string;
+    dataSourceId?: string | null;
+    sourceId?: string | null;
   };
+
+  const dataSourceId =
+    typeof rawDataSourceId === 'string' && rawDataSourceId
+      ? rawDataSourceId
+      : typeof sourceId === 'string' && sourceId
+      ? sourceId
+      : null;
 
   if (!message) {
     return NextResponse.json({ error: 'Message is required' }, { status: 400 });
   }
 
-  console.log(`[Chat] ← "${message.slice(0, 100)}" (conv=${conversationId ?? 'new'}, org=${orgId})`);
+  console.log(`[Chat] ← "${message.slice(0, 100)}" (conv=${conversationId ?? 'new'}, source=${dataSourceId ?? 'none'}, org=${orgId})`);
 
   // Rate limiting
   const rateResult = await checkRateLimit(orgId, AGENT_RATE_LIMIT_BUCKET);
@@ -196,8 +225,26 @@ export const POST = withAuth(async (req, { db, orgId }) => {
     },
   };
 
-  // Generate or reuse conversation/session ID
-  const sessionId = conversationId ?? `conv_${Date.now()}_${crypto.randomUUID().slice(0, 8)}`;
+  // Resolve the canonical conversation id. The DB UUID is the session key —
+  // we no longer fabricate a `conv_<ts>_<rand>` prefix because every
+  // resumable conversation must be addressable from the sidebar by id.
+  let sessionId: string;
+  try {
+    sessionId = await resolveConversationId({
+      db,
+      orgId,
+      userId: user.id,
+      conversationId,
+      dataSourceId,
+      message,
+    });
+  } catch (err) {
+    console.error('[Chat] Failed to resolve conversation row:', err);
+    return NextResponse.json(
+      { error: 'Could not create or load this conversation. Please try again.' },
+      { status: 500 },
+    );
+  }
 
   // Passive conversation log — one JSONL per turn. Advisory; failures never
   // block the response. Consumed later (eval / past-mistakes curation).
@@ -216,10 +263,12 @@ export const POST = withAuth(async (req, { db, orgId }) => {
   // Reuse existing LeaderAgent for this session, or create a new one.
   // Leaders persist across turns to keep conversation state in-memory.
   let leader: LeaderAgent;
+  let priorSeq: number;
   const cached = leaderCache.get(sessionId);
   if (cached) {
     leader = cached.leader;
     cached.lastAccess = Date.now();
+    priorSeq = cached.priorSeq;
     // Rebind the tool context so this turn's conversation log captures
     // SQL + schema calls made by the cached leader.
     leader.setToolContext(loggedToolContext);
@@ -234,27 +283,41 @@ export const POST = withAuth(async (req, { db, orgId }) => {
       maxTokensPerRole,
     });
 
-    // Load conversation history from Redis for cold-start recovery
-    if (conversationId) {
-      const stored = await loadConversation(orgId, conversationId);
-      if (stored) {
-        leader.loadHistory(stored);
-      }
-    }
+    // Cold-start recovery: prefer the warm Redis mirror, fall back to the DB
+    // when Redis is empty (TTL expired, server restart, or this is a chat the
+    // user resumed from the sidebar a week later).
+    priorSeq = await hydrateLeader({
+      db,
+      orgId,
+      sessionId,
+      conversationId,
+      leader,
+    });
 
-    leaderCache.set(sessionId, { leader, lastAccess: Date.now() });
+    leaderCache.set(sessionId, { leader, lastAccess: Date.now(), priorSeq });
   }
 
   // Check if client wants SSE streaming
   const acceptHeader = req.headers.get('Accept') ?? '';
   const wantsStream = acceptHeader.includes('text/event-stream');
 
-  console.log(`[Chat] Mode: ${wantsStream ? 'SSE streaming' : 'JSON'}, session=${sessionId}`);
+  console.log(`[Chat] Mode: ${wantsStream ? 'SSE streaming' : 'JSON'}, session=${sessionId}, priorSeq=${priorSeq}`);
   if (wantsStream) {
-    return handleStreaming(leader, message, orgId, sessionId, sourcesNeedingBootstrap, adminDb, agentDataSources, convLog);
+    return handleStreaming(
+      leader,
+      message,
+      orgId,
+      sessionId,
+      sourcesNeedingBootstrap,
+      adminDb,
+      agentDataSources,
+      convLog,
+      db,
+      priorSeq,
+    );
   }
 
-  return handleNonStreaming(leader, message, orgId, sessionId, convLog);
+  return handleNonStreaming(leader, message, orgId, sessionId, convLog, db, priorSeq);
 });
 
 /**
@@ -266,6 +329,8 @@ async function handleNonStreaming(
   orgId: string,
   sessionId: string,
   convLog: ConversationLog,
+  db: Database,
+  priorSeq: number,
 ): Promise<NextResponse> {
   let stopReason = 'unknown';
   try {
@@ -345,8 +410,24 @@ async function handleNonStreaming(
       }
     }
 
-    // Save conversation to Redis
+    // Persist tail to Postgres FIRST so the conversationId we hand back is
+    // already addressable by GET /api/conversations/:id. Block on this — a
+    // failed write returns 500 rather than leaking an unrecoverable session.
     const updatedHistory = leader.getHistory();
+    const newPriorSeq = await persistConversationTail({
+      db,
+      orgId,
+      sessionId,
+      history: updatedHistory,
+      priorSeq,
+    });
+    leaderCache.set(sessionId, {
+      leader,
+      lastAccess: Date.now(),
+      priorSeq: newPriorSeq,
+    });
+
+    // Save conversation to Redis (warm cache)
     await saveConversation(orgId, sessionId, updatedHistory);
 
     const toolSummary = toolCalls.map((t) => `${t.name}:${t.status}`).join(', ');
@@ -492,6 +573,8 @@ function handleStreaming(
   adminDb: ReturnType<typeof getAdminDb>,
   agentDataSources: AgentDataSource[],
   convLog: ConversationLog,
+  db: Database,
+  priorSeq: number,
 ): Response {
   const encoder = new TextEncoder();
   const abort = new AbortController();
@@ -689,6 +772,33 @@ function handleStreaming(
                 break;
               case 'done': {
                 const history = leader.getHistory();
+                // Block the `done` event on the DB write so the client only
+                // hears about the conversation id once a GET round-trip would
+                // succeed. The plan deliberately accepts the latency hit;
+                // resume reliability is more important than turn close speed.
+                try {
+                  const newPriorSeq = await persistConversationTail({
+                    db,
+                    orgId,
+                    sessionId,
+                    history,
+                    priorSeq,
+                  });
+                  priorSeq = newPriorSeq;
+                  leaderCache.set(sessionId, {
+                    leader,
+                    lastAccess: Date.now(),
+                    priorSeq: newPriorSeq,
+                  });
+                } catch (dbErr) {
+                  console.error('[Chat] Failed to persist conversation tail:', dbErr);
+                  enqueue('error', {
+                    error:
+                      'Conversation could not be saved. Your reply rendered, but the next reload may not show it.',
+                  });
+                  streamStopReason = 'error:persist';
+                  break;
+                }
                 await saveConversation(orgId, sessionId, history);
                 enqueue('done', { stopReason: event.stopReason, conversationId: sessionId });
                 streamStopReason = event.stopReason;
@@ -811,4 +921,192 @@ async function saveConversation(orgId: string, conversationId: string, messages:
   } catch {
     // Log at debug level only — don't fail the request
   }
+}
+
+/** Hard cap on a derived conversation title — long titles wrap badly in the sidebar. */
+const TITLE_MAX_LENGTH = 60;
+
+/**
+ * Resolve the canonical conversation id for this turn. Returns the existing
+ * conversation id when one was supplied (and it belongs to this org), or
+ * inserts a new row and returns its UUID. Throws when the supplied id is
+ * not found — the caller surfaces a 500 rather than silently creating a
+ * different conversation.
+ */
+async function resolveConversationId(opts: {
+  db: Database;
+  orgId: string;
+  userId: string;
+  conversationId: string | undefined;
+  dataSourceId: string | null;
+  message: string;
+}): Promise<string> {
+  const { db, orgId, userId, conversationId, dataSourceId, message } = opts;
+
+  if (conversationId) {
+    const [existing] = await db
+      .select({ id: conversations.id })
+      .from(conversations)
+      .where(and(eq(conversations.id, conversationId), eq(conversations.orgId, orgId)))
+      .limit(1);
+    if (!existing) {
+      throw new Error(`Conversation ${conversationId} not found for this org`);
+    }
+    return existing.id;
+  }
+
+  // First turn — derive a title from the user's message and insert.
+  const title = deriveTitle(message);
+  const [created] = await db
+    .insert(conversations)
+    .values({
+      orgId,
+      createdBy: userId,
+      ...(dataSourceId ? { dataSourceId } : {}),
+      title,
+    })
+    .returning({ id: conversations.id });
+
+  if (!created) {
+    throw new Error('Failed to create conversation row');
+  }
+  return created.id;
+}
+
+/** Trim a user message into a sidebar-friendly title. */
+function deriveTitle(message: string): string {
+  const compact = message.replace(/\s+/g, ' ').trim();
+  if (!compact) return 'New conversation';
+  if (compact.length <= TITLE_MAX_LENGTH) return compact;
+  return compact.slice(0, TITLE_MAX_LENGTH).trimEnd() + '…';
+}
+
+/**
+ * Cold-start hydrate path. Tries the warm Redis mirror first; on miss, pulls
+ * the persisted history from `conversation_messages` and warms Redis for the
+ * next turn. Returns the highest sequence number observed so the caller can
+ * track what's already on disk.
+ */
+async function hydrateLeader(opts: {
+  db: Database;
+  orgId: string;
+  sessionId: string;
+  conversationId: string | undefined;
+  leader: LeaderAgent;
+}): Promise<number> {
+  const { db, orgId, sessionId, conversationId, leader } = opts;
+
+  // Brand-new conversation has no prior history to load.
+  if (!conversationId) return 0;
+
+  const cachedMessages = await loadConversation(orgId, sessionId);
+  if (cachedMessages && cachedMessages.length > 0) {
+    leader.loadHistory(cachedMessages);
+    // Look up the watermark separately — Redis has no sequence info.
+    const seq = await readMaxSequence(db, orgId, sessionId);
+    return seq;
+  }
+
+  // Redis miss — fall back to the durable store.
+  const rows = await db
+    .select({
+      role: conversationMessages.role,
+      content: conversationMessages.content,
+      toolCalls: conversationMessages.toolCalls,
+      toolResults: conversationMessages.toolResults,
+      sequence: conversationMessages.sequence,
+    })
+    .from(conversationMessages)
+    .where(
+      and(
+        eq(conversationMessages.conversationId, sessionId),
+        eq(conversationMessages.orgId, orgId),
+      ),
+    )
+    .orderBy(asc(conversationMessages.sequence));
+
+  if (rows.length === 0) return 0;
+
+  const hydrated: Message[] = rows.map((r) =>
+    hydratePersistedMessage({
+      role: r.role as Message['role'],
+      content: r.content,
+      toolCalls: r.toolCalls,
+      toolResults: r.toolResults,
+    }),
+  );
+  leader.loadHistory(hydrated);
+  // Warm Redis with the rehydrated history so the next turn skips the DB hit.
+  await saveConversation(orgId, sessionId, hydrated);
+  return rows[rows.length - 1]!.sequence;
+}
+
+/**
+ * Read the highest persisted sequence for a conversation. Used when Redis
+ * cached the leader's messages but the writer needs to know where to
+ * resume sequence numbering from.
+ */
+async function readMaxSequence(
+  db: Database,
+  orgId: string,
+  conversationId: string,
+): Promise<number> {
+  const [row] = await db
+    .select({ max: sql<number>`COALESCE(MAX(${conversationMessages.sequence}), 0)` })
+    .from(conversationMessages)
+    .where(
+      and(
+        eq(conversationMessages.conversationId, conversationId),
+        eq(conversationMessages.orgId, orgId),
+      ),
+    );
+  return row?.max ?? 0;
+}
+
+/**
+ * Persist the diff between the leader's in-memory history and what's already
+ * on disk. Inserts the tail in a single multi-row INSERT inside a
+ * transaction, bumps `conversations.last_message_at`, and returns the new
+ * `priorSeq` watermark. No-op (returns the existing watermark) when nothing
+ * new arrived — happens occasionally when the leader yields `done` without
+ * appending anything (e.g. cancelled mid-turn).
+ */
+async function persistConversationTail(opts: {
+  db: Database;
+  orgId: string;
+  sessionId: string;
+  history: Message[];
+  priorSeq: number;
+}): Promise<number> {
+  const { db, orgId, sessionId, history, priorSeq } = opts;
+  if (history.length <= priorSeq) return priorSeq;
+
+  const tail = history.slice(priorSeq);
+  const rows = toPersistedMessagesWithNames(tail, priorSeq);
+  if (rows.length === 0) return priorSeq;
+
+  await db.transaction(async (tx) => {
+    await tx.insert(conversationMessages).values(
+      rows.map((r) => ({
+        orgId,
+        conversationId: sessionId,
+        sequence: r.sequence,
+        role: r.role,
+        content: r.content,
+        toolCalls:
+          r.toolCalls && (r.toolCalls as unknown[]).length > 0 ? (r.toolCalls as unknown[]) : null,
+        toolResults:
+          r.toolResults && (r.toolResults as PersistedToolResult[]).length > 0
+            ? (r.toolResults as PersistedToolResult[])
+            : null,
+        viewSpec: r.viewSpec,
+      })),
+    );
+    await tx
+      .update(conversations)
+      .set({ lastMessageAt: new Date() })
+      .where(and(eq(conversations.id, sessionId), eq(conversations.orgId, orgId)));
+  });
+
+  return rows[rows.length - 1]!.sequence;
 }

--- a/apps/web/src/app/api/conversations/[id]/route.ts
+++ b/apps/web/src/app/api/conversations/[id]/route.ts
@@ -1,0 +1,79 @@
+import { conversationMessages, conversations } from '@lightboard/db/schema';
+import { and, asc, eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { withAuth } from '@/lib/auth';
+
+/** Cap on messages returned in the initial payload. */
+const MAX_INITIAL_MESSAGES = 100;
+
+/** Extract the `[id]` segment from `/api/conversations/[id]`. */
+function extractId(req: Request): string | null {
+  const segments = new URL(req.url).pathname.split('/').filter(Boolean);
+  return segments[segments.length - 1] ?? null;
+}
+
+/**
+ * GET /api/conversations/:id
+ *
+ * Returns the conversation header plus the most recent
+ * {@link MAX_INITIAL_MESSAGES} messages ordered by `sequence`. RLS gates
+ * access to the conversation row itself; messages inherit the same gate
+ * via their own `org_id` column.
+ *
+ * The leader's `ConversationManager` further trims to its own
+ * `DEFAULT_MAX_MESSAGES = 50` window once the history is loaded — this
+ * route's cap exists primarily to keep the initial payload small for the
+ * UI thread render.
+ */
+export const GET = withAuth(async (req, { db, orgId }) => {
+  const id = extractId(req);
+  if (!id) {
+    return NextResponse.json({ error: 'ID is required' }, { status: 400 });
+  }
+
+  const [conversation] = await db
+    .select({
+      id: conversations.id,
+      title: conversations.title,
+      dataSourceId: conversations.dataSourceId,
+      createdAt: conversations.createdAt,
+      lastMessageAt: conversations.lastMessageAt,
+    })
+    .from(conversations)
+    .where(and(eq(conversations.id, id), eq(conversations.orgId, orgId)))
+    .limit(1);
+
+  if (!conversation) {
+    return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+  }
+
+  const messages = await db
+    .select({
+      id: conversationMessages.id,
+      sequence: conversationMessages.sequence,
+      role: conversationMessages.role,
+      content: conversationMessages.content,
+      toolCalls: conversationMessages.toolCalls,
+      toolResults: conversationMessages.toolResults,
+      viewSpec: conversationMessages.viewSpec,
+      createdAt: conversationMessages.createdAt,
+    })
+    .from(conversationMessages)
+    .where(
+      and(
+        eq(conversationMessages.conversationId, id),
+        eq(conversationMessages.orgId, orgId),
+      ),
+    )
+    .orderBy(asc(conversationMessages.sequence))
+    .limit(MAX_INITIAL_MESSAGES + 1);
+
+  const hasMore = messages.length > MAX_INITIAL_MESSAGES;
+  const trimmed = hasMore ? messages.slice(0, MAX_INITIAL_MESSAGES) : messages;
+
+  return NextResponse.json({
+    conversation,
+    messages: trimmed,
+    hasMore,
+  });
+});

--- a/apps/web/src/app/api/conversations/route.ts
+++ b/apps/web/src/app/api/conversations/route.ts
@@ -1,0 +1,46 @@
+import { conversations } from '@lightboard/db/schema';
+import { and, desc, eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { withAuth } from '@/lib/auth';
+
+/** Default cap on conversations returned in one page; sidebar consumes <50 entries. */
+const DEFAULT_LIMIT = 50;
+/** Hard ceiling so a malformed query can't pull the whole table. */
+const MAX_LIMIT = 200;
+
+/**
+ * GET /api/conversations?sourceId=<uuid>&limit=50
+ *
+ * Lists conversations for the current org, optionally filtered to a single
+ * data source. RLS handles tenant isolation; the org filter is implicit. The
+ * sidebar always passes `sourceId` when one is selected; the no-source path
+ * returns every accessible conversation for the eventual "All conversations"
+ * navigation surface.
+ */
+export const GET = withAuth(async (req, { db, orgId }) => {
+  const url = new URL(req.url);
+  const sourceId = url.searchParams.get('sourceId');
+  const rawLimit = Number(url.searchParams.get('limit') ?? DEFAULT_LIMIT);
+  const limit = Number.isFinite(rawLimit)
+    ? Math.min(Math.max(Math.trunc(rawLimit), 1), MAX_LIMIT)
+    : DEFAULT_LIMIT;
+
+  const where = sourceId
+    ? and(eq(conversations.orgId, orgId), eq(conversations.dataSourceId, sourceId))
+    : eq(conversations.orgId, orgId);
+
+  const rows = await db
+    .select({
+      id: conversations.id,
+      title: conversations.title,
+      dataSourceId: conversations.dataSourceId,
+      lastMessageAt: conversations.lastMessageAt,
+      createdAt: conversations.createdAt,
+    })
+    .from(conversations)
+    .where(where)
+    .orderBy(desc(conversations.lastMessageAt))
+    .limit(limit);
+
+  return NextResponse.json({ conversations: rows });
+});

--- a/apps/web/src/components/explore/explore-page-client.tsx
+++ b/apps/web/src/components/explore/explore-page-client.tsx
@@ -49,6 +49,36 @@ import { Thread } from './thread';
 import { parseSSE } from '@/lib/sse-parser';
 
 /**
+ * Run `fn` inside a `document.startViewTransition` when the View Transitions
+ * API is available, otherwise just call it. Used to wrap the wholesale
+ * thread-message swaps that happen on conversation load / new chat / initial
+ * `?c=<id>` mount-load — the only state changes that warrant a cross-fade.
+ *
+ * The Explore route names its centered content column `thread-content`
+ * (see thread.tsx) so this transition only fades that subtree, leaving the
+ * sidebar (where the click usually originates) steady underneath.
+ *
+ * Browsers without the API (Firefox <128, older Safari) fall through to a
+ * plain synchronous swap — graceful degradation, not a feature gate.
+ */
+function runWithViewTransition(fn: () => void): void {
+  if (
+    typeof document !== 'undefined' &&
+    'startViewTransition' in document &&
+    typeof (document as Document & { startViewTransition?: unknown })
+      .startViewTransition === 'function'
+  ) {
+    (
+      document as Document & {
+        startViewTransition: (cb: () => void) => unknown;
+      }
+    ).startViewTransition(fn);
+    return;
+  }
+  fn();
+}
+
+/**
  * Client-side Explore page. Centered-thread model: sidebar slot hosts the DB
  * picker + conversations list + new-chat button, the main area is a stacked
  * Thread + Composer. Charts render inline in the thread inside each turn's
@@ -772,17 +802,24 @@ export function ExplorePageClient() {
           messages?: PersistedMessage[];
         };
         if (!body.conversation || !body.messages) return;
-        setConversationId(id);
-        setMessages(persistedToUi(body.messages));
-        setActiveViewIndex(-1);
-        // Snap the picker back to the conversation's source so the next
-        // turn inherits the same connection. If the source has been
-        // deleted (dataSourceId === null) we leave the current selection
-        // alone — the user can pick something else.
         const targetSource = body.conversation.dataSourceId;
-        if (targetSource && targetSource !== selectedSource) {
-          setSelectedSource(targetSource);
-        }
+        // Batch the wholesale swap inside a view transition so the
+        // thread-content fades old → new instead of popping. The sidebar is
+        // outside the named transition root so it stays steady under the
+        // user's pointer. Falls back to a plain sync swap on browsers
+        // without the API.
+        runWithViewTransition(() => {
+          setConversationId(id);
+          setMessages(persistedToUi(body.messages!));
+          setActiveViewIndex(-1);
+          // Snap the picker back to the conversation's source so the next
+          // turn inherits the same connection. If the source has been
+          // deleted (dataSourceId === null) we leave the current selection
+          // alone — the user can pick something else.
+          if (targetSource && targetSource !== selectedSource) {
+            setSelectedSource(targetSource);
+          }
+        });
       } catch (err) {
         console.error(`[Explore] Error loading conversation ${id}:`, err);
       }
@@ -792,9 +829,14 @@ export function ExplorePageClient() {
 
   const handleNewConversation = useCallback(() => {
     handleStop();
-    setMessages([]);
-    setActiveViewIndex(-1);
-    setConversationId(null);
+    // Wrap the wholesale clear in a view transition so the thread fades
+    // out to its empty state instead of blanking — matches the
+    // load-conversation feel from the same entry-point family.
+    runWithViewTransition(() => {
+      setMessages([]);
+      setActiveViewIndex(-1);
+      setConversationId(null);
+    });
   }, [handleStop]);
 
   /**

--- a/apps/web/src/components/explore/explore-page-client.tsx
+++ b/apps/web/src/components/explore/explore-page-client.tsx
@@ -11,8 +11,10 @@ import {
 } from '@lightboard/viz-core';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { persistedToUi, type PersistedMessage } from '@/lib/agent-stream/persisted-to-ui';
 import { queryKeys } from '@/lib/query-keys';
 
 // Register chart panel plugins on module load so legacy ViewSpec paths
@@ -96,6 +98,10 @@ export function ExplorePageClient() {
   const schemaGenerationTriggered = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
   const queryClient = useQueryClient();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  // Guards `?c=<id>` mount-load against double-firing in dev/strict mode.
+  const initialLoadHandled = useRef(false);
 
   /**
    * Load the org's data sources and project them into the `DataSourceOption`
@@ -532,7 +538,9 @@ export function ExplorePageClient() {
           },
           body: JSON.stringify({
             message,
-            sourceId: selectedSource,
+            // Canonical key — the route also accepts `sourceId` as a legacy
+            // alias, but new senders should always supply `dataSourceId`.
+            dataSourceId: selectedSource,
             conversationId,
           }),
           signal: controller.signal,
@@ -742,12 +750,80 @@ export function ExplorePageClient() {
     );
   }, [selectedSource, dataSources, handleSend]);
 
+  /**
+   * Load a previously-persisted conversation into the thread by id. Pulls
+   * the transcript from `/api/conversations/[id]`, hydrates the parts[] via
+   * the persisted-to-ui adapter, and switches the picker to the
+   * conversation's original data source so follow-up turns hit the same
+   * connection. Aborts any in-flight stream first so a half-rendered
+   * assistant turn doesn't leak into the loaded transcript.
+   */
+  const handleLoadConversation = useCallback(
+    async (id: string) => {
+      handleStop();
+      try {
+        const res = await fetch(`/api/conversations/${id}`);
+        if (!res.ok) {
+          console.error(`[Explore] Failed to load conversation ${id}: HTTP ${res.status}`);
+          return;
+        }
+        const body = (await res.json()) as {
+          conversation?: { id: string; dataSourceId: string | null };
+          messages?: PersistedMessage[];
+        };
+        if (!body.conversation || !body.messages) return;
+        setConversationId(id);
+        setMessages(persistedToUi(body.messages));
+        setActiveViewIndex(-1);
+        // Snap the picker back to the conversation's source so the next
+        // turn inherits the same connection. If the source has been
+        // deleted (dataSourceId === null) we leave the current selection
+        // alone — the user can pick something else.
+        const targetSource = body.conversation.dataSourceId;
+        if (targetSource && targetSource !== selectedSource) {
+          setSelectedSource(targetSource);
+        }
+      } catch (err) {
+        console.error(`[Explore] Error loading conversation ${id}:`, err);
+      }
+    },
+    [handleStop, selectedSource],
+  );
+
   const handleNewConversation = useCallback(() => {
     handleStop();
     setMessages([]);
     setActiveViewIndex(-1);
     setConversationId(null);
   }, [handleStop]);
+
+  /**
+   * Sync the active conversation id with the `?c=<id>` URL param so a hard
+   * reload restores the user's place. On mount, load the conversation
+   * pointed to by the URL (one-shot, guarded by `initialLoadHandled`).
+   * Subsequent `conversationId` changes write back to the URL.
+   */
+  useEffect(() => {
+    if (initialLoadHandled.current) return;
+    initialLoadHandled.current = true;
+    const initial = searchParams?.get('c');
+    if (initial) {
+      void handleLoadConversation(initial);
+    }
+  }, [searchParams, handleLoadConversation]);
+
+  useEffect(() => {
+    const current = searchParams?.get('c') ?? null;
+    if (conversationId === current) return;
+    const params = new URLSearchParams(searchParams?.toString() ?? '');
+    if (conversationId) {
+      params.set('c', conversationId);
+    } else {
+      params.delete('c');
+    }
+    const qs = params.toString();
+    router.replace(qs ? `?${qs}` : '?');
+  }, [conversationId, router, searchParams]);
 
   /**
    * Install the Explore sidebar into the shell on mount; clear it on
@@ -763,12 +839,21 @@ export function ExplorePageClient() {
         selectedId={selectedSource}
         onSelectSource={setSelectedSource}
         onNewChat={handleNewConversation}
+        activeConversationId={conversationId}
+        onSelectConversation={handleLoadConversation}
       />,
     );
     return () => {
       setSidebarSlot(null);
     };
-  }, [dataSources, selectedSource, handleNewConversation, setSidebarSlot]);
+  }, [
+    dataSources,
+    selectedSource,
+    handleNewConversation,
+    setSidebarSlot,
+    conversationId,
+    handleLoadConversation,
+  ]);
 
   // Active source metadata for the composer dek. Tables/rows are not yet
   // exposed on the data-source API; pass just the name for now.

--- a/apps/web/src/components/explore/sidebar/__tests__/conversations-list.test.tsx
+++ b/apps/web/src/components/explore/sidebar/__tests__/conversations-list.test.tsx
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+
+import { ConversationsList } from '../conversations-list';
+import { renderWithQuery } from '@/test-utils/render-with-query';
+
+// Stub next-intl with the literal English copy from messages/en.json so the
+// test isn't coupled to the full provider wiring.
+vi.mock('next-intl', () => ({
+  useTranslations: () => {
+    const dict: Record<string, string> = {
+      conversationsHeading: 'Conversations',
+      conversationsToday: 'Today',
+      conversationsYesterday: 'Yesterday',
+      conversationsThisWeek: 'This week',
+      conversationsOlder: 'Older',
+      conversationsEmpty: 'No saved conversations yet.',
+    };
+    return (key: string) => dict[key] ?? key;
+  },
+}));
+
+// Anchor timestamps to the test runner's real "now" so the client-side
+// bucketizer in ConversationsList puts each row in a deterministic bucket
+// regardless of when the test executes. We avoid fake timers here because
+// `waitFor` polls via real setTimeout — see beforeEach for the rationale.
+const NOW = Date.now();
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+const ROWS = [
+  {
+    id: 'c-today',
+    title: 'Today conversation',
+    dataSourceId: 'src-1',
+    lastMessageAt: new Date(NOW).toISOString(),
+    createdAt: new Date(NOW).toISOString(),
+  },
+  {
+    id: 'c-yesterday',
+    title: 'Yesterday conversation',
+    dataSourceId: 'src-1',
+    lastMessageAt: new Date(NOW - ONE_DAY - 60_000).toISOString(),
+    createdAt: new Date(NOW - ONE_DAY - 60_000).toISOString(),
+  },
+];
+
+describe('<ConversationsList>', () => {
+  beforeEach(() => {
+    // Real timers — `waitFor` polls via setTimeout under the hood, so faking
+    // them deadlocks the resolution of the fetch microtask queue.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ conversations: ROWS }),
+      } as Response),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  /** Pull the absolutely-positioned indicator out of the rendered tree. */
+  function getIndicator(container: HTMLElement): HTMLElement | null {
+    return container.querySelector<HTMLElement>('span[aria-hidden]');
+  }
+
+  it('hides the indicator (opacity 0) when there is no active id', async () => {
+    const { container } = renderWithQuery(
+      <ConversationsList sourceId="src-1" activeId={null} />,
+    );
+
+    // Resolve the fetch promise + the useQuery state update.
+    await waitFor(() => {
+      expect(container.querySelector('button[title="Today conversation"]')).toBeTruthy();
+    });
+
+    const indicator = getIndicator(container);
+    expect(indicator).toBeTruthy();
+    expect(indicator!.style.opacity).toBe('0');
+  });
+
+  it('shows the indicator opaque when activeId matches a rendered row', async () => {
+    const { container } = renderWithQuery(
+      <ConversationsList sourceId="src-1" activeId="c-today" />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('button[title="Today conversation"]')).toBeTruthy();
+    });
+
+    const indicator = getIndicator(container);
+    expect(indicator).toBeTruthy();
+    expect(indicator!.style.opacity).toBe('1');
+  });
+
+  it('hides the indicator when activeId is set but no row matches it', async () => {
+    // Simulates the post-source-switch state: the active conversation isn't in
+    // the new list, so the bar should clear rather than freeze on a stale row.
+    const { container } = renderWithQuery(
+      <ConversationsList sourceId="src-1" activeId="not-in-list" />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('button[title="Today conversation"]')).toBeTruthy();
+    });
+
+    const indicator = getIndicator(container);
+    expect(indicator!.style.opacity).toBe('0');
+  });
+
+  it('drops the per-item border (rows render with constant left padding)', async () => {
+    // The sliding bar is the sole visual source of truth for the active row.
+    // Asserts that no row paints its own border-left, which would compete with
+    // the bar at group boundaries.
+    const { container } = renderWithQuery(
+      <ConversationsList sourceId="src-1" activeId="c-today" />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('button[title="Today conversation"]')).toBeTruthy();
+    });
+
+    const activeRow = container.querySelector<HTMLButtonElement>(
+      'button[title="Today conversation"]',
+    );
+    // Constant 10px left padding regardless of active state.
+    expect(activeRow!.style.paddingLeft).toBe('10px');
+    // No competing static border.
+    expect(activeRow!.style.borderLeft).toBe('');
+  });
+
+  it('renders the empty state when the API returns no conversations', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ conversations: [] }),
+      } as Response),
+    );
+
+    const { container, getByText } = renderWithQuery(
+      <ConversationsList sourceId="src-1" activeId={null} />,
+    );
+
+    await waitFor(() => {
+      expect(getByText('No saved conversations yet.')).toBeTruthy();
+    });
+
+    // Indicator is still mounted but hidden in the empty case.
+    const indicator = getIndicator(container);
+    expect(indicator!.style.opacity).toBe('0');
+  });
+});

--- a/apps/web/src/components/explore/sidebar/conversations-list.tsx
+++ b/apps/web/src/components/explore/sidebar/conversations-list.tsx
@@ -1,102 +1,158 @@
 'use client';
 
+import { useQuery } from '@tanstack/react-query';
+import { useTranslations } from 'next-intl';
+import { useMemo } from 'react';
+
 import { Label } from './label';
 
-/**
- * One conversation entry in a group.
- */
-interface ConvoItem {
+/** One conversation row returned by `GET /api/conversations`. */
+interface ConversationRow {
   id: string;
   title: string;
+  dataSourceId: string | null;
+  lastMessageAt: string;
+  createdAt: string;
 }
 
 /**
- * Group of conversations shown under a single time bucket (Today, Yesterday, ...).
+ * Time bucket the sidebar groups by. The buckets stay client-side so the API
+ * doesn't have to know the user's locale or "today" boundary.
  */
-interface ConvoGroup {
-  label: string;
-  items: ConvoItem[];
-}
+type GroupKey = 'today' | 'yesterday' | 'thisWeek' | 'older';
 
-/**
- * MOCK: Replace with real conversations once backend persistence lands
- * (see documentation/backend-ui-polish-followups.md §4). These fixtures
- * match the editorial handoff's example so the sidebar looks correct
- * during visual review before the wire-up ticket is done.
- */
-const MOCK_GROUPS: ConvoGroup[] = [
-  {
-    label: 'Today',
-    items: [
-      { id: 'c1', title: 'Post 2014 IPL True Strike Rate' },
-      { id: 'c2', title: 'RCB Team Analysis' },
-    ],
-  },
-  {
-    label: 'Yesterday',
-    items: [
-      { id: 'c3', title: 'Toss decision · win %' },
-      { id: 'c4', title: 'Death overs economy' },
-    ],
-  },
-  {
-    label: 'This week',
-    items: [
-      { id: 'c5', title: 'Fielder impact model v2' },
-      { id: 'c6', title: 'Venue-adjusted averages' },
-      { id: 'c7', title: 'Powerplay SR trends' },
-    ],
-  },
-];
-
-/**
- * Props for {@link ConversationsList}.
- */
+/** Props for {@link ConversationsList}. */
 interface ConversationsListProps {
+  /**
+   * Currently selected data source id. When non-null, the API filters the
+   * list to that source. When null, the list shows every conversation in
+   * the org (the all-conversations surface — currently never reached
+   * because the picker is required, but kept as a clean fallback).
+   */
+  sourceId: string | null;
   /** Id of the currently-active conversation, if any. */
   activeId?: string | null;
-  /** Called with the id of the selected conversation. No-op by default. */
+  /** Called with the id of a clicked conversation. */
   onSelect?: (id: string) => void;
 }
 
 /**
  * Grouped, time-bucketed conversations rendered in the Explore sidebar.
  *
- * Currently ships with hardcoded editorial fixture data — real conversation
- * titles come from the backend persistence ticket (see backend followups §4).
- * Selection is optional; when no handler is wired, clicks are no-ops.
+ * Replaces the historical hardcoded fixture — the list is now driven by
+ * `useQuery` against `/api/conversations?sourceId=<id>`. Switching the
+ * picker invalidates the query key and refetches automatically. Bucketing
+ * is computed client-side from `lastMessageAt` so the API stays a flat
+ * sorted list.
  */
-export function ConversationsList({ activeId, onSelect }: ConversationsListProps) {
+export function ConversationsList({
+  sourceId,
+  activeId,
+  onSelect,
+}: ConversationsListProps) {
+  const t = useTranslations('explore');
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['conversations', sourceId],
+    queryFn: async (): Promise<ConversationRow[]> => {
+      const params = sourceId ? `?sourceId=${encodeURIComponent(sourceId)}` : '';
+      const res = await fetch(`/api/conversations${params}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as { conversations?: ConversationRow[] };
+      return body.conversations ?? [];
+    },
+    staleTime: 30_000,
+  });
+
+  const groups = useMemo(() => bucketize(data ?? []), [data]);
+  const groupOrder: GroupKey[] = ['today', 'yesterday', 'thisWeek', 'older'];
+  const labelMap: Record<GroupKey, string> = {
+    today: t('conversationsToday'),
+    yesterday: t('conversationsYesterday'),
+    thisWeek: t('conversationsThisWeek'),
+    older: t('conversationsOlder'),
+  };
+
+  const isEmpty = !isLoading && (data?.length ?? 0) === 0;
+
   return (
     <div className="flex flex-col gap-3.5">
-      <Label>Conversations</Label>
-      {MOCK_GROUPS.map((g) => (
-        <div key={g.label}>
-          <div
-            className="lb-mono-tag uppercase"
-            style={{
-              fontSize: 9,
-              letterSpacing: '0.1em',
-              color: 'var(--ink-6)',
-              padding: '0 4px 4px',
-            }}
-          >
-            {g.label}
-          </div>
-          <div className="flex flex-col gap-px">
-            {g.items.map((i) => (
-              <ConvoItemButton
-                key={i.id}
-                item={i}
-                active={i.id === activeId}
-                onSelect={onSelect}
-              />
-            ))}
-          </div>
+      <Label>{t('conversationsHeading')}</Label>
+      {isEmpty && (
+        <div
+          className="px-2.5 text-[12px]"
+          style={{ color: 'var(--ink-5)' }}
+        >
+          {t('conversationsEmpty')}
         </div>
-      ))}
+      )}
+      {groupOrder.map((key) => {
+        const items = groups[key];
+        if (!items || items.length === 0) return null;
+        return (
+          <div key={key}>
+            <div
+              className="lb-mono-tag uppercase"
+              style={{
+                fontSize: 9,
+                letterSpacing: '0.1em',
+                color: 'var(--ink-6)',
+                padding: '0 4px 4px',
+              }}
+            >
+              {labelMap[key]}
+            </div>
+            <div className="flex flex-col gap-px">
+              {items.map((row) => (
+                <ConvoItemButton
+                  key={row.id}
+                  item={row}
+                  active={row.id === activeId}
+                  onSelect={onSelect}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
+}
+
+/**
+ * Bucket conversations into Today / Yesterday / This week / Older using a
+ * locally-computed "now" so the user's clock — not the server's — defines
+ * the boundary. Inputs are assumed to be sorted newest-first by the API; the
+ * bucket order preserves that relative order within each bucket.
+ */
+function bucketize(rows: ConversationRow[]): Record<GroupKey, ConversationRow[]> {
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfYesterday = new Date(startOfToday);
+  startOfYesterday.setDate(startOfToday.getDate() - 1);
+  const startOfWeek = new Date(startOfToday);
+  startOfWeek.setDate(startOfToday.getDate() - 7);
+
+  const out: Record<GroupKey, ConversationRow[]> = {
+    today: [],
+    yesterday: [],
+    thisWeek: [],
+    older: [],
+  };
+
+  for (const row of rows) {
+    const ts = new Date(row.lastMessageAt);
+    if (ts >= startOfToday) {
+      out.today.push(row);
+    } else if (ts >= startOfYesterday) {
+      out.yesterday.push(row);
+    } else if (ts >= startOfWeek) {
+      out.thisWeek.push(row);
+    } else {
+      out.older.push(row);
+    }
+  }
+  return out;
 }
 
 /**
@@ -108,7 +164,7 @@ function ConvoItemButton({
   active,
   onSelect,
 }: {
-  item: ConvoItem;
+  item: ConversationRow;
   active: boolean;
   onSelect?: (id: string) => void;
 }) {

--- a/apps/web/src/components/explore/sidebar/conversations-list.tsx
+++ b/apps/web/src/components/explore/sidebar/conversations-list.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
-import { useMemo } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { Label } from './label';
 
@@ -37,6 +37,15 @@ interface ConversationsListProps {
 }
 
 /**
+ * Geometry for the sliding indicator bar — `top` is the active item's
+ * `offsetTop` relative to the items wrapper, `height` is its `offsetHeight`.
+ */
+interface IndicatorRect {
+  top: number;
+  height: number;
+}
+
+/**
  * Grouped, time-bucketed conversations rendered in the Explore sidebar.
  *
  * Replaces the historical hardcoded fixture — the list is now driven by
@@ -44,6 +53,12 @@ interface ConversationsListProps {
  * picker invalidates the query key and refetches automatically. Bucketing
  * is computed client-side from `lastMessageAt` so the API stays a flat
  * sorted list.
+ *
+ * Active state is rendered as a single sliding 2px warm-accent bar that
+ * glides between rows on `activeId` change (220ms iOS-style spring-out
+ * curve). Individual rows no longer carry a static left border so the bar
+ * is the sole visual source of truth — this keeps the active indicator
+ * consistent across group boundaries (Today / Yesterday / etc.).
  */
 export function ConversationsList({
   sourceId,
@@ -75,6 +90,90 @@ export function ConversationsList({
 
   const isEmpty = !isLoading && (data?.length ?? 0) === 0;
 
+  // ---------- sliding indicator ----------
+  // Wrapper that anchors the absolutely-positioned indicator. The wrapper
+  // contains every group + its items, so a single indicator can glide between
+  // rows even when they live under different group labels.
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  // Refs keyed by conversation id — populated by each row's ref callback.
+  // A Map (not an object) so id deletions don't leave stale keys around.
+  const itemRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+  const [indicator, setIndicator] = useState<IndicatorRect | null>(null);
+  // First-paint snap: the very first time `activeId` resolves to a real row,
+  // we want the bar to appear *at* its position rather than slide in from
+  // translateY(0). After that, every measurement should animate.
+  const hasAnimatedRef = useRef(false);
+  const [snapNoTransition, setSnapNoTransition] = useState(false);
+
+  // Recompute indicator geometry whenever the active id changes or the
+  // underlying list reflows. useLayoutEffect runs before paint so the bar
+  // is positioned correctly on the same frame the new active row mounts —
+  // no flash of unpositioned indicator.
+  useLayoutEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+
+    if (!activeId) {
+      // No active conversation — drop the indicator. Hidden state is keyed
+      // off `indicator === null` in the render branch below.
+      setIndicator(null);
+      hasAnimatedRef.current = false;
+      return;
+    }
+
+    const node = itemRefs.current.get(activeId);
+    if (!node) {
+      // Active row isn't in the current list (e.g. user switched data sources
+      // and the conversation isn't visible under the new filter). Hide rather
+      // than freeze on a stale position.
+      setIndicator(null);
+      hasAnimatedRef.current = false;
+      return;
+    }
+
+    // offsetTop is relative to the nearest positioned ancestor — we make
+    // `wrapper` `relative` below, so this is the right coordinate space.
+    const next: IndicatorRect = {
+      top: node.offsetTop,
+      height: node.offsetHeight,
+    };
+
+    if (!hasAnimatedRef.current) {
+      // First positioned frame for this mount: snap without animating, then
+      // re-enable the transition on the next paint so subsequent activeId
+      // changes glide. Two requestAnimationFrames so the no-transition
+      // style commits to the DOM before we flip the flag back.
+      setSnapNoTransition(true);
+      setIndicator(next);
+      hasAnimatedRef.current = true;
+      const id = requestAnimationFrame(() => {
+        requestAnimationFrame(() => setSnapNoTransition(false));
+      });
+      return () => cancelAnimationFrame(id);
+    }
+
+    setIndicator(next);
+    return undefined;
+    // `data` is included so groups reflowing (new chat lands, source switch
+    // adds/removes rows) re-runs the measurement — the row positions inside
+    // the wrapper change even when activeId itself didn't.
+  }, [activeId, data]);
+
+  // Re-measure on container resize too — covers cases the deps array can't
+  // catch, like layout reflow from a sibling sidebar block changing height.
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper || typeof ResizeObserver === 'undefined') return;
+    const obs = new ResizeObserver(() => {
+      if (!activeId) return;
+      const node = itemRefs.current.get(activeId);
+      if (!node) return;
+      setIndicator({ top: node.offsetTop, height: node.offsetHeight });
+    });
+    obs.observe(wrapper);
+    return () => obs.disconnect();
+  }, [activeId]);
+
   return (
     <div className="flex flex-col gap-3.5">
       <Label>{t('conversationsHeading')}</Label>
@@ -86,35 +185,66 @@ export function ConversationsList({
           {t('conversationsEmpty')}
         </div>
       )}
-      {groupOrder.map((key) => {
-        const items = groups[key];
-        if (!items || items.length === 0) return null;
-        return (
-          <div key={key}>
-            <div
-              className="lb-mono-tag uppercase"
-              style={{
-                fontSize: 9,
-                letterSpacing: '0.1em',
-                color: 'var(--ink-6)',
-                padding: '0 4px 4px',
-              }}
-            >
-              {labelMap[key]}
+      <div ref={wrapperRef} className="relative flex flex-col gap-3.5">
+        {/*
+         * Single sliding indicator. Hidden via opacity 0 when no active
+         * conversation so a fresh chat doesn't show a stale marker. The
+         * `transition` shorthand intentionally omits opacity — fade-out on
+         * activeId clear should be instant, not a slow trail.
+         */}
+        <span
+          aria-hidden
+          className="pointer-events-none absolute left-0 rounded-full"
+          style={{
+            top: 0,
+            width: 2,
+            height: indicator?.height ?? 0,
+            background: 'var(--accent-warm)',
+            opacity: indicator ? 1 : 0,
+            transform: `translateY(${indicator?.top ?? 0}px)`,
+            transition: snapNoTransition
+              ? 'none'
+              : 'transform 220ms cubic-bezier(0.32, 0.72, 0, 1), height 220ms cubic-bezier(0.32, 0.72, 0, 1)',
+            willChange: 'transform',
+          }}
+        />
+        {groupOrder.map((key) => {
+          const items = groups[key];
+          if (!items || items.length === 0) return null;
+          return (
+            <div key={key}>
+              <div
+                className="lb-mono-tag uppercase"
+                style={{
+                  fontSize: 9,
+                  letterSpacing: '0.1em',
+                  color: 'var(--ink-6)',
+                  padding: '0 4px 4px',
+                }}
+              >
+                {labelMap[key]}
+              </div>
+              <div className="flex flex-col gap-px">
+                {items.map((row) => (
+                  <ConvoItemButton
+                    key={row.id}
+                    item={row}
+                    active={row.id === activeId}
+                    onSelect={onSelect}
+                    refCallback={(node) => {
+                      if (node) {
+                        itemRefs.current.set(row.id, node);
+                      } else {
+                        itemRefs.current.delete(row.id);
+                      }
+                    }}
+                  />
+                ))}
+              </div>
             </div>
-            <div className="flex flex-col gap-px">
-              {items.map((row) => (
-                <ConvoItemButton
-                  key={row.id}
-                  item={row}
-                  active={row.id === activeId}
-                  onSelect={onSelect}
-                />
-              ))}
-            </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -156,32 +286,39 @@ function bucketize(rows: ConversationRow[]): Record<GroupKey, ConversationRow[]>
 }
 
 /**
- * Single conversation row. Active state uses a 2px warm-accent left bar and
- * the `--bg-6` fill; passive rows fade between ink-3 (idle) and ink-2 (hover).
+ * Single conversation row. Active state uses the `--bg-6` fill and the
+ * brighter ink ramp; the vertical accent bar is rendered separately by the
+ * parent's sliding indicator so this row never paints its own border (which
+ * would compete with the sliding bar).
  */
 function ConvoItemButton({
   item,
   active,
   onSelect,
+  refCallback,
 }: {
   item: ConversationRow;
   active: boolean;
   onSelect?: (id: string) => void;
+  /** Receives the underlying button node for indicator positioning. */
+  refCallback: (node: HTMLButtonElement | null) => void;
 }) {
   return (
     <button
+      ref={refCallback}
       type="button"
       title={item.title}
       onClick={() => onSelect?.(item.id)}
-      className="block w-full truncate rounded-md px-2.5 py-1.5 text-left text-[12.5px] transition-colors"
+      className="block w-full truncate rounded-md py-1.5 text-left text-[12.5px] transition-colors"
       style={{
+        // Constant 10px left padding so rows don't shift horizontally when
+        // the sliding bar arrives — the bar overlays the gutter rather than
+        // displacing the text.
+        paddingLeft: 10,
+        paddingRight: 10,
         color: active ? 'var(--ink-1)' : 'var(--ink-3)',
         background: active ? 'var(--bg-6)' : 'transparent',
         fontWeight: active ? 500 : 400,
-        borderLeft: active
-          ? '2px solid var(--accent-warm)'
-          : '2px solid transparent',
-        paddingLeft: active ? 8 : 10,
       }}
       onMouseEnter={(e) => {
         if (!active) e.currentTarget.style.color = 'var(--ink-2)';

--- a/apps/web/src/components/explore/sidebar/explore-sidebar.tsx
+++ b/apps/web/src/components/explore/sidebar/explore-sidebar.tsx
@@ -13,13 +13,18 @@ interface ExploreSidebarProps {
   selectedId: string | null;
   onSelectSource: (id: string) => void;
   onNewChat: () => void;
+  /** Currently-active conversation id, if one is loaded. */
+  activeConversationId?: string | null;
+  /** Called with the id of a clicked conversation. */
+  onSelectConversation?: (id: string) => void;
 }
 
 /**
  * Composed sidebar for the Explore route. Stacks:
  *
  * 1. Database picker (source dropdown).
- * 2. Grouped conversations list (mock data until backend persistence lands).
+ * 2. Grouped conversations list — fed by `/api/conversations?sourceId=<id>`,
+ *    bucketed Today / Yesterday / This week / Older client-side.
  * 3. Flex spacer.
  * 4. `New conversation` button pinned to the bottom.
  *
@@ -32,6 +37,8 @@ export function ExploreSidebar({
   selectedId,
   onSelectSource,
   onNewChat,
+  activeConversationId,
+  onSelectConversation,
 }: ExploreSidebarProps) {
   return (
     <div className="flex h-full flex-col gap-4">
@@ -40,7 +47,11 @@ export function ExploreSidebar({
         selectedId={selectedId}
         onChange={onSelectSource}
       />
-      <ConversationsList />
+      <ConversationsList
+        sourceId={selectedId}
+        activeId={activeConversationId}
+        onSelect={onSelectConversation}
+      />
       <div className="flex-1" />
       <NewChatButton onClick={onNewChat} />
     </div>

--- a/apps/web/src/components/explore/thread.tsx
+++ b/apps/web/src/components/explore/thread.tsx
@@ -139,7 +139,17 @@ export function Thread({
     >
       <div
         className="relative mx-auto"
-        style={{ maxWidth: 920, padding: '28px 48px 40px' }}
+        // `viewTransitionName` opts the centered content column into the
+        // scoped `thread-content` view transition declared in globals.css.
+        // The outer scroll container above is intentionally excluded so the
+        // scrollbar position doesn't flicker mid-fade. Keeping the value
+        // alongside the other layout-only inline styles is acceptable per
+        // CLAUDE.md: Tailwind has no utility for `view-transition-name`.
+        style={{
+          maxWidth: 920,
+          padding: '28px 48px 40px',
+          viewTransitionName: 'thread-content',
+        }}
       >
         {hasMessages && (
           <ConversationHeader

--- a/apps/web/src/lib/agent-stream/persisted-to-ui.ts
+++ b/apps/web/src/lib/agent-stream/persisted-to-ui.ts
@@ -1,0 +1,221 @@
+import type { ChatMessageData, MessagePart } from '@/components/explore/chat-message';
+import type { HtmlView } from '@/components/view-renderer';
+
+/**
+ * One persisted message row, as returned by `GET /api/conversations/[id]`.
+ * Mirrors the columns of `conversation_messages` (see
+ * `packages/db/src/schema/conversations.ts`). Field types are the wire shape
+ * after JSON.parse, so jsonb columns surface as plain objects/arrays.
+ */
+export interface PersistedMessage {
+  id: string;
+  sequence: number;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  toolCalls: PersistedToolCall[] | null;
+  toolResults: PersistedToolResultRow[] | null;
+  viewSpec: PersistedViewSpec | null;
+  createdAt?: string;
+}
+
+/** Wire-shape mirror of `ToolCallResult` from the agent package. */
+interface PersistedToolCall {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+/**
+ * Wire-shape mirror of `PersistedToolResult` from
+ * `packages/agent/src/conversation/persisted.ts`. Kept duplicated rather
+ * than imported so the client adapter doesn't pull the agent package's
+ * server-side helpers into the client bundle.
+ */
+interface PersistedToolResultRow {
+  toolCallId: string;
+  toolName?: string;
+  isError?: boolean;
+  content: string;
+  summary?: string;
+  truncated?: boolean;
+}
+
+/**
+ * Denormalized HTML view payload. Source of truth lives in `tool_results` —
+ * this column is a render convenience for the filmstrip + thread.
+ */
+interface PersistedViewSpec {
+  html?: string;
+  title?: string;
+  sql?: string;
+  viewId?: string;
+  description?: string;
+}
+
+/**
+ * Convert persisted message rows into the `ChatMessageData[]` the Explore
+ * thread renders. Every assistant "turn" on disk spans multiple rows
+ * (`assistant + tool calls → user + tool results → assistant + next tool
+ * calls → ...`); this collapses each contiguous run of those rows into a
+ * single `ChatMessageData` with parts in the same temporal order the live
+ * SSE reducer would have produced.
+ *
+ * Behavior contract:
+ *   1. Each `role === 'user'` row with non-empty `content` and no
+ *      `toolResults` becomes its own `{ role: 'user' }` message.
+ *   2. Assistant text → `{ kind: 'text' }`. Empty assistant text rows still
+ *      contribute their tool calls to the in-progress turn.
+ *   3. `toolCalls[]` → `{ kind: 'tool_call' }` parts in order, paired with
+ *      the matching `toolResultsById` entry from the immediately-following
+ *      `user` row when one exists.
+ *   4. When a row carries a non-null `viewSpec`, an additional
+ *      `{ kind: 'view' }` part is appended after that row's tool calls so
+ *      the HTML chart renders in the same position the live stream would
+ *      have placed it.
+ *
+ * The adapter intentionally does not synthesize narration / suggestions —
+ * those were transient in the live stream and not persisted.
+ */
+export function persistedToUi(rows: PersistedMessage[]): ChatMessageData[] {
+  const out: ChatMessageData[] = [];
+  let i = 0;
+
+  while (i < rows.length) {
+    const row = rows[i]!;
+
+    // User message that originated from the human (no tool results attached).
+    const isHumanUserMessage =
+      row.role === 'user' &&
+      (!row.toolResults || row.toolResults.length === 0) &&
+      row.content.length > 0;
+
+    if (isHumanUserMessage) {
+      out.push({
+        id: row.id,
+        role: 'user',
+        parts: [{ kind: 'text', text: row.content }],
+      });
+      i += 1;
+      continue;
+    }
+
+    if (row.role === 'assistant') {
+      // Walk forward collecting consecutive assistant + tool-result rows
+      // into a single rendered turn. The pattern on disk is:
+      //   [assistant, user(toolResults), assistant, user(toolResults), ...]
+      // ending when the next assistant row carries no toolCalls or we hit
+      // a different role.
+      const turnRows: PersistedMessage[] = [];
+      let j = i;
+      while (j < rows.length) {
+        const r = rows[j]!;
+        if (r.role === 'assistant') {
+          turnRows.push(r);
+          j += 1;
+          // Consume the matching toolResults row, if any.
+          const next = rows[j];
+          if (
+            next &&
+            next.role === 'user' &&
+            next.toolResults &&
+            next.toolResults.length > 0
+          ) {
+            turnRows.push(next);
+            j += 1;
+            continue;
+          }
+          break;
+        }
+        break;
+      }
+
+      const parts = buildAssistantParts(turnRows);
+      out.push({ id: row.id, role: 'assistant', parts });
+      i = j;
+      continue;
+    }
+
+    // System rows (truncation markers etc.) are not rendered in the thread.
+    i += 1;
+  }
+
+  return out;
+}
+
+/**
+ * Stitch a contiguous assistant-turn run of persisted rows into the ordered
+ * `parts[]` shape the thread expects. Tool calls on row N are paired with
+ * tool results on row N+1 (when present). HTML view specs are appended
+ * after the tool call that produced them.
+ */
+function buildAssistantParts(turnRows: PersistedMessage[]): MessagePart[] {
+  const parts: MessagePart[] = [];
+
+  for (let k = 0; k < turnRows.length; k += 1) {
+    const r = turnRows[k]!;
+    if (r.role !== 'assistant') continue;
+
+    if (r.content.length > 0) {
+      parts.push({ kind: 'text', text: r.content });
+    }
+
+    if (!r.toolCalls || r.toolCalls.length === 0) continue;
+
+    // The toolResults arrive on the next row (a user message). Build a
+    // lookup so we can pair without scanning each iteration.
+    const next = turnRows[k + 1];
+    const resultsByCallId = new Map<string, PersistedToolResultRow>();
+    if (
+      next &&
+      next.role === 'user' &&
+      next.toolResults &&
+      next.toolResults.length > 0
+    ) {
+      for (const tr of next.toolResults) {
+        resultsByCallId.set(tr.toolCallId, tr);
+      }
+    }
+
+    for (const tc of r.toolCalls) {
+      const result = resultsByCallId.get(tc.id);
+      const status: 'done' | 'error' = result?.isError ? 'error' : 'done';
+      const part: Extract<MessagePart, { kind: 'tool_call' }> = {
+        kind: 'tool_call',
+        name: tc.name,
+        status,
+        input: tc.input,
+        // `toolKind` and `label` are populated by the SSE reducer from the
+        // live `tool_start` payload. The renderer falls back to its
+        // built-in `kindFor`/derived label when these are absent — fine
+        // for resumed turns since the only consumer is the trace UI.
+        ...(result?.summary ? { resultSummary: result.summary } : {}),
+        ...(result?.content !== undefined ? { result: result.content } : {}),
+      };
+      parts.push(part);
+    }
+
+    // Hoist any HTML view from the row's denormalized viewSpec column.
+    // Rendering a `{ kind: 'view' }` part lets the same Thread/Filmstrip
+    // code that handles live streams pick this up — no resume-specific
+    // branching required.
+    const viewSource = next?.viewSpec?.html
+      ? next.viewSpec
+      : r.viewSpec?.html
+      ? r.viewSpec
+      : null;
+    if (viewSource && viewSource.html) {
+      const view: HtmlView = {
+        html: viewSource.html,
+        // `sql` is required by HtmlView; persisted writers always supply it
+        // for create_view results, but old rows may have dropped it on the
+        // floor. Empty string keeps the type contract.
+        sql: viewSource.sql ?? '',
+        ...(viewSource.title ? { title: viewSource.title } : {}),
+        ...(viewSource.description ? { description: viewSource.description } : {}),
+      };
+      parts.push({ kind: 'view', view, data: null });
+    }
+  }
+
+  return parts;
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -250,6 +250,24 @@
   animation: fade-in 200ms ease-out;
 }
 
+/*
+ * Scoped thread-content fade for Explore conversation switching. Same
+ * timings as the root fade above so the two surfaces feel unified, but
+ * scoped to the centered thread column so the sidebar (where the click
+ * originated) stays steady underneath.
+ *
+ * Triggered manually via document.startViewTransition() in
+ * `explore-page-client.tsx` — the URL only updates `?c=<id>` via
+ * router.replace(), so the framework's automatic fade doesn't fire.
+ */
+::view-transition-old(thread-content) {
+  animation: fade-out 150ms ease-in;
+}
+
+::view-transition-new(thread-content) {
+  animation: fade-in 200ms ease-out;
+}
+
 @keyframes fade-out {
   from {
     opacity: 1;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -261,11 +261,11 @@
  * router.replace(), so the framework's automatic fade doesn't fire.
  */
 ::view-transition-old(thread-content) {
-  animation: fade-out 150ms ease-in;
+  animation: fade-out 150ms ease-in both;
 }
 
 ::view-transition-new(thread-content) {
-  animation: fade-in 200ms ease-out;
+  animation: fade-in 200ms ease-out 150ms both;
 }
 
 @keyframes fade-out {

--- a/packages/agent/src/conversation/index.ts
+++ b/packages/agent/src/conversation/index.ts
@@ -1,1 +1,9 @@
 export { ConversationManager } from './manager';
+export {
+  hydratePersistedMessage,
+  summarizeToolResult,
+  toPersistedMessages,
+  toPersistedMessagesWithNames,
+  type PersistedRow,
+  type PersistedToolResult,
+} from './persisted';

--- a/packages/agent/src/conversation/persisted.test.ts
+++ b/packages/agent/src/conversation/persisted.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  hydratePersistedMessage,
+  summarizeToolResult,
+  toPersistedMessagesWithNames,
+} from './persisted';
+
+describe('summarizeToolResult', () => {
+  describe('run_sql / execute_query', () => {
+    it('keeps small rowsets intact and reports row count in summary', () => {
+      const raw = JSON.stringify({
+        columns: ['a', 'b'],
+        rowCount: 3,
+        rows: [
+          { a: 1, b: 2 },
+          { a: 3, b: 4 },
+          { a: 5, b: 6 },
+        ],
+      });
+      const out = summarizeToolResult('run_sql', raw);
+      const content = JSON.parse(out.content) as { rows: unknown[] };
+      expect(content.rows).toHaveLength(3);
+      expect(out.truncated).toBeUndefined();
+      expect(out.summary).toBe('→ 3 rows');
+    });
+
+    it('caps oversized rowsets at 20 rows and flags truncated', () => {
+      const rows = Array.from({ length: 250 }, (_, i) => ({ id: i, val: `row_${i}` }));
+      const raw = JSON.stringify({ columns: ['id', 'val'], rowCount: 250, rows });
+      const out = summarizeToolResult('run_sql', raw);
+      const content = JSON.parse(out.content) as {
+        rows: unknown[];
+        truncatedRowCount?: number;
+      };
+      expect(content.rows).toHaveLength(20);
+      expect(content.truncatedRowCount).toBe(250);
+      expect(out.truncated).toBe(true);
+      expect(out.summary).toBe('→ 250 rows');
+    });
+
+    it('treats execute_query the same as run_sql', () => {
+      const rows = Array.from({ length: 30 }, (_, i) => ({ id: i }));
+      const raw = JSON.stringify({ rowCount: 30, rows });
+      const out = summarizeToolResult('execute_query', raw);
+      const content = JSON.parse(out.content) as { rows: unknown[] };
+      expect(content.rows).toHaveLength(20);
+      expect(out.truncated).toBe(true);
+    });
+  });
+
+  describe('create_view / modify_view', () => {
+    it('preserves the full HTML payload — never truncates a view', () => {
+      const html = '<html>'.padEnd(50_000, 'x');
+      const raw = JSON.stringify({
+        viewSpec: { html, title: 'Test view', sql: 'SELECT 1' },
+      });
+      const out = summarizeToolResult('create_view', raw);
+      expect(out.content).toBe(raw);
+      expect(out.truncated).toBeUndefined();
+      expect(out.summary).toBe('→ view created');
+    });
+
+    it('keeps modify_view payloads intact', () => {
+      const raw = JSON.stringify({ viewSpec: { html: '<svg/>', title: 'V2' } });
+      const out = summarizeToolResult('modify_view', raw);
+      expect(out.content).toBe(raw);
+      expect(out.summary).toBe('→ view updated');
+    });
+  });
+
+  describe('delegate_* / await_tasks', () => {
+    it('drops data.rows from a delegate_query result', () => {
+      const raw = JSON.stringify({
+        success: true,
+        role: 'query',
+        summary: 'returned 412 rows',
+        scratchpad_table: 'query_1',
+        data: {
+          columns: ['a'],
+          rows: Array.from({ length: 412 }, (_, i) => ({ a: i })),
+        },
+      });
+      const out = summarizeToolResult('delegate_query', raw);
+      const parsed = JSON.parse(out.content) as {
+        data?: { rows?: unknown };
+        success?: boolean;
+        role?: string;
+        scratchpad_table?: string;
+        summary?: string;
+      };
+      expect(parsed.success).toBe(true);
+      expect(parsed.role).toBe('query');
+      expect(parsed.summary).toBe('returned 412 rows');
+      expect(parsed.scratchpad_table).toBe('query_1');
+      expect(parsed.data?.rows).toBeUndefined();
+    });
+
+    it('keeps viewSpec inside a delegate_view result', () => {
+      const raw = JSON.stringify({
+        success: true,
+        role: 'view',
+        summary: 'rendered chart',
+        viewSpec: { html: '<svg/>', title: 'Chart' },
+      });
+      const out = summarizeToolResult('delegate_view', raw);
+      const parsed = JSON.parse(out.content) as {
+        viewSpec?: { html?: string };
+      };
+      expect(parsed.viewSpec?.html).toBe('<svg/>');
+    });
+
+    it('strips data.rows from each entry of an await_tasks map', () => {
+      const raw = JSON.stringify({
+        task_query_1: {
+          success: true,
+          role: 'query',
+          summary: '120 rows',
+          data: { rows: [{ a: 1 }, { a: 2 }, { a: 3 }] },
+          data_summary: { rowCount: 120 },
+        },
+        task_view_1: {
+          success: true,
+          role: 'view',
+          summary: 'view ok',
+          viewSpec: { html: '<svg/>', title: 'V' },
+        },
+      });
+      const out = summarizeToolResult('await_tasks', raw);
+      const parsed = JSON.parse(out.content) as Record<string, {
+        data?: { rows?: unknown };
+        data_summary?: { rowCount?: number };
+        viewSpec?: { html?: string };
+      }>;
+      expect(parsed.task_query_1!.data?.rows).toBeUndefined();
+      expect(parsed.task_query_1!.data_summary?.rowCount).toBe(120);
+      expect(parsed.task_view_1!.viewSpec?.html).toBe('<svg/>');
+    });
+  });
+
+  describe('analyze_table', () => {
+    it('keeps columns / rowCount / findings / first 5 sample rows', () => {
+      const raw = JSON.stringify({
+        columns: ['a', 'b'],
+        rowCount: 999,
+        findings: ['outlier in column a'],
+        sampleRows: Array.from({ length: 50 }, (_, i) => ({ a: i, b: i * 2 })),
+      });
+      const out = summarizeToolResult('analyze_table', raw);
+      const parsed = JSON.parse(out.content) as {
+        columns?: string[];
+        rowCount?: number;
+        findings?: string[];
+        sampleRows?: unknown[];
+      };
+      expect(parsed.columns).toEqual(['a', 'b']);
+      expect(parsed.rowCount).toBe(999);
+      expect(parsed.findings).toEqual(['outlier in column a']);
+      expect(parsed.sampleRows).toHaveLength(5);
+    });
+  });
+
+  describe('load_scratchpad', () => {
+    it('replaces content with a scratchpad_not_restored stub', () => {
+      const raw = JSON.stringify({
+        id: 'query_3',
+        rows: [{ a: 1 }, { a: 2 }, { a: 3 }],
+        rowCount: 3,
+      });
+      const out = summarizeToolResult('load_scratchpad', raw);
+      const parsed = JSON.parse(out.content) as {
+        note: string;
+        requestedId?: string;
+      };
+      expect(parsed.note).toBe('scratchpad_not_restored');
+      expect(parsed.requestedId).toBe('query_3');
+    });
+
+    it('still emits a stub even when the original output had no id', () => {
+      const out = summarizeToolResult('load_scratchpad', '"raw text without an id"');
+      const parsed = JSON.parse(out.content) as { note: string };
+      expect(parsed.note).toBe('scratchpad_not_restored');
+    });
+  });
+
+  describe('get_schema / describe_table / propose_schema_doc', () => {
+    it('keeps schema payloads intact when small', () => {
+      const raw = JSON.stringify({ tables: [{ name: 'users', columns: [] }] });
+      const out = summarizeToolResult('get_schema', raw);
+      expect(out.content).toBe(raw);
+      expect(out.truncated).toBeUndefined();
+    });
+  });
+
+  describe('fallback', () => {
+    it('truncates oversize fallback content at 16 KB and flags it', () => {
+      const big = 'x'.repeat(20_000);
+      const out = summarizeToolResult('some_unknown_tool', big);
+      expect(out.truncated).toBe(true);
+      expect(out.content.endsWith('...[truncated]')).toBe(true);
+      // Body itself should be exactly 16 KB before the suffix.
+      expect(out.content.length).toBe(16_384 + '...[truncated]'.length);
+    });
+
+    it('leaves small fallback content alone', () => {
+      const small = 'short result';
+      const out = summarizeToolResult('some_unknown_tool', small);
+      expect(out.content).toBe(small);
+      expect(out.truncated).toBeUndefined();
+    });
+  });
+
+  describe('errors', () => {
+    it('marks isError and keeps the raw error string under the cap', () => {
+      const out = summarizeToolResult('run_sql', 'syntax error at "SELET"', true);
+      expect(out.isError).toBe(true);
+      expect(out.content).toBe('syntax error at "SELET"');
+      expect(out.summary).toBe('→ error');
+    });
+  });
+});
+
+describe('toPersistedMessagesWithNames', () => {
+  it('numbers rows starting at priorSeq + 1 and resolves tool names from prior toolCalls', () => {
+    const msgs = [
+      { role: 'user' as const, content: 'top batters?' },
+      {
+        role: 'assistant' as const,
+        content: '',
+        toolCalls: [{ id: 'tc1', name: 'run_sql', input: { sql: 'SELECT 1' } }],
+      },
+      {
+        role: 'user' as const,
+        content: '',
+        toolResults: [
+          {
+            toolCallId: 'tc1',
+            content: JSON.stringify({
+              rowCount: 3,
+              rows: [{ a: 1 }, { a: 2 }, { a: 3 }],
+            }),
+          },
+        ],
+      },
+    ];
+
+    const rows = toPersistedMessagesWithNames(msgs, 5);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.sequence)).toEqual([6, 7, 8]);
+    // The third row's tool result was looked up against tc1 from row 2 and
+    // routed through the run_sql rule (which keeps the rows intact under cap).
+    expect(rows[2]!.toolResults![0]!.toolName).toBe('run_sql');
+    expect(rows[2]!.toolResults![0]!.summary).toBe('→ 3 rows');
+  });
+
+  it('hoists the HTML payload from create_view onto the row viewSpec column', () => {
+    const html = '<svg>...</svg>';
+    const msgs = [
+      {
+        role: 'assistant' as const,
+        content: '',
+        toolCalls: [{ id: 'tc-view', name: 'create_view', input: { title: 'X' } }],
+      },
+      {
+        role: 'user' as const,
+        content: '',
+        toolResults: [
+          {
+            toolCallId: 'tc-view',
+            content: JSON.stringify({
+              viewSpec: { html, title: 'X', sql: 'SELECT 1' },
+            }),
+          },
+        ],
+      },
+    ];
+
+    const rows = toPersistedMessagesWithNames(msgs, 0);
+    expect(rows[1]!.viewSpec).toMatchObject({ html, title: 'X', sql: 'SELECT 1' });
+  });
+});
+
+describe('hydratePersistedMessage', () => {
+  it('round-trips role + content + toolCalls + toolResults', () => {
+    const msg = hydratePersistedMessage({
+      role: 'user',
+      content: '',
+      toolCalls: null,
+      toolResults: [
+        {
+          toolCallId: 'tc1',
+          toolName: 'run_sql',
+          content: '{"rowCount":3}',
+          isError: false,
+        },
+      ],
+    });
+    expect(msg.toolResults).toEqual([
+      { toolCallId: 'tc1', content: '{"rowCount":3}' },
+    ]);
+    expect(msg.toolCalls).toBeUndefined();
+  });
+});

--- a/packages/agent/src/conversation/persisted.ts
+++ b/packages/agent/src/conversation/persisted.ts
@@ -1,0 +1,431 @@
+import { formatEnd } from '../events/tool-event-formatter';
+import type { Message } from '../provider/types';
+
+/** Cap on raw tool output size for tools without an explicit rule. */
+const FALLBACK_MAX_BYTES = 16_384;
+/** Row cap for query-shaped tool results kept on resume. */
+const QUERY_ROW_CAP = 20;
+/** Sample row cap for table-analysis-shaped results. */
+const ANALYZE_SAMPLE_CAP = 5;
+
+/**
+ * A persisted tool result — the shape we store on
+ * `conversation_messages.tool_results` rows.
+ *
+ * Distinct from the live-agent `ToolResult` (`packages/agent/src/provider/types.ts`)
+ * in two ways:
+ *
+ * 1. `content` is not guaranteed to be the full tool output. For big payloads
+ *    (rowsets, scratchpad loads) it is a shrunk replay payload — enough for
+ *    the LLM to understand what happened on resume, without dragging the full
+ *    multi-megabyte history into the next context window.
+ * 2. Carries a `summary` string derived from
+ *    {@link formatEnd} so the UI can render the terminal `→ 412 rows`-style
+ *    suffix without re-parsing the JSON payload.
+ */
+export interface PersistedToolResult {
+  /** Matches the live {@link Message.toolResults} `toolCallId`. */
+  toolCallId: string;
+  /** Tool name — needed when summarizing on resume so we know which rule to apply. */
+  toolName: string;
+  /** Propagates error state into the message row. */
+  isError?: boolean;
+  /** Replay payload — JSON-stringified. May be a truncated view of the original. */
+  content: string;
+  /** Human-readable tail like `→ 412 rows`, mirroring the SSE `resultSummary`. */
+  summary?: string;
+  /** Set when {@link content} had data dropped. */
+  truncated?: boolean;
+}
+
+/**
+ * One append-ready row for {@link conversationMessages}. `conversationId`,
+ * `orgId`, `id`, and `createdAt` are supplied by the writer — this shape
+ * carries only the per-turn fields we derive from the in-memory leader state.
+ */
+export interface PersistedRow {
+  sequence: number;
+  role: Message['role'];
+  content: string;
+  toolCalls: Message['toolCalls'] | null;
+  toolResults: PersistedToolResult[] | null;
+  viewSpec: Record<string, unknown> | null;
+}
+
+/**
+ * Shrink a tool-result content string per the per-tool rules documented in
+ * the conversation persistence plan. Big rowsets collapse to 20 rows, HTML
+ * views are kept intact, scratchpad loads are replaced with a stub, and
+ * everything else falls through to a 16 KB cap to prevent runaway storage.
+ *
+ * The returned {@link PersistedToolResult.summary} is derived from
+ * {@link formatEnd} so replays match the live UI's `→ N rows`-style tails.
+ */
+export function summarizeToolResult(
+  name: string,
+  rawContent: string,
+  isError?: boolean,
+): PersistedToolResult {
+  const { resultSummary } = formatEnd(name, rawContent, !!isError, 0);
+  const base: Pick<PersistedToolResult, 'toolCallId' | 'toolName' | 'isError' | 'summary'> = {
+    toolCallId: '', // filled in by caller
+    toolName: name,
+    ...(isError ? { isError: true } : {}),
+    ...(resultSummary ? { summary: resultSummary } : {}),
+  };
+
+  // Errors are usually short and diagnostic — keep as-is up to the fallback cap.
+  if (isError) {
+    return withFallbackCap(base, rawContent);
+  }
+
+  // Rowset tools — collapse rows to QUERY_ROW_CAP.
+  if (name === 'run_sql' || name === 'execute_query') {
+    const shrunk = shrinkRowset(rawContent, QUERY_ROW_CAP);
+    if (shrunk) {
+      return {
+        ...base,
+        content: shrunk.content,
+        ...(shrunk.truncated ? { truncated: true } : {}),
+      };
+    }
+    return withFallbackCap(base, rawContent);
+  }
+
+  // View tools — keep intact, callers hoist the HTML into `viewSpec`.
+  if (name === 'create_view' || name === 'modify_view') {
+    return { ...base, content: rawContent };
+  }
+
+  // Delegate / await — strip bulky data payloads, keep control-plane summary.
+  if (
+    name === 'delegate_query' ||
+    name === 'delegate_view' ||
+    name === 'delegate_analyst' ||
+    name === 'delegate_insights' ||
+    name === 'await_tasks'
+  ) {
+    return { ...base, content: stripDelegatePayload(rawContent) };
+  }
+
+  // analyze_data / analyze_table style — keep schema + findings, trim samples.
+  if (name === 'analyze_data' || name === 'analyze_table') {
+    return { ...base, content: shrinkAnalysis(rawContent) };
+  }
+
+  // Scratchpad load on a resumed session can't return real data — stub it
+  // so the LLM doesn't think the row count/samples are still live.
+  if (name === 'load_scratchpad') {
+    const requestedId = extractScratchpadId(rawContent);
+    const stub = {
+      note: 'scratchpad_not_restored',
+      ...(requestedId ? { requestedId } : {}),
+    };
+    return { ...base, content: JSON.stringify(stub) };
+  }
+
+  // Schema-shaped tools — small and fully useful on resume.
+  if (
+    name === 'get_schema' ||
+    name === 'describe_table' ||
+    name === 'check_query_hints' ||
+    name === 'propose_schema_doc' ||
+    name === 'narrate_summary'
+  ) {
+    return withFallbackCap(base, rawContent);
+  }
+
+  // Unknown tool — fall through to the generic byte cap.
+  return withFallbackCap(base, rawContent);
+}
+
+/**
+ * Convert an in-memory leader history slice into rows ready to insert into
+ * `conversation_messages`. `priorSeq` is the highest existing sequence for
+ * the conversation (0 on first turn) — new rows start at `priorSeq + 1` and
+ * climb from there.
+ *
+ * Each tool result is routed through {@link summarizeToolResult} so we never
+ * persist multi-megabyte rowsets. When an assistant message calls
+ * `create_view` or `modify_view`, the row that carries its tool results also
+ * surfaces the rendered HTML in `viewSpec` for cheap filmstrip rendering.
+ */
+export function toPersistedMessages(msgs: Message[], priorSeq: number): PersistedRow[] {
+  return msgs.map((m, i) => {
+    const toolResults = m.toolResults
+      ? m.toolResults.map((tr) => {
+          // The live `ToolResult` only carries `toolCallId`, `content`, and
+          // `isError` — we don't have the original tool name at this layer.
+          // Fall back to a generic label; tools we care about (create_view,
+          // run_sql, ...) are recognized by the caller via `viewSpec` hoist
+          // and by the replay path that re-infers from the paired toolCalls.
+          const persisted = summarizeToolResult('unknown', tr.content, tr.isError);
+          return { ...persisted, toolCallId: tr.toolCallId };
+        })
+      : null;
+
+    return {
+      sequence: priorSeq + i + 1,
+      role: m.role,
+      content: m.content,
+      toolCalls: m.toolCalls ?? null,
+      toolResults,
+      viewSpec: null,
+    };
+  });
+}
+
+/**
+ * Like {@link toPersistedMessages}, but uses the preceding assistant
+ * message's `toolCalls` array to recover the tool name for each result so
+ * per-tool summarization rules fire correctly. Also hoists the HTML payload
+ * from `create_view` / `modify_view` outputs onto the row's `viewSpec`.
+ *
+ * This is the writer the SSE route uses — the plain `toPersistedMessages`
+ * exists for callers that only have the raw history without adjacent tool
+ * metadata (tests, utilities).
+ */
+export function toPersistedMessagesWithNames(
+  msgs: Message[],
+  priorSeq: number,
+): PersistedRow[] {
+  const toolNamesById = new Map<string, string>();
+
+  // Pre-scan: every `toolCalls` entry gives us an `id → name` mapping so the
+  // matching `toolResults` (one message later) can look up its source tool.
+  for (const m of msgs) {
+    if (m.toolCalls) {
+      for (const tc of m.toolCalls) {
+        toolNamesById.set(tc.id, tc.name);
+      }
+    }
+  }
+
+  return msgs.map((m, i) => {
+    let viewSpec: Record<string, unknown> | null = null;
+    const toolResults = m.toolResults
+      ? m.toolResults.map((tr) => {
+          const toolName = toolNamesById.get(tr.toolCallId) ?? 'unknown';
+          const persisted = summarizeToolResult(toolName, tr.content, tr.isError);
+          if (
+            !tr.isError &&
+            (toolName === 'create_view' || toolName === 'modify_view')
+          ) {
+            const hoisted = hoistViewSpec(tr.content);
+            if (hoisted) viewSpec = hoisted;
+          }
+          return { ...persisted, toolCallId: tr.toolCallId };
+        })
+      : null;
+
+    return {
+      sequence: priorSeq + i + 1,
+      role: m.role,
+      content: m.content,
+      toolCalls: m.toolCalls ?? null,
+      toolResults,
+      viewSpec,
+    };
+  });
+}
+
+/**
+ * Cheap rehydration — a persisted row back into the live
+ * `Message` shape the leader's {@link ConversationManager} expects. The
+ * resulting `toolResults` are the summarized `content` strings, not the
+ * original rowsets; follow-ups that need fresh data should re-run the query.
+ */
+export function hydratePersistedMessage(row: {
+  role: Message['role'];
+  content: string;
+  toolCalls: unknown;
+  toolResults: unknown;
+}): Message {
+  const msg: Message = {
+    role: row.role,
+    content: row.content,
+  };
+  if (Array.isArray(row.toolCalls) && row.toolCalls.length > 0) {
+    msg.toolCalls = row.toolCalls as Message['toolCalls'];
+  }
+  if (Array.isArray(row.toolResults) && row.toolResults.length > 0) {
+    msg.toolResults = (row.toolResults as PersistedToolResult[]).map((r) => ({
+      toolCallId: r.toolCallId,
+      content: r.content,
+      ...(r.isError ? { isError: true } : {}),
+    }));
+  }
+  return msg;
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/** Apply the generic 16 KB cap + attach `truncated` when a trim happens. */
+function withFallbackCap(
+  base: Omit<PersistedToolResult, 'content' | 'truncated'>,
+  raw: string,
+): PersistedToolResult {
+  if (raw.length <= FALLBACK_MAX_BYTES) {
+    return { ...base, content: raw };
+  }
+  return {
+    ...base,
+    content: raw.slice(0, FALLBACK_MAX_BYTES) + '...[truncated]',
+    truncated: true,
+  };
+}
+
+/**
+ * Parse a rowset payload (`{columns, rows, rowCount}`) and keep the first
+ * `cap` rows. Returns null if the payload doesn't look like a rowset — the
+ * caller should fall through to the generic byte cap.
+ */
+function shrinkRowset(
+  raw: string,
+  cap: number,
+): { content: string; truncated: boolean } | null {
+  const parsed = safeParseObject(raw);
+  if (!parsed) return null;
+  const rows = Array.isArray(parsed.rows) ? parsed.rows : null;
+  if (!rows) return null;
+  const keptRows = rows.slice(0, cap);
+  const truncated = rows.length > cap;
+  const out: Record<string, unknown> = {
+    ...parsed,
+    rows: keptRows,
+  };
+  if (truncated) out.truncatedRowCount = rows.length;
+  return { content: JSON.stringify(out), truncated };
+}
+
+/**
+ * Strip the bulky `data.rows` payload from a delegate/await result while
+ * keeping `success`, `role`, `summary`, and `viewSpec` — everything a resumed
+ * leader needs to understand what each sub-agent actually produced.
+ */
+function stripDelegatePayload(raw: string): string {
+  const parsed = safeParseObject(raw);
+  if (!parsed) return truncateBytes(raw);
+
+  // await_tasks returns a map of taskId → entry — strip each entry individually.
+  // We detect this shape by the absence of a top-level `success` / `role` and
+  // the presence of at least one value that itself looks like a delegate result.
+  const looksLikeAwaitMap = !(
+    'success' in parsed || 'role' in parsed || 'summary' in parsed
+  ) && Object.values(parsed).some((v) => isDelegateEntry(v));
+
+  if (looksLikeAwaitMap) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      out[k] = isDelegateEntry(v) ? stripSingleDelegateEntry(v as Record<string, unknown>) : v;
+    }
+    return JSON.stringify(out);
+  }
+
+  return JSON.stringify(stripSingleDelegateEntry(parsed));
+}
+
+/** True when a value has the shape of a single delegate result entry. */
+function isDelegateEntry(v: unknown): v is Record<string, unknown> {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return false;
+  const obj = v as Record<string, unknown>;
+  return 'success' in obj || 'role' in obj || 'summary' in obj || 'viewSpec' in obj || 'data' in obj;
+}
+
+/** Build a shrunken copy of a single delegate entry. */
+function stripSingleDelegateEntry(entry: Record<string, unknown>): Record<string, unknown> {
+  const keep: Record<string, unknown> = {};
+  if ('success' in entry) keep.success = entry.success;
+  if ('role' in entry) keep.role = entry.role;
+  if ('summary' in entry) keep.summary = entry.summary;
+  if ('error' in entry) keep.error = entry.error;
+  if ('scratchpad_table' in entry) keep.scratchpad_table = entry.scratchpad_table;
+  if ('scratchpadTable' in entry) keep.scratchpadTable = entry.scratchpadTable;
+  if ('viewSpec' in entry) keep.viewSpec = entry.viewSpec;
+  if ('data_summary' in entry) keep.data_summary = entry.data_summary;
+  // Note: we drop `data.rows` but keep the rest of `data` (e.g. findings)
+  if (entry.data && typeof entry.data === 'object' && !Array.isArray(entry.data)) {
+    const data = { ...(entry.data as Record<string, unknown>) };
+    delete data.rows;
+    keep.data = data;
+  }
+  return keep;
+}
+
+/**
+ * Keep `columns`, `rowCount`, `findings`, and the first N sample rows from an
+ * analyze_* result; drop the rest. Falls through to the generic byte cap if
+ * the payload isn't shaped as expected.
+ */
+function shrinkAnalysis(raw: string): string {
+  const parsed = safeParseObject(raw);
+  if (!parsed) return truncateBytes(raw);
+  const out: Record<string, unknown> = {};
+  if ('columns' in parsed) out.columns = parsed.columns;
+  if ('rowCount' in parsed) out.rowCount = parsed.rowCount;
+  if ('findings' in parsed) out.findings = parsed.findings;
+  if (Array.isArray(parsed.sampleRows)) {
+    out.sampleRows = parsed.sampleRows.slice(0, ANALYZE_SAMPLE_CAP);
+  }
+  return JSON.stringify(out);
+}
+
+/**
+ * Pull the requested scratchpad table id out of a load_scratchpad result if
+ * the tool left one in its output. Best-effort — returns null when the shape
+ * doesn't match, which is fine because the stub is already minimal.
+ */
+function extractScratchpadId(raw: string): string | null {
+  const parsed = safeParseObject(raw);
+  if (!parsed) return null;
+  if (typeof parsed.id === 'string') return parsed.id;
+  if (typeof parsed.name === 'string') return parsed.name;
+  if (typeof parsed.table === 'string') return parsed.table;
+  return null;
+}
+
+/**
+ * Pull the HTML view payload out of a create_view / modify_view result for
+ * the denormalized `viewSpec` column. Expected shape is `{viewSpec: {...}}`;
+ * we also accept a top-level view object for tools that flatten the shape.
+ */
+function hoistViewSpec(raw: string): Record<string, unknown> | null {
+  const parsed = safeParseObject(raw);
+  if (!parsed) return null;
+  const candidate =
+    parsed.viewSpec && typeof parsed.viewSpec === 'object'
+      ? (parsed.viewSpec as Record<string, unknown>)
+      : parsed;
+  if (!candidate || typeof candidate !== 'object') return null;
+  // Only keep the fields the UI actually renders. Avoid accidentally
+  // hoisting something that isn't a view.
+  if (!('html' in candidate) && !('viewId' in candidate)) return null;
+  const keep: Record<string, unknown> = {};
+  if ('html' in candidate) keep.html = candidate.html;
+  if ('title' in candidate) keep.title = candidate.title;
+  if ('sql' in candidate) keep.sql = candidate.sql;
+  if ('viewId' in candidate) keep.viewId = candidate.viewId;
+  if ('description' in candidate) keep.description = candidate.description;
+  return keep;
+}
+
+/** Apply the generic 16 KB cap to a raw string. */
+function truncateBytes(raw: string): string {
+  if (raw.length <= FALLBACK_MAX_BYTES) return raw;
+  return raw.slice(0, FALLBACK_MAX_BYTES) + '...[truncated]';
+}
+
+/** Parse-and-reject-non-objects helper. */
+function safeParseObject(raw: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    /* not JSON — caller falls through */
+  }
+  return null;
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -14,7 +14,15 @@ export {
   type AgentTask,
   type SubAgentResult,
 } from './agents';
-export { ConversationManager } from './conversation';
+export {
+  ConversationManager,
+  hydratePersistedMessage,
+  summarizeToolResult,
+  toPersistedMessages,
+  toPersistedMessagesWithNames,
+  type PersistedRow,
+  type PersistedToolResult,
+} from './conversation';
 export {
   ClaudeProvider,
   type ClaudeProviderConfig,

--- a/packages/agent/src/prompt/leader-prompt.ts
+++ b/packages/agent/src/prompt/leader-prompt.ts
@@ -102,6 +102,8 @@ You can inspect intermediate results saved by query tasks:
 
 Query results are auto-saved to the scratchpad — look for \`scratchpadTable\` in the query task summary.
 
+Scratchpads do not persist across sessions; if a resumed conversation needs prior data, re-run the underlying query.
+
 ## Rules
 
 - Be conversational and concise

--- a/packages/db/drizzle/0003_known_spot.sql
+++ b/packages/db/drizzle/0003_known_spot.sql
@@ -1,0 +1,48 @@
+CREATE TABLE "conversation_messages" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"conversation_id" uuid NOT NULL,
+	"sequence" integer NOT NULL,
+	"role" text NOT NULL,
+	"content" text DEFAULT '' NOT NULL,
+	"tool_calls" jsonb,
+	"tool_results" jsonb,
+	"view_spec" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "conversations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"created_by" uuid NOT NULL,
+	"data_source_id" uuid,
+	"title" text DEFAULT 'New conversation' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_message_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_conversation_id_conversations_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversations" ADD CONSTRAINT "conversations_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversations" ADD CONSTRAINT "conversations_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversations" ADD CONSTRAINT "conversations_data_source_id_data_sources_id_fk" FOREIGN KEY ("data_source_id") REFERENCES "public"."data_sources"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "conversation_messages_conv_seq_idx" ON "conversation_messages" USING btree ("conversation_id","sequence");--> statement-breakpoint
+CREATE INDEX "conversation_messages_org_conv_idx" ON "conversation_messages" USING btree ("org_id","conversation_id");--> statement-breakpoint
+CREATE INDEX "conversations_org_source_last_idx" ON "conversations" USING btree ("org_id","data_source_id","last_message_at");--> statement-breakpoint
+CREATE INDEX "conversations_org_creator_last_idx" ON "conversations" USING btree ("org_id","created_by","last_message_at");--> statement-breakpoint
+
+-- Row-Level Security: follow the pattern from 0001_enable_rls.sql. Both tables
+-- carry `org_id` and are gated by the `app.current_org_id` session variable
+-- that the API middleware sets on every request for the app pool.
+
+ALTER TABLE "conversations" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "conversations_tenant_isolation" ON "conversations"
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
+CREATE POLICY "conversations_tenant_insert" ON "conversations"
+  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
+
+ALTER TABLE "conversation_messages" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "conversation_messages_tenant_isolation" ON "conversation_messages"
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);--> statement-breakpoint
+CREATE POLICY "conversation_messages_tenant_insert" ON "conversation_messages"
+  FOR INSERT WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);

--- a/packages/db/drizzle/meta/0003_snapshot.json
+++ b/packages/db/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1057 @@
+{
+  "id": "3e8f9a29-f5e9-418a-8ed5-c7447220bc72",
+  "prevId": "f5be42c2-7a15-476f-a5ad-35ba40472561",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_role_assignments": {
+      "name": "agent_role_assignments",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_config_id": {
+          "name": "model_config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_role_assignments_org_id_organizations_id_fk": {
+          "name": "agent_role_assignments_org_id_organizations_id_fk",
+          "tableFrom": "agent_role_assignments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_role_assignments_model_config_id_model_configs_id_fk": {
+          "name": "agent_role_assignments_model_config_id_model_configs_id_fk",
+          "tableFrom": "agent_role_assignments",
+          "tableTo": "model_configs",
+          "columnsFrom": [
+            "model_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_role_assignments_org_id_role_pk": {
+          "name": "agent_role_assignments_org_id_role_pk",
+          "columns": [
+            "org_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_messages": {
+      "name": "conversation_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_results": {
+          "name": "tool_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view_spec": {
+          "name": "view_spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_messages_conv_seq_idx": {
+          "name": "conversation_messages_conv_seq_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_messages_org_conv_idx": {
+          "name": "conversation_messages_org_conv_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_messages_org_id_organizations_id_fk": {
+          "name": "conversation_messages_org_id_organizations_id_fk",
+          "tableFrom": "conversation_messages",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_messages_conversation_id_conversations_id_fk": {
+          "name": "conversation_messages_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_source_id": {
+          "name": "data_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New conversation'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_org_source_last_idx": {
+          "name": "conversations_org_source_last_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "data_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_org_creator_last_idx": {
+          "name": "conversations_org_creator_last_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_org_id_organizations_id_fk": {
+          "name": "conversations_org_id_organizations_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_created_by_users_id_fk": {
+          "name": "conversations_created_by_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_data_source_id_data_sources_id_fk": {
+          "name": "conversations_data_source_id_data_sources_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "data_sources",
+          "columnsFrom": [
+            "data_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_sources": {
+      "name": "data_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "data_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_sources_org_id_idx": {
+          "name": "data_sources_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_sources_org_id_organizations_id_fk": {
+          "name": "data_sources_org_id_organizations_id_fk",
+          "tableFrom": "data_sources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_configs": {
+      "name": "model_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_configs_org_id_idx": {
+          "name": "model_configs_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_configs_org_id_organizations_id_fk": {
+          "name": "model_configs_org_id_organizations_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ai_credentials": {
+          "name": "ai_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_org_id_organizations_id_fk": {
+          "name": "sessions_org_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "telemetry.telemetry_events": {
+      "name": "telemetry_events",
+      "schema": "telemetry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telemetry_events_org_type_time_idx": {
+          "name": "telemetry_events_org_type_time_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_org_id_organizations_id_fk": {
+          "name": "users_org_id_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_org_email_unique": {
+          "name": "users_org_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.views": {
+      "name": "views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "views_org_created_by_idx": {
+          "name": "views_org_created_by_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "views_org_id_organizations_id_fk": {
+          "name": "views_org_id_organizations_id_fk",
+          "tableFrom": "views",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "views_created_by_users_id_fk": {
+          "name": "views_created_by_users_id_fk",
+          "tableFrom": "views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.data_source_type": {
+      "name": "data_source_type",
+      "schema": "public",
+      "values": [
+        "postgres",
+        "mysql",
+        "clickhouse",
+        "rest",
+        "csv",
+        "prometheus",
+        "elasticsearch"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "editor",
+        "viewer"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "org",
+        "public"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1776500002000,
       "tag": "0002_model_configs_rls_and_backfill",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1776874744952,
+      "tag": "0003_known_spot",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/conversations.ts
+++ b/packages/db/src/schema/conversations.ts
@@ -1,0 +1,124 @@
+import {
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from 'drizzle-orm/pg-core';
+
+import { dataSources } from './data-sources';
+import { organizations } from './organizations';
+import { users } from './users';
+
+/**
+ * Persistent chat transcripts for the Explore surface.
+ *
+ * One row per top-level conversation thread. The sidebar filters on
+ * `dataSourceId`, orders on `lastMessageAt`, and never loads message bodies —
+ * message contents live in {@link conversationMessages}. The FK to
+ * `data_sources` intentionally uses `ON DELETE SET NULL` so deleting a source
+ * does not destroy transcripts the user may still want to read.
+ */
+export const conversations = pgTable(
+  'conversations',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    createdBy: uuid('created_by')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    /**
+     * Data source the conversation was started against. Null after the source
+     * is deleted (see `SET NULL` above) so the transcript survives.
+     */
+    dataSourceId: uuid('data_source_id').references(() => dataSources.id, {
+      onDelete: 'set null',
+    }),
+    /**
+     * Short human-readable title — seeded from the first user message on
+     * conversation creation. A follow-up ticket will replace this with an
+     * LLM-generated title after turn 2.
+     */
+    title: text('title').notNull().default('New conversation'),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    /**
+     * Updated on every appended turn. Drives sidebar ordering without needing
+     * a `MAX(sequence)` subquery per row.
+     */
+    lastMessageAt: timestamp('last_message_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index('conversations_org_source_last_idx').on(
+      table.orgId,
+      table.dataSourceId,
+      table.lastMessageAt,
+    ),
+    index('conversations_org_creator_last_idx').on(
+      table.orgId,
+      table.createdBy,
+      table.lastMessageAt,
+    ),
+  ],
+);
+
+/**
+ * One row per message inside a conversation — append-only.
+ *
+ * `sequence` is a monotonically increasing int assigned by the writer and is
+ * used for ordering instead of `createdAt` because a single agent turn can
+ * append many tool-result messages inside a <5 ms window. `toolCalls` and
+ * `toolResults` mirror the in-memory `Message` shape the leader reads on
+ * resume; `viewSpec` denormalizes the HTML output from `create_view` so the
+ * filmstrip and thread can render without re-parsing the stringified
+ * `toolResults` JSON.
+ */
+export const conversationMessages = pgTable(
+  'conversation_messages',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    conversationId: uuid('conversation_id')
+      .notNull()
+      .references(() => conversations.id, { onDelete: 'cascade' }),
+    /** Writer-assigned, unique per conversation. See the unique index below. */
+    sequence: integer('sequence').notNull(),
+    /** `'user' | 'assistant' | 'system'` — not enforced at the DB layer. */
+    role: text('role').notNull(),
+    content: text('content').notNull().default(''),
+    /**
+     * Shape: `ToolCallResult[]` — `{ id, name, input }`. Present on assistant
+     * messages that emitted tool calls; null otherwise.
+     */
+    toolCalls: jsonb('tool_calls'),
+    /**
+     * Shape: `PersistedToolResult[]` — tool output after {@link summarizeToolResult}.
+     * Big rowsets are truncated, HTML views are kept intact, scratchpad loads
+     * are stubbed. See `packages/agent/src/conversation/persisted.ts`.
+     */
+    toolResults: jsonb('tool_results'),
+    /**
+     * Denormalized HTML view payload for fast filmstrip + thread rendering.
+     * Shape: `{ html, title, sql?, viewId? }` for create/modify_view
+     * outputs. Null on every other message. Source of truth stays inside
+     * `toolResults` — this column is a render convenience.
+     */
+    viewSpec: jsonb('view_spec'),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('conversation_messages_conv_seq_idx').on(
+      table.conversationId,
+      table.sequence,
+    ),
+    index('conversation_messages_org_conv_idx').on(table.orgId, table.conversationId),
+  ],
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,10 +1,13 @@
 export { agentRoleAssignments } from './agent-role-assignments';
+export { conversationMessages, conversations } from './conversations';
 export { dataSources } from './data-sources';
 export { dataSourceTypeEnum, userRoleEnum, visibilityEnum } from './enums';
 export { modelConfigs } from './model-configs';
 export { organizations } from './organizations';
 export {
   agentRoleAssignmentsRelations,
+  conversationMessagesRelations,
+  conversationsRelations,
   dataSourcesRelations,
   modelConfigsRelations,
   organizationsRelations,

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -1,6 +1,7 @@
 import { relations } from 'drizzle-orm';
 
 import { agentRoleAssignments } from './agent-role-assignments';
+import { conversationMessages, conversations } from './conversations';
 import { dataSources } from './data-sources';
 import { modelConfigs } from './model-configs';
 import { organizations } from './organizations';
@@ -78,5 +79,34 @@ export const agentRoleAssignmentsRelations = relations(agentRoleAssignments, ({ 
   modelConfig: one(modelConfigs, {
     fields: [agentRoleAssignments.modelConfigId],
     references: [modelConfigs.id],
+  }),
+}));
+
+/** Conversation belongs to an org, a creator, and (optionally) a data source. */
+export const conversationsRelations = relations(conversations, ({ one, many }) => ({
+  organization: one(organizations, {
+    fields: [conversations.orgId],
+    references: [organizations.id],
+  }),
+  creator: one(users, {
+    fields: [conversations.createdBy],
+    references: [users.id],
+  }),
+  dataSource: one(dataSources, {
+    fields: [conversations.dataSourceId],
+    references: [dataSources.id],
+  }),
+  messages: many(conversationMessages),
+}));
+
+/** Conversation message belongs to an org and a conversation. */
+export const conversationMessagesRelations = relations(conversationMessages, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [conversationMessages.orgId],
+    references: [organizations.id],
+  }),
+  conversation: one(conversations, {
+    fields: [conversationMessages.conversationId],
+    references: [conversations.id],
   }),
 }));


### PR DESCRIPTION
## Summary
- Replaces the Redis-only 1h TTL chat history with a durable Postgres backing — users can now resume old Explore chats and reference past HTML outputs from the sidebar.
- New `conversations` + `conversation_messages` tables follow the standard `org_id` + RLS pattern. The conversation FK to `data_sources` is `ON DELETE SET NULL` so transcripts outlive the source rows.
- Tool results are summarized on write via `summarizeToolResult`: `run_sql` rowsets shrink to 20 rows, `create_view` HTML stays intact, scratchpad loads become `scratchpad_not_restored` stubs, unknown outputs cap at 16 KB. HTML view payloads are denormalized onto the message row's `view_spec` column for cheap filmstrip + thread rendering.
- The chat route now creates the conversation row on first turn (DB UUID = session id; the synthetic `conv_<ts>_<rand>` is gone), appends each turn's tail above a `priorSeq` watermark inside a transaction, and falls back from a Redis miss to a DB hydrate path. SSE `done` blocks on the DB write so the returned conversation id is always addressable by the next `GET /api/conversations/:id`.
- Sidebar is rewired: react-query keyed on the selected source, client-side bucketing into Today / Yesterday / This week / Older, `?c=<id>` URL sync that survives reloads.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter @lightboard/web lint` — clean
- [x] `pnpm test` — 288 agent + 165 web tests pass; new `summarizeToolResult` Vitest suite covers each per-tool rule (rowset cap, HTML preservation, delegate strip, await_tasks map, analyze, scratchpad stub, fallback truncation, error path, hoist) and the `toPersistedMessagesWithNames` numbering / viewSpec hoist behaviors.
- [x] Browser tested end-to-end against the cricket Postgres on `localhost:5434`:
  - Created a conversation, watched it land in the sidebar under TODAY.
  - Reloaded `/explore?c=<id>` — conversation rehydrated.
  - Clicked the sidebar entry on a fresh page load — thread rendered with full text + tool-call rows.
  - Sent a follow-up after a cold-start hydrate (`priorSeq=12 → 13/14` in the route log) — the leader recalled the original question, proving `loadHistory` replay with summarized results still produces coherent next turns.
  - Switched to a second data source — sidebar refetched and showed the empty state; switching back restored the cricket list.
  - Cross-org RLS spot-check: a second org saw no rows from the first org and got a 404 on the cross-org conversation id.

## Known follow-ups (per the plan, deliberately out of scope)
- LLM-generated titles after turn 2 — first-message substring is ugly when the prompt is short.
- Rename / delete / pin conversations.
- Concurrent tab writes on the same conversation are unique-constrained on `(conversation_id, sequence)` so data integrity is safe, but `last_message_at` and Redis can clobber.
- "Different source" badge on the thread header when the active conversation's `dataSourceId` doesn't match the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)