### PR TITLE
docs: sync CLAUDE.md + agent prompts with current codebase

### DIFF
--- a/.claude/agents/dev-agent.md
+++ b/.claude/agents/dev-agent.md
@@ -14,21 +14,20 @@ Lightboard is a TypeScript monorepo (Turborepo + pnpm workspaces):
 
 ```
 lightboard/
-├── apps/web/              # Next.js 15 (app router, Turbopack)
+├── apps/web/              # Next.js 15 (app router, Turbopack) + Playwright specs under e2e/
 ├── packages/
 │   ├── db/                # Drizzle ORM, auth, migrations
 │   ├── ui/                # shadcn/ui components (Button, Card, Input, Label)
-│   ├── query-ir/          # Query intermediate representation
+│   ├── query-ir/          # Query intermediate representation (legacy — connectors still use it)
 │   ├── connector-sdk/     # Data source adapter interface
 │   ├── connectors/postgres/ # PostgreSQL connector
-│   ├── compute/           # DuckDB compute engine
-│   ├── viz-core/          # visx charts, panel protocol, ViewSpec, auto-viz
-│   ├── agent/             # AI agent (Claude API + OpenAI-compatible)
-│   ├── telemetry/         # OpenTelemetry SDK + local exporter
-│   └── mcp-server/        # MCP server for programmatic operations
+│   ├── viz-core/          # visx charts, panel protocol, ViewSpec (legacy — agent now emits HTML)
+│   └── agent/             # Multi-agent orchestration (Claude API + OpenAI-compatible)
 ├── docker/                # Docker Compose (Postgres 16 + Redis 7)
 └── pnpm-workspace.yaml    # includes packages/* and packages/connectors/*
 ```
+
+**Not present** (scope-cutting reminders so you don't look for them): `packages/compute/` (DuckDB engine — planned, never built), `packages/mcp-server/` (also planned), `packages/telemetry/` (OpenTelemetry SDK — exists on disk but is orphaned with no consumers; do not wire it in unless explicitly asked), and `plugins/` / `helm/` at the root.
 
 ## Development Workflow
 
@@ -115,11 +114,10 @@ Common lint failures in CI that pass typecheck locally:
 
 ### 8. Browser Testing with Chrome Extension
 
-- Use `mcp__claude-in-chrome__*` tools for browser automation
-- The app runs on `http://192.168.1.17:3000` (network address), not `localhost`
-- Some Chrome extensions block the automation — if `javascript_tool` returns "Cannot access chrome-extension:// URL", try a new tab
-- For form submissions that fail via `fill()`, use `javascript_tool` to call the API directly then navigate
-- Always `wait` 2-3 seconds after navigation before taking screenshots
+- Use the Chrome DevTools MCP tools (`mcp__plugin_chrome-devtools-mcp_chrome-devtools__*`) for browser automation — navigate, snapshot, screenshot, evaluate scripts.
+- The app runs on `http://localhost:3000`.
+- For form submissions that fail via `fill()` under automation, fall back to calling the API route directly via `evaluate_script`, then navigate.
+- Use `wait_for` with a text anchor after navigation rather than sleeping — snapshots taken too early return half-rendered trees.
 
 ### 9. Package Dependencies
 
@@ -144,15 +142,15 @@ Every user-facing string goes through `next-intl`:
 - JSDoc on every export
 - Components < 150 lines, business logic in hooks
 - No code duplication > 3 lines
-- Apache Arrow IPC for data transfer, never JSON
+- **JSON rows** for agent query results (`{ columns, rows, rowCount }`). Arrow IPC remains in the connector interface for backward compatibility, but agent tools return JSON.
 - react-query for all server state
 - Feature branches only, squash merge
 
 ## Available Test Infrastructure
 
 - **Unit tests**: Vitest across all packages
-- **E2E tests**: Playwright in `apps/web/e2e/auth.spec.ts` (13 tests)
-- **Storybook**: `pnpm --filter @lightboard/viz-core storybook` for chart visual testing
+- **E2E tests**: Playwright in `apps/web/e2e/` (currently `auth.spec.ts`, `agent-chat.spec.ts`, `multi-agent-chat.spec.ts`)
+- **Storybook**: `pnpm --filter @lightboard/viz-core storybook` for chart visual testing (legacy)
 - **Docker**: `docker compose up -d` for Postgres + Redis
 - **Sample database**: Postgres on `localhost:5434`, database `cricket`, user `cricket_user`, password `cricket_pass`
 
@@ -161,17 +159,17 @@ Every user-facing string goes through `next-intl`:
 ```bash
 pnpm dev                    # Start dev server (Turbopack)
 pnpm build                  # Production build
-pnpm test                   # All unit tests (203+)
+pnpm test                   # All unit tests (Vitest across every package)
 pnpm typecheck              # TypeScript across all packages
 pnpm --filter @lightboard/web lint   # ESLint
 cd apps/web && npx playwright test    # E2E tests
 
-pnpm --filter @lightboard/db db:push      # Push schema to Postgres
+pnpm --filter @lightboard/db db:migrate   # Apply journaled migrations (do not use db:push — it is for throwaway experiments only)
 pnpm --filter @lightboard/db db:seed      # Seed demo data
-pnpm --filter @lightboard/viz-core storybook  # Chart Storybook
+pnpm --filter @lightboard/viz-core storybook  # Chart Storybook (legacy visx)
 
-docker compose up -d        # Start Postgres + Redis
-docker start lightboard-postgres lightboard-redis  # Restart existing
+docker compose up -d           # Start Postgres + Redis
+docker compose start postgres redis  # Restart existing services
 ```
 
 ## PR Template

--- a/.claude/agents/project-manager.md
+++ b/.claude/agents/project-manager.md
@@ -26,30 +26,29 @@ You do NOT write code. You create the plan that guides code creation.
 
 ```
 lightboard/
-├── apps/web/              # Next.js 15 (app router) — UI + API routes
+├── apps/web/              # Next.js 15 (app router) — UI + API routes + Playwright e2e/
 ├── packages/
 │   ├── db/                # Drizzle ORM, auth, migrations, crypto
 │   ├── ui/                # shadcn/ui components (Button, Card, Input, Label)
-│   ├── query-ir/          # Query intermediate representation (types + Zod + utils)
+│   ├── query-ir/          # Query intermediate representation (legacy — connector-only)
 │   ├── connector-sdk/     # Connector interface + registry
 │   ├── connectors/postgres/ # PostgreSQL connector (IR→SQL, Arrow, streaming)
-│   ├── compute/           # DuckDB compute engine (cross-source joins, CSV/Parquet)
-│   ├── viz-core/          # Charts (visx), panel protocol, ViewSpec, auto-viz, Storybook
-│   ├── agent/             # AI agent (Claude + OpenAI-compatible providers, tools, prompts)
-│   ├── telemetry/         # OpenTelemetry SDK, metrics, local exporter, TelemetryConnector
-│   └── mcp-server/        # MCP server (5 Phase 1 tools)
+│   ├── viz-core/          # Charts (visx), panel protocol, ViewSpec (legacy — agent emits HTML)
+│   └── agent/             # Multi-agent orchestration (leader + query/view/insights + scratchpad)
 ├── docker/                # Docker Compose (Postgres 16 + Redis 7)
 └── documentation/         # Phase plans, QA test plans
 ```
 
+**Planned but not built** (so you do not scope issues against packages that do not exist): `packages/compute/` (DuckDB compute engine for cross-source joins / CSV / Parquet), `packages/mcp-server/`, and a dedicated `plugins/` tarball system. `packages/telemetry/` is on disk but orphaned — has no consumers and is not wired into the web app. If an issue needs any of these, call out the missing prerequisite package as an explicit pre-step.
+
 ### Key Architectural Patterns
 
-- **QueryIR** is the lingua franca — every query flows through it. Agent produces it, connectors translate it.
-- **ViewSpec** is the agent's output — a JSON document describing query + chart + controls.
+- **QueryIR** is the connector lingua franca — connectors still translate it to native SQL, but the agent no longer produces it (the agent writes raw SQL directly via `run_sql`).
+- **HtmlView** is the agent's current visualization output — a complete self-contained HTML document. The older **ViewSpec** (JSON query + chart + controls) still exists in `viz-core` for backward compatibility.
 - **Connector interface** is the adapter pattern — every data source implements `connect`, `introspect`, `query`, `stream`, `healthCheck`, `capabilities`, `disconnect`.
-- **PanelPlugin** is the viz adapter — charts register as plugins with `id`, `configSchema`, `dataShape`, `Component`.
+- **PanelPlugin** is the legacy viz adapter — deprecated; new visualizations come from the agent.
 - **RLS on every table** — all tables have `org_id`, Postgres RLS enforces tenant isolation. Route handlers use `withAuth` wrapper.
-- **Arrow IPC** for data transfer — never JSON between server↔client for query results.
+- **JSON rows** between the agent and the web app (`{ columns, rows, rowCount }`). Arrow IPC is still how connectors return data internally; it does not reach the browser.
 
 ### Tech Stack (non-negotiable)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Lightboard is an AI-native data exploration and visualization platform. Users co
 
 ```
 lightboard/
-├── apps/web/              # Next.js 15 app (app router)
+├── apps/web/              # Next.js 15 app (app router) + Playwright specs under e2e/
 ├── packages/
 │   ├── connector-sdk/     # TypeScript interface for data sources
 │   ├── connectors/        # Postgres connector (others planned)
@@ -16,12 +16,8 @@ lightboard/
 │   ├── viz-core/          # visx chart components (legacy — agent now generates HTML)
 │   ├── agent/             # Multi-agent orchestration (leader + query/view/insights agents + scratchpad)
 │   ├── ui/                # shadcn/ui components (copied, not installed)
-│   ├── telemetry/         # OpenTelemetry SDK + built-in data source
 │   └── db/                # Drizzle ORM schema + migrations
-├── plugins/               # Local plugin tarballs (.tar.gz)
-├── docker/                # Dockerfiles + compose
-├── helm/                  # K8s Helm charts
-└── e2e/                   # Playwright E2E tests
+└── docker/                # Dockerfiles + compose
 ```
 
 ## Key abstractions
@@ -48,7 +44,7 @@ packages/agent/src/
 │   ├── leader.ts               # LeaderAgent — orchestrates conversation + delegates
 │   ├── query-agent.ts          # Query specialist (schema, raw SQL)
 │   ├── view-agent.ts           # View specialist (HTML visualization generation)
-│   └── insights-agent.ts       # Insights specialist (stats via DuckDB)
+│   └── insights-agent.ts       # Insights specialist (stats over the in-memory scratchpad)
 ├── scratchpad/
 │   ├── scratchpad.ts           # SessionScratchpad — per-session in-memory data store
 │   └── manager.ts              # ScratchpadManager — session lifecycle + cleanup
@@ -75,7 +71,7 @@ packages/agent/src/
 | Forms | react-hook-form + zod | Formik, final-form |
 | Layout grid | react-grid-layout | CSS grid (for drag/drop) |
 | ORM | Drizzle ORM | Prisma, TypeORM, Knex |
-| Auth | Lucia | NextAuth (unless OAuth needed) |
+| Auth | Session-based (Argon2 via @node-rs/argon2 + @oslojs/crypto for sessions) | NextAuth, Lucia |
 | i18n | next-intl | react-i18next, FormatJS |
 | Icons | lucide-react | heroicons, react-icons |
 | Testing | Vitest + Playwright + Testing Library | Jest, Cypress |
@@ -141,12 +137,7 @@ pnpm --filter @lightboard/query-ir test
 pnpm --filter @lightboard/viz-core storybook
 
 # Docker
-docker build -t lightboard .         # Production image (multi-stage, rootless)
-docker compose -f docker-compose.prod.yml up  # Production single-node
-
-# Plugins (airgap)
-lightboard plugin pack <name>        # Create .tar.gz on connected machine
-# Copy to /plugins directory, restart or POST /api/admin/plugins/reload
+docker compose up -d                 # Start local Postgres + Redis (single docker-compose.yml)
 ```
 
 ## Running migrations


### PR DESCRIPTION
## Summary

Follow-on from #113 / #114. The README is now accurate; these three files were still lying:

- **\`CLAUDE.md\`** advertised \`plugins/\`, \`helm/\`, root \`e2e/\`, and \`telemetry/\` in the monorepo tree (none shipped or consumed); called auth \"Lucia\" (it's Argon2 + oslo); pointed at \`docker-compose.prod.yml\` and a \`lightboard plugin pack\` CLI that don't exist; described the insights agent as using DuckDB (it's a plain in-memory Map).
- **\`.claude/agents/dev-agent.md\`** told the dev agent about three packages that were never built (\`compute/\`, \`mcp-server/\`, \`telemetry/\` wired up), pointed at an old LAN IP instead of \`localhost\`, still said \"Apache Arrow IPC, never JSON\" (agent tools return JSON per CLAUDE.md rule #6 since Phase 1.5), recommended \`db:push\` even though CLAUDE.md bans it for real work, and used wrong Docker container names.
- **\`.claude/agents/project-manager.md\`** carried the same ghost-package list and the same stale Arrow-everywhere claim, plus out-of-date architectural bullets (agent no longer produces QueryIR, ViewSpec is legacy, PanelPlugin is deprecated).

### What was changed (by file)

**CLAUDE.md**
- Tree: drop \`telemetry/\`, \`plugins/\`, \`helm/\`, root \`e2e/\`. Roll Playwright mention into the \`apps/web/\` comment.
- Multi-agent section: insights specialist \"stats via DuckDB\" → \"stats over the in-memory scratchpad\".
- Tech stack: Auth row flips Lucia → Session-based (Argon2 + oslo). Lucia moves to the \"not this\" column.
- Commands: drop the \`docker-compose.prod.yml\` line and the \`lightboard plugin pack\` / \`/api/admin/plugins/reload\` references.

**.claude/agents/dev-agent.md**
- Tree: drop \`compute/\`, \`mcp-server/\`, \`telemetry/\`. Add an explicit \"Not present\" note so the dev agent doesn't search for packages that don't exist.
- Browser section: swap \`mcp__claude-in-chrome__*\` for \`mcp__plugin_chrome-devtools-mcp_chrome-devtools__*\` and fix the URL to \`localhost:3000\`.
- Standards: \"Apache Arrow IPC, never JSON\" → JSON rows for agent queries, Arrow only in the connector interface (matching CLAUDE.md rule #6).
- Commands: \`db:migrate\` instead of \`db:push\`, with a callout that \`db:push\` is for throwaway experiments; \`docker compose start postgres redis\` instead of hard-coded container names.
- Test infra: list the three current E2E specs instead of a single old file with a stale test count; drop the \`(203+)\` unit-test count.

**.claude/agents/project-manager.md**
- Tree: same compute/mcp-server/telemetry cleanup with a \"Planned but not built\" callout so scope plans don't reference phantom packages.
- Architectural patterns: rewrite the bullets — agent no longer produces QueryIR (writes raw SQL), ViewSpec is legacy, PanelPlugin is deprecated, JSON rows between agent and web with Arrow only inside the connector interface.

## Test plan

- [x] Grep for every drifted string (\`DuckDB\`, \`compute/\`, \`mcp-server\`, \`plugins/\`, \`helm/\`, \`Lucia\`, \`192.168\`, \`docker-compose.prod\`, \`db:push\`, \`lightboard-postgres\`, \`Apache Arrow IPC for data transfer\`) across \`CLAUDE.md\` and \`.claude/agents/*.md\` — only explicit \"not present\" / \"do not use\" contexts remain.
- [x] Docs-only; no code paths touched, no dependency changes, no test run needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)